### PR TITLE
The local tuple for the exception was being created in a no-longer-available memory context

### DIFF
--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -804,10 +804,10 @@ spock_apply_heap_update(SpockRelation *rel, SpockTupleData *oldtup,
 		 * Fetch the contents of the local slot and store it in the error log
 		 */
 		local_tuple = ExecFetchSlotHeapTuple(localslot, true, &clear_localslot);
-		exception_log->local_tuple = local_tuple;
 
-		/* Process and store remote tuple in the slot */
-		oldctx = MemoryContextSwitchTo(GetPerTupleMemoryContext(estate));
+		/* Save the old tuple in MessageContext for it to available later */
+		oldctx = MemoryContextSwitchTo(MessageContext);
+		exception_log->local_tuple = heap_copytuple(local_tuple);
 		MemoryContextSwitchTo(oldctx);
 
 		remotetuple = ExecFetchSlotHeapTuple(remoteslot, true,
@@ -1023,7 +1023,11 @@ spock_apply_heap_delete(SpockRelation *rel, SpockTupleData *oldtup)
 		 * Fetch the contents of the local slot and store it in the error log
 		 */
 		local_tuple = ExecFetchSlotHeapTuple(localslot, true, &clear_localslot);
-		exception_log->local_tuple = local_tuple;
+
+		/* Save the old tuple in MessageContext for it to available later */
+		oldctx = MemoryContextSwitchTo(MessageContext);
+		exception_log->local_tuple = heap_copytuple(local_tuple);
+		MemoryContextSwitchTo(oldctx);
 
 		/* Make sure that any user-supplied code runs as the table owner. */
 		SwitchToUntrustedUser(rel->rel->rd_rel->relowner, &ucxt);


### PR DESCRIPTION
Local tuple was being saved in a memory context that was getting cleaned up as the transaction was getting rolled back or released.
    
So, perserving local tuple in the MessageContext ensures that it is available beyond the scope of the subtranction.
