### PR TITLE
Improve Feedback Handling for Synchronous Replication and WAL message 'w' flood control.

### DIFF
--- a/spock_apply.c
+++ b/spock_apply.c
@@ -1870,7 +1870,6 @@ handle_startup(StringInfo s)
 static void
 spock_apply_worker_on_exit(int code, Datum arg)
 {
-	/* FIXME: Do we really need to flush the sync_replica_lsn*/
 	spock_apply_worker_detach();
 }
 

--- a/spock_apply.c
+++ b/spock_apply.c
@@ -2545,6 +2545,8 @@ append_feedback_position(XLogRecPtr recvpos)
 	XLogRecPtr writepos;
 	XLogRecPtr flushpos;
 	RemoteSyncPosition *syncpos;
+	MemoryContext oldctx;
+
 	Assert(WalSndCtl->sync_standbys_defined);
 
 	if (get_flush_position(&writepos, &flushpos))
@@ -2556,7 +2558,11 @@ append_feedback_position(XLogRecPtr recvpos)
 		flushpos = writepos = recvpos;
 	}
 
+	/* Ensure that we are allocating in the top memory context */
+	oldctx = MemoryContextSwitchTo(TopMemoryContext);
 	syncpos = (RemoteSyncPosition *) palloc0(sizeof(RemoteSyncPosition));
+	MemoryContextSwitchTo(oldctx);
+
 	syncpos->recvpos = recvpos;
 	syncpos->writepos = writepos;
 	syncpos->flushpos = flushpos;

--- a/spock_apply.c
+++ b/spock_apply.c
@@ -2869,7 +2869,7 @@ apply_work(PGconn *streamConn)
 					if (last_received < end_lsn)
 						last_received = end_lsn;
 
-					w_message_count++; // Increment the 'w' message counter
+					w_message_count++;
 
 					/*
 					 * Send feedback if wal_sender_timeout/2 has passed or after 10 'w' messages.


### PR DESCRIPTION
This PR introduces two key enhancements to improve synchronous replication behavior and WAL sender efficiency:

1 - Enhanced Synchronous Replication Feedback
Previously, when a synchronous replica was attached, the spock set synchronous_commit to off, potentially sending feedback prematurely before receiving acknowledgment from the remote synchronous standby. Introduced tracking of locally committed LSNs. Feedback is now held back until an acknowledgment from the synchronous replica is received. This change improves data consistency by ensuring durability before transaction acknowledgment.

2 - Flood Control for 'w' Messages
We are now sending the feedback if 1/2 the wal_sender_timeout occurs or in case of 10 'w' messages to avoid the wal_sender_timeout on the other side in case of too many 'w' messages. 
