### PR TITLE
Docs: Link to Large Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,7 +886,8 @@ encoding. We recommend using `UTF-8` encoding in all replicated databases.
 ### Large objects
 
 PostgreSQL's logical decoding facility does not support decoding changes
-to large objects, so spock cannot replicate large objects.
+to [large objects](https://www.postgresql.org/docs/current/largeobjects.html), 
+so spock cannot replicate large objects.
 
 Also any DDL limitations apply so extra care need to be taken when using
 `replicate_ddl_command()`.


### PR DESCRIPTION
So I was not immediately sure (not DBA) about what a large object was and if it applied to standard JSON or TEXT or BLOB.

This link goes to the postgres documentation explaining it's a large stream. (which I believe means it will not affect JSON, TEXT, BLOB)

Sorry about the branch name... Used GitHub UI (ugh)