### PR TITLE
Enhance synchronous replication feedback handling to avoid premature acknowledgment.

### DIFF
--- a/spock_apply.c
+++ b/spock_apply.c
@@ -2529,7 +2529,7 @@ append_feedback_position(XLogRecPtr recvpos)
 	RemoteSyncPosition *syncpos;
 	MemoryContext oldctx;
 
-	Assert(WalSndCtl->sync_standbys_defined);
+	Assert(WalSndCtl->sync_standbys_status & SYNC_STANDBY_DEFINED);
 
 	if (get_flush_position(&writepos, &flushpos))
 	{
@@ -2570,7 +2570,7 @@ get_feedback_position(XLogRecPtr *recvpos, XLogRecPtr *writepos, XLogRecPtr *flu
 	dlist_mutable_iter iter1;
 	RemoteSyncPosition *syncpos;
 
-	Assert(WalSndCtl->sync_standbys_defined);
+	Assert(WalSndCtl->sync_standbys_status & SYNC_STANDBY_DEFINED);
 	if (dlist_is_empty(&sync_replica_lsn))
 		return;
 

--- a/spock_apply.c
+++ b/spock_apply.c
@@ -71,6 +71,8 @@
 #include "utils/memutils.h"
 #include "utils/pg_lsn.h"
 #include "utils/snapmgr.h"
+#include "replication/syncrep.h"
+#include "replication/walsender_private.h"
 
 #include "spock_common.h"
 #include "spock_conflict.h"
@@ -226,6 +228,24 @@ struct ActionErrCallbackArg errcallback_arg;
 TransactionId remote_xid;
 
 /*
+ * Structure of RemoteSyncPosition to Save the LSN in case of
+ * Synchronous replica is attached
+ */
+typedef struct RemoteSyncPosition
+{
+	dlist_node  node;
+	XLogRecPtr  recvpos;
+	XLogRecPtr  flushpos;
+	XLogRecPtr  writepos;
+} RemoteSyncPosition;
+
+/*
+ * Queue of structure RemoteSyncPosition to Save the LSN in
+ * case of Synchronous replica is attached
+ */
+dlist_head sync_replica_lsn = DLIST_STATIC_INIT(sync_replica_lsn);
+
+/*
  * We enable skipping all data modification changes (INSERT, UPDATE, etc.) for
  * the subscription if the remote transaction's finish LSN matches the sub_skip_lsn.
  * Once we start skipping changes, we don't stop it until we skip all changes of
@@ -273,6 +293,10 @@ static void
 apply_replay_entry_free(ApplyReplayEntry *entry);
 static void
 apply_replay_queue_reset(void);
+
+static void append_feedback_position(XLogRecPtr recvpos);
+static void get_feedback_position(XLogRecPtr *recvpos, XLogRecPtr *writepos, XLogRecPtr *flushpos, XLogRecPtr *max_recvpos);
+
 
 /*
  * Install hooks to request shared resources for apply workers
@@ -993,6 +1017,9 @@ handle_commit(StringInfo s)
 		remoteTransactionStopTimestamp = commit_time;
 
 		CommitTransactionCommand();
+
+		if (WalSndCtl->sync_standbys_status & SYNC_STANDBY_DEFINED)
+			append_feedback_position(XactLastCommitEnd);
 
 		remoteTransactionStopTimestamp = 0;
 
@@ -2487,22 +2514,115 @@ get_flush_position(XLogRecPtr *write, XLogRecPtr *flush)
 }
 
 /*
- * Send a Standby Status Update message to server.
- *
- * 'recvpos' is the latest LSN we've received data to, force is set if we need
- * to send a response to avoid timeouts.
+ * If a synchronous replica is attached, in code we set synchronous commit off.
+ * This can be dangerous because feedback might be sent before receiving
+ * acknowledgment from the remote synchronous replica. To handle this,
+ * a list of locally committed LSNs is maintained. Feedback is delayed
+ * until acknowledgment is received from the remote synchronous replica,
+ * thus avoiding blocking the transaction while ensuring data consistency.
  */
+static void
+append_feedback_position(XLogRecPtr recvpos)
+{
+	XLogRecPtr writepos;
+	XLogRecPtr flushpos;
+	RemoteSyncPosition *syncpos;
+	MemoryContext oldctx;
+
+	Assert(WalSndCtl->sync_standbys_defined);
+
+	if (get_flush_position(&writepos, &flushpos))
+	{
+		/*
+		 * No outstanding transactions to flush, we can report the latest
+		 * received position. This is important for synchronous replication.
+		 */
+		flushpos = writepos = recvpos;
+	}
+
+	/* Ensure that we are allocating in the top memory context */
+	oldctx = MemoryContextSwitchTo(TopMemoryContext);
+	syncpos = (RemoteSyncPosition *) palloc0(sizeof(RemoteSyncPosition));
+	MemoryContextSwitchTo(oldctx);
+
+	syncpos->recvpos = recvpos;
+	syncpos->writepos = writepos;
+	syncpos->flushpos = flushpos;
+	dlist_push_tail(&sync_replica_lsn, &syncpos->node);
+	elog(DEBUG2, "SPOCK %s: appended feedback to list %X/%X, write %X/%X, flush %X/%X",
+		 MySubscription->name,
+		 (uint32) (recvpos >> 32), (uint32) recvpos,
+		 (uint32) (writepos >> 32), (uint32) writepos,
+		 (uint32) (flushpos >> 32), (uint32) flushpos
+		);
+}
+
+/*
+ * As we have maintained a list of LSNs that are waiting for
+ * acknowledgment from the synchronous replica, we need to get the
+ * feedback position from the list and send it to the Spock node attached to it.
+ * This ensures that we only send feedback that is committed and acknowledged
+ * by the synchronous replica.
+ */
+static void
+get_feedback_position(XLogRecPtr *recvpos, XLogRecPtr *writepos, XLogRecPtr *flushpos, XLogRecPtr *max_recvpos)
+{
+	dlist_mutable_iter iter1;
+	RemoteSyncPosition *syncpos;
+
+	Assert(WalSndCtl->sync_standbys_defined);
+	if (dlist_is_empty(&sync_replica_lsn))
+		return;
+
+	/* Acquire lock to update the sync position */
+	LWLockAcquire(SyncRepLock, LW_EXCLUSIVE);
+
+	/* Iterate through the wait queue and update positions */
+	dlist_foreach_modify(iter1, &sync_replica_lsn)
+	{
+		syncpos = dlist_container(RemoteSyncPosition, node, iter1.cur);
+		if (syncpos == NULL)
+			break;
+
+		if (syncpos->recvpos <= WalSndCtl->lsn[SYNC_REP_WAIT_FLUSH])
+		{
+			*recvpos = syncpos->recvpos;
+			*writepos = syncpos->writepos;
+			*flushpos = syncpos->flushpos;
+			elog(DEBUG2, "SPOCK %s: received feedback %X/%X, "
+				 "write %X/%X, flush %X/%X",
+				 MySubscription->name,
+				 (uint32) (*recvpos >> 32), (uint32) *recvpos,
+				 (uint32) (*writepos >> 32), (uint32) *writepos,
+				 (uint32) (*flushpos >> 32), (uint32) *flushpos
+				);
+			dlist_delete(iter1.cur);
+			pfree(syncpos);
+			syncpos = NULL;
+		}
+		if (syncpos != NULL)
+			*max_recvpos = syncpos->recvpos;
+	}
+	/* Release the lock */
+	LWLockRelease(SyncRepLock);
+}
+
 static bool
 send_feedback(PGconn *conn, XLogRecPtr recvpos, int64 now, bool force)
 {
 	static StringInfo reply_message = NULL;
 
+	static XLogRecPtr max_recvpos = InvalidXLogRecPtr;
 	static XLogRecPtr last_recvpos = InvalidXLogRecPtr;
 	static XLogRecPtr last_writepos = InvalidXLogRecPtr;
 	static XLogRecPtr last_flushpos = InvalidXLogRecPtr;
 
 	XLogRecPtr	writepos;
 	XLogRecPtr	flushpos;
+
+	/* In case of any syncrounoun replica is attached get the  LSN from the list */
+	if (WalSndCtl->sync_standbys_status & SYNC_STANDBY_DEFINED)
+		get_feedback_position(&recvpos, &writepos, &flushpos, &max_recvpos);
 
 	/* It's legal to not pass a recvpos */
 	if (recvpos < last_recvpos)
@@ -2547,11 +2667,12 @@ send_feedback(PGconn *conn, XLogRecPtr recvpos, int64 now, bool force)
 	pq_sendbyte(reply_message, false);	/* replyRequested */
 
 	elog(DEBUG2, "SPOCK %s: sending feedback (force %d) to recv %X/%X, "
-		 "write %X/%X, flush %X/%X",
+		 "write %X/%X, flush %X/%X, max_waiting_lsn %X/%X",
 		 MySubscription->name, force,
 		 (uint32) (recvpos >> 32), (uint32) recvpos,
 		 (uint32) (writepos >> 32), (uint32) writepos,
-		 (uint32) (flushpos >> 32), (uint32) flushpos
+		 (uint32) (flushpos >> 32), (uint32) flushpos,
+		 (uint32) (max_recvpos >> 32), (uint32) max_recvpos
 		);
 
 	if (PQputCopyData(conn, reply_message->data, reply_message->len) <= 0 ||
@@ -2758,8 +2879,9 @@ stream_replay:
 
 				if (c == 'w')
 				{
-					XLogRecPtr	start_lsn;
-					XLogRecPtr	end_lsn;
+					XLogRecPtr start_lsn;
+					XLogRecPtr end_lsn;
+					static int w_message_count = 0;
 
 					start_lsn = pq_getmsgint64(msg);
 					end_lsn = pq_getmsgint64(msg);
@@ -2770,6 +2892,26 @@ stream_replay:
 
 					if (last_received < end_lsn)
 						last_received = end_lsn;
+
+					w_message_count++;
+
+					/*
+					 * Send feedback if wal_sender_timeout/2 has passed or after 10 'w' messages.
+					 */
+					if (TimestampDifferenceExceeds(last_receive_timestamp, GetCurrentTimestamp(), wal_sender_timeout / 2) ||
+						w_message_count >= 10)
+					{
+						elog(DEBUG2, "SPOCK %s: force sending feedback after %d 'w' messages or timeout",
+							 MySubscription->name, w_message_count);
+						/*
+						 * We need to send feedback to the walsender process
+						 * to avoid remote wal_sender_timeout.
+						 */
+						send_feedback(applyconn, last_received, GetCurrentTimestamp(), true);
+						last_receive_timestamp = GetCurrentTimestamp();
+						w_message_count = 0;
+					}
+
 
 					/*
 					 * Append the entry to the end of the replay queue
@@ -3910,6 +4052,9 @@ spock_apply_main(Datum main_arg)
 	VALGRIND_DISABLE_ERROR_REPORTING;
 	VALGRIND_DO_LEAK_CHECK;
 	VALGRIND_ENABLE_ERROR_REPORTING;
+
+	/* Initialize the wait queue for replicated LSNs */
+	dlist_init(&sync_replica_lsn);
 
 	apply_work(streamConn);
 


### PR DESCRIPTION
When a synchronous replica is attached, the system had previously set synchronous_commit to 'off', which could lead to premature feedback being sent before receiving an acknowledgment from the remote synchronous replica. This behavior posed a risk to data consistency.

To address this, a list of locally committed LSNs is maintained. Feedback is now delayed until acknowledgment is received from the remote synchronous replica, ensuring transaction durability while preventing unnecessary blocking.

Now the feedback will be sent if 1/2 the wal_sender_timeout occurs or in case of 10 'w' messages.