### PR TITLE
Queue stream messages to replay on exception

### DIFF
--- a/spock.c
+++ b/spock.c
@@ -130,6 +130,7 @@ bool	spock_include_ddl_repset = false;
 bool	allow_ddl_from_functions = false;
 int		restart_delay_default;
 int		restart_delay_on_exception;
+int		spock_replay_queue_size;
 
 
 void _PG_init(void);
@@ -989,6 +990,19 @@ _PG_init(void)
 							0,
 							INT_MAX,
 							PGC_POSTMASTER,
+							0,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("spock.exception_replay_queue_size",
+							"apply-worker replay queue size for exception",
+							NULL,
+							&spock_replay_queue_size,
+							4194304,
+							0,
+							INT_MAX,
+							PGC_SIGHUP,
 							0,
 							NULL,
 							NULL,

--- a/spock.h
+++ b/spock.h
@@ -53,6 +53,7 @@ extern bool	spock_include_ddl_repset;
 extern bool	allow_ddl_from_functions;
 extern int	restart_delay_default;
 extern int	restart_delay_on_exception;
+extern int	spock_replay_queue_size;
 extern char *shorten_hash(const char *str, int maxlen);
 
 extern List *textarray_to_list(ArrayType *textarray);

--- a/spock_relcache.c
+++ b/spock_relcache.c
@@ -253,6 +253,25 @@ spock_relation_close(SpockRelation * rel, LOCKMODE lockmode)
 	rel->rel = NULL;
 }
 
+void
+spock_relation_cache_reset(void)
+{
+	SpockRelation *entry;
+
+	/* Just to be sure. */
+	if (SpockRelationHash == NULL)
+		return;
+
+	/* invalidate all cache entries */
+	HASH_SEQ_STATUS status;
+
+	hash_seq_init(&status, SpockRelationHash);
+
+	while ((entry = (SpockRelation *) hash_seq_search(&status)) != NULL)
+		entry->reloid = InvalidOid;
+}
+
+
 static void
 spock_relcache_invalidate_callback(Datum arg, Oid reloid)
 {

--- a/spock_relcache.c
+++ b/spock_relcache.c
@@ -256,14 +256,13 @@ spock_relation_close(SpockRelation * rel, LOCKMODE lockmode)
 void
 spock_relation_cache_reset(void)
 {
+	/* invalidate all cache entries */
+	HASH_SEQ_STATUS status;
 	SpockRelation *entry;
 
 	/* Just to be sure. */
 	if (SpockRelationHash == NULL)
 		return;
-
-	/* invalidate all cache entries */
-	HASH_SEQ_STATUS status;
 
 	hash_seq_init(&status, SpockRelationHash);
 

--- a/spock_relcache.h
+++ b/spock_relcache.h
@@ -64,6 +64,8 @@ extern void spock_relation_close(SpockRelation * rel,
 									  LOCKMODE lockmode);
 extern void spock_relation_invalidate_cb(Datum arg, Oid reloid);
 
+extern void spock_relation_cache_reset(void);
+
 extern Oid spock_lookup_delta_function(char *fname, Oid typeoid);
 
 struct SpockTupleData;


### PR DESCRIPTION
Create a queue that collects replication stream messages up to a GUC (spock.exception_replay_queue_size) number of bytes. In case the original transaction (before exception handling got activated) ERRORs out, the apply-worker will not terminate, but internally reset and retry the same transaction in exception handling mode, replaying the messages from memory without tearing down the replication connection.

Note: The apply-worker previously created a ResourceOwner. This seems completely obsolete since it is done in StartTransaction(). It also interfered with resource cleanup while handling the initial ERROR.

Note: The current queue limit of 4MB it totally arbitrary. Since this is an allocation maximum on an apply-worker, it doesn't seem excessive. It is meant to prevent OOM on gigantic transactions by forcing a restart only if a transaction of that size causes an exception.