### PR TITLE
Fix progress entry creation timing and correct remote_node_id usage i…

### DIFF
--- a/spock_functions.c
+++ b/spock_functions.c
@@ -572,6 +572,9 @@ Datum spock_create_subscription(PG_FUNCTION_ARGS)
 
 	create_subscription(&sub);
 
+	/* Create progress entry to track commit ts per local/remote origin */
+	create_progress_entry(localnode->node->id, originif.nodeid, 0);
+
 	/* Create synchronization status for the subscription. */
 	memset(&sync, 0, sizeof(SpockSyncStatus));
 
@@ -614,9 +617,6 @@ Datum spock_create_subscription(PG_FUNCTION_ARGS)
 		(void) replorigin_create(slot_name.data);
 	}
 	create_local_sync_status(&sync);
-
-	/* Create progress entry to track commit ts per local/remote origin */
-	create_progress_entry(localnode->node->id, originif.nodeid, 0);
 
 	PG_RETURN_OID(sub.id);
 }

--- a/spock_sync.c
+++ b/spock_sync.c
@@ -389,7 +389,7 @@ adjust_progress_info(PGconn *origin_conn, PGconn *target_conn)
 		"    remote_insert_lsn = %s, "
 		"    last_updated_ts = %s, "
 		"    updated_by_decode = %s "
-		"WHERE node_id = '%d' AND remote_node_id = %s";
+		"WHERE node_id = '%d' AND remote_node_id = '%d'";
 
 	StringInfoData	query;
 	PGresult	   *originRes;
@@ -442,8 +442,7 @@ adjust_progress_info(PGconn *origin_conn, PGconn *target_conn)
 							 PQescapeLiteral(target_conn, updated_by_decode,
 											 strlen(updated_by_decode)),
 							 MySubscription->target->id,
-							 PQescapeLiteral(target_conn, remote_node_id,
-											 strlen(remote_node_id)));
+							 MySubscription->origin->id);
 			updateRes = PQexec(target_conn, query.data);
 
 			if (PQresultStatus(updateRes) != PGRES_COMMAND_OK)


### PR DESCRIPTION
…n sync update

- Moved create_progress_entry() earlier in spock_create_subscription() to ensure the progress entry exists before sync status creation.

- Fixed SQL query in adjust_progress_info() to use the correct remote_node_id, ensuring the update targets the appropriate row for the newly created subscription.