### PR TITLE
UC Insert Exists

### DIFF
--- a/spock.c
+++ b/spock.c
@@ -130,6 +130,7 @@ bool	spock_include_ddl_repset = false;
 bool	allow_ddl_from_functions = false;
 int		restart_delay_default;
 int		restart_delay_on_exception;
+bool	check_all_uc_indexes = false;
 
 
 void _PG_init(void);
@@ -1001,6 +1002,15 @@ _PG_init(void)
 							 READONLY_OFF,
 							 readonly_options,
 							 PGC_SUSET, 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("spock.check_all_uc_indexes",
+							 gettext_noop("Check all valid unique indexes for conflict resolution on INSERT when primary or replica identity index fails."),
+							 NULL,
+							 &check_all_uc_indexes,
+							 false,
+							 PGC_SIGHUP,
+							 0,
 							 NULL, NULL, NULL);
 
 	if (IsBinaryUpgrade)

--- a/spock.h
+++ b/spock.h
@@ -53,6 +53,8 @@ extern bool	spock_include_ddl_repset;
 extern bool	allow_ddl_from_functions;
 extern int	restart_delay_default;
 extern int	restart_delay_on_exception;
+extern bool check_all_uc_indexes;
+
 extern char *shorten_hash(const char *str, int maxlen);
 
 extern List *textarray_to_list(ArrayType *textarray);

--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -437,12 +437,14 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
 
 	if (OidIsValid(localidxoid))
 	{
+#if PG_VERSION_NUM >= 160000	/* GetRelationIdentityOrPK() added in PG16 */
 #ifdef USE_ASSERT_CHECKING
 		Relation	idxrel = index_open(localidxoid, AccessShareLock);
 
 		/* Index must be PK, or RI */
 		Assert(GetRelationIdentityOrPK(localrel) == localidxoid);
 		index_close(idxrel, AccessShareLock);
+#endif
 #endif
 
 		found = RelationFindReplTupleByIndex(localrel, localidxoid,

--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -473,7 +473,9 @@ FindReplTupleByUCIndex(ApplyExecutionData *edata,
 	ListCell   *lc;
 	bool		found = false;
 
-	Assert(check_all_uc_indexes);
+	if (!check_all_uc_indexes)
+		elog(ERROR, "spock.check_all_uc_indexes must be enabled to call this function");
+
 
 	/* Get the list of index OIDs for the table from the relcache. */
 	indexoidlist = RelationGetIndexList(localrel);

--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -456,6 +456,59 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
 	return found;
 }
 
+/*
+ * Find a matching tuple using all usable unique indexes (excluding PK and RI
+ * indexes)
+ *
+ * This is a fallback mechanism when PK/RI indexes do not match. The caller must
+ * ensure this function is only called in that context.
+ */
+static bool
+FindReplTupleByUCIndex(ApplyExecutionData *edata,
+					   Relation localrel,
+					   TupleTableSlot *remoteslot,
+					   TupleTableSlot **localslot)
+{
+	List	   *indexoidlist = NIL;
+	ListCell   *lc;
+	bool		found = false;
+
+	Assert(check_all_uc_indexes);
+
+	/* Get the list of index OIDs for the table from the relcache. */
+	indexoidlist = RelationGetIndexList(localrel);
+
+	foreach(lc, indexoidlist)
+	{
+		Relation idxrel;
+		Oid	indexoid = lfirst_oid(lc);
+
+		/* Open the index. */
+		idxrel = index_open(indexoid, RowExclusiveLock);
+
+		if (!IsIndexUsableForInsertConflict(idxrel))
+		{
+			index_close(idxrel, RowExclusiveLock);
+			continue;
+		}
+
+		found = SpockRelationFindReplTupleByIndex(localrel, idxrel,
+											 LockTupleExclusive,
+											 remoteslot, *localslot);
+		if (found)
+		{
+			/* Don't release lock until commit. */
+			index_close(idxrel, NoLock);
+			break;
+		}
+		index_close(idxrel, RowExclusiveLock);
+	}
+
+	list_free(indexoidlist);
+
+	return found;
+}
+
 void
 spock_apply_heap_begin(void)
 {
@@ -714,7 +767,7 @@ spock_handle_conflict_and_apply(SpockRelation *rel, EState *estate,
 	}
 	else
 	{
-		spock_report_conflict(is_insert ? CONFLICT_INSERT_INSERT : CONFLICT_UPDATE_UPDATE,
+		spock_report_conflict(is_insert ? CONFLICT_INSERT_EXISTS : CONFLICT_UPDATE_UPDATE,
 							  rel, TTS_TUP(localslot), oldtup,
 							  remotetuple, applytuple, resolution,
 							  xmin, local_origin_found, local_origin,
@@ -893,6 +946,17 @@ spock_apply_heap_insert(SpockRelation *rel, SpockTupleData *newtup)
 	found = FindReplTupleInLocalRel(edata, relinfo->ri_RelationDesc,
 									edata->targetRel->idxoid,
 									remoteslot, &localslot);
+
+	if (check_all_uc_indexes &&
+		!found)
+	{
+		/*
+		 * Handle the special case of looking through all unique indexes
+		 * defined on the relation.
+		 */
+		found = FindReplTupleByUCIndex(edata, relinfo->ri_RelationDesc,
+									   remoteslot, &localslot);
+	}
 
 	if (found)
 	{

--- a/spock_common.c
+++ b/spock_common.c
@@ -12,10 +12,21 @@
 
 #include "postgres.h"
 #include "miscadmin.h"
+
+#include "executor/executor.h"
+#include "storage/ipc.h"
+#include "storage/lmgr.h"
+#include "storage/proc.h"
 #include "utils/guc.h"
+#include "utils/lsyscache.h"
+#include "utils/syscache.h"
 
 #include "spock_common.h"
 #include "spock_compat.h"
+
+static StrategyNumber spock_get_equal_strategy_number(Oid opclass);
+static int spock_build_replindex_scan_key(ScanKey skey, Relation rel,
+							Relation idxrel, TupleTableSlot *searchslot);
 
 /*
  * Temporarily switch to a new user ID.
@@ -149,4 +160,233 @@ SPKExecARInsertTriggers(EState *estate,
 	SwitchToUntrustedUser(relinfo->ri_RelationDesc->rd_rel->relowner, &ucxt);
 	ExecARInsertTriggers(estate, relinfo, slot, recheckIndexes);
 	RestoreUserContext(&ucxt);
+}
+
+/*
+ * Check if an index is usable for INSERT conflict detection (Insert-Exists).
+ *
+ * Usable indexes must be:
+ * - Valid
+ * - Unique and immediate (not deferrable)
+ * - Not partial (no predicate)
+ *
+ * PK and RI indexes are excluded, as they are already used by default for
+ * conflict resolution.
+ */
+bool
+IsIndexUsableForInsertConflict(Relation idxrel)
+{
+	/* Skip if already used for replica identity or primary key */
+	if (idxrel->rd_index->indisprimary || idxrel->rd_index->indisreplident)
+		return false;
+
+	/* Skip if index is invalid, non-unique, non-immediate, or partial */
+	if (!idxrel->rd_index->indisvalid ||
+		!idxrel->rd_index->indisunique ||
+		!idxrel->rd_index->indimmediate ||
+		!heap_attisnull(idxrel->rd_indextuple, Anum_pg_index_indpred, NULL))
+		return false;
+
+	return true;
+}
+
+/*
+ * Search the relation 'rel' for tuple using the index.
+ *
+ * If a matching tuple is found, lock it with lockmode, fill the slot with its
+ * contents, and return true.  Return false otherwise.
+ */
+bool
+SpockRelationFindReplTupleByIndex(Relation rel,
+							 Relation idxrel,
+							 LockTupleMode lockmode,
+							 TupleTableSlot *searchslot,
+							 TupleTableSlot *outslot)
+{
+	ScanKeyData skey[INDEX_MAX_KEYS];
+	int			skey_attoff;
+	IndexScanDesc scan;
+	SnapshotData snap;
+	TransactionId xwait;
+	bool		found;
+
+	InitDirtySnapshot(snap);
+
+	/* Build scan key. */
+	skey_attoff = spock_build_replindex_scan_key(skey, rel, idxrel, searchslot);
+
+	/* Start an index scan. */
+	scan = index_beginscan(rel, idxrel, &snap, skey_attoff, 0);
+
+retry:
+	found = false;
+
+	index_rescan(scan, skey, skey_attoff, NULL, 0);
+
+	/* Try to find the tuple */
+	while (index_getnext_slot(scan, ForwardScanDirection, outslot))
+	{
+		ExecMaterializeSlot(outslot);
+
+		xwait = TransactionIdIsValid(snap.xmin) ?
+			snap.xmin : snap.xmax;
+
+		/*
+		 * If the tuple is locked, wait for locking transaction to finish and
+		 * retry.
+		 */
+		if (TransactionIdIsValid(xwait))
+		{
+			XactLockTableWait(xwait, NULL, NULL, XLTW_None);
+			goto retry;
+		}
+
+		/* Found our tuple and it's not locked */
+		found = true;
+		break;
+	}
+
+	/* Found tuple, try to lock it in the lockmode. */
+	if (found)
+	{
+		TM_FailureData tmfd;
+		TM_Result	res;
+
+		PushActiveSnapshot(GetLatestSnapshot());
+
+		res = table_tuple_lock(rel, &(outslot->tts_tid), GetActiveSnapshot(),
+							   outslot,
+							   GetCurrentCommandId(false),
+							   lockmode,
+							   LockWaitBlock,
+							   0 /* don't follow updates */ ,
+							   &tmfd);
+
+		PopActiveSnapshot();
+
+		switch (res)
+		{
+			case TM_Ok:
+				break;
+			case TM_Updated:
+				/* XXX: Improve handling here */
+				if (ItemPointerIndicatesMovedPartitions(&tmfd.ctid))
+					ereport(DEBUG1,
+							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							 errmsg("tuple to be locked was already moved to another partition due to concurrent update, retrying")));
+				else
+					ereport(DEBUG1,
+							(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+							 errmsg("concurrent update, retrying")));
+				goto retry;
+			case TM_Deleted:
+				/* XXX: Improve handling here */
+				ereport(DEBUG1,
+						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
+						 errmsg("concurrent delete, retrying")));
+				goto retry;
+			case TM_Invisible:
+				elog(ERROR, "attempted to lock invisible tuple");
+				break;
+			default:
+				elog(ERROR, "unexpected table_tuple_lock status: %u", res);
+				break;
+		}
+	}
+
+	index_endscan(scan);
+
+	return found;
+}
+
+/*
+ * Return the appropriate strategy number which corresponds to the equality
+ * operator.
+ */
+static StrategyNumber
+spock_get_equal_strategy_number(Oid opclass)
+{
+	Oid			am = get_opclass_method(opclass);
+
+	return get_equal_strategy_number_for_am(am);
+}
+
+/*
+ * Setup a ScanKey for a search in the relation 'rel' for a tuple 'key' that
+ * is setup to match 'rel' (*NOT* idxrel!).
+ *
+ * Returns how many columns to use for the index scan.
+ */
+static int
+spock_build_replindex_scan_key(ScanKey skey, Relation rel, Relation idxrel,
+						 TupleTableSlot *searchslot)
+{
+	int			index_attoff;
+	int			skey_attoff = 0;
+	Datum		indclassDatum;
+	oidvector  *opclass;
+	int2vector *indkey = &idxrel->rd_index->indkey;
+
+	indclassDatum = SysCacheGetAttrNotNull(INDEXRELID, idxrel->rd_indextuple,
+										   Anum_pg_index_indclass);
+	opclass = (oidvector *) DatumGetPointer(indclassDatum);
+
+	/* Build scankey for every non-expression attribute in the index. */
+	for (index_attoff = 0; index_attoff < IndexRelationGetNumberOfKeyAttributes(idxrel);
+		 index_attoff++)
+	{
+		Oid			operator;
+		Oid			optype;
+		Oid			opfamily;
+		RegProcedure regop;
+		int			table_attno = indkey->values[index_attoff];
+		StrategyNumber eq_strategy;
+
+		if (!AttributeNumberIsValid(table_attno))
+		{
+			/*
+			 * XXX: Currently, we don't support expressions in the scan key,
+			 * see code below.
+			 */
+			continue;
+		}
+
+		/*
+		 * Load the operator info.  We need this to get the equality operator
+		 * function for the scan key.
+		 */
+		optype = get_opclass_input_type(opclass->values[index_attoff]);
+		opfamily = get_opclass_family(opclass->values[index_attoff]);
+		eq_strategy = spock_get_equal_strategy_number(opclass->values[index_attoff]);
+
+		operator = get_opfamily_member(opfamily, optype,
+									   optype,
+									   eq_strategy);
+
+		if (!OidIsValid(operator))
+			elog(ERROR, "missing operator %d(%u,%u) in opfamily %u",
+				 eq_strategy, optype, optype, opfamily);
+
+		regop = get_opcode(operator);
+
+		/* Initialize the scankey. */
+		ScanKeyInit(&skey[skey_attoff],
+					index_attoff + 1,
+					eq_strategy,
+					regop,
+					searchslot->tts_values[table_attno - 1]);
+
+		skey[skey_attoff].sk_collation = idxrel->rd_indcollation[index_attoff];
+
+		/* Check for null value. */
+		if (searchslot->tts_isnull[table_attno - 1])
+			skey[skey_attoff].sk_flags |= (SK_ISNULL | SK_SEARCHNULL);
+
+		skey_attoff++;
+	}
+
+	/* There must always be at least one attribute for the index scan. */
+	Assert(skey_attoff > 0);
+
+	return skey_attoff;
 }

--- a/spock_common.h
+++ b/spock_common.h
@@ -69,4 +69,11 @@ extern void SPKExecARInsertTriggers(EState *estate,
 								 TupleTableSlot *slot,
 								 List *recheckIndexes);
 
+extern bool IsIndexUsableForInsertConflict(Relation idxrel);
+extern bool SpockRelationFindReplTupleByIndex(Relation rel,
+								 Relation idxrel,
+								 LockTupleMode lockmode,
+								 TupleTableSlot *searchslot,
+								 TupleTableSlot *outslot);
+
 #endif /* SPOCK_COMMON_H */

--- a/spock_conflict.c
+++ b/spock_conflict.c
@@ -608,8 +608,8 @@ conflict_type_to_string(SpockConflictType conflict_type)
 {
 	switch (conflict_type)
 	{
-		case CONFLICT_INSERT_INSERT:
-			return "insert_insert";
+		case CONFLICT_INSERT_EXISTS:
+			return "insert_exists";
 		case CONFLICT_UPDATE_UPDATE:
 			return "update_update";
 		case CONFLICT_UPDATE_DELETE:
@@ -735,12 +735,12 @@ spock_report_conflict(SpockConflictType conflict_type,
 	 */
 	switch (conflict_type)
 	{
-		case CONFLICT_INSERT_INSERT:
+		case CONFLICT_INSERT_EXISTS:
 		case CONFLICT_UPDATE_UPDATE:
 			ereport(spock_conflict_log_level,
 					(errcode(ERRCODE_INTEGRITY_CONSTRAINT_VIOLATION),
 					 errmsg("CONFLICT: remote %s on relation %s (local index %s). Resolution: %s.",
-							conflict_type == CONFLICT_INSERT_INSERT ? "INSERT" : "UPDATE",
+							conflict_type == CONFLICT_INSERT_EXISTS ? "INSERT EXISTS" : "UPDATE",
 							qualrelname, idxname,
 							conflict_resolution_to_string(resolution)),
 					 errdetail("existing local tuple {%s} xid=%u,origin=%d,timestamp=%s; remote tuple {%s}%s in xact origin=%u,timestamp=%s,commit_lsn=%X/%X",

--- a/spock_conflict.c
+++ b/spock_conflict.c
@@ -942,15 +942,12 @@ get_conflict_log_seq(void)
 
 	if (seqoid == InvalidOid)
 	{
-		Oid			reloid;
-		Relation	rel;
-
-		reloid = get_conflict_log_table_oid();
+		Oid			reloid = get_conflict_log_table_oid();
 #if PG_VERSION_NUM >= 170000
-		rel = RelationIdGetRelation(reloid);
+		Relation	rel = RelationIdGetRelation(reloid);
+
 		seqoid = getIdentitySequence(rel, InvalidAttrNumber, false);
 		RelationClose(rel);
-		rel = NULL;
 #else
 		seqoid = getIdentitySequence(reloid, InvalidAttrNumber, false);
 #endif

--- a/spock_conflict.h
+++ b/spock_conflict.h
@@ -46,7 +46,7 @@ extern bool	spock_save_resolutions;
 
 typedef enum SpockConflictType
 {
-	CONFLICT_INSERT_INSERT,
+	CONFLICT_INSERT_EXISTS,
 	CONFLICT_UPDATE_UPDATE,
 	CONFLICT_UPDATE_DELETE,
 	CONFLICT_DELETE_DELETE


### PR DESCRIPTION
Introduce a new GUC `spock.check_all_uc_indexes` (default: false) that, when enabled, allows INSERT conflict detection to fall back on all usable unique indexes (excluding PK and replica identity indexes) if primary and replica identity indexes fail to find a match.

This feature enhances conflict resolution reliability in cases where unique constraints exist but are not part of PK/RI.

- Added new GUC spock.check_all_uc_indexes
- Implemented FindReplTupleByUCIndex() to scan all valid unique indexes
- Refactored index conflict checking logic into reusable helpers:
  - IsIndexUsableForInsertConflict()
  - SpockRelationFindReplTupleByIndex()
- Changed conflict type from CONFLICT_INSERT_INSERT to CONFLICT_INSERT_EXISTS for better semantics