### PR TITLE
Fix compilation error with older PG 15/16 versions; refine index key …

### DIFF
--- a/spock_exception_handler.c
+++ b/spock_exception_handler.c
@@ -38,6 +38,7 @@
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
 #include "utils/lsyscache.h"
+#include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/builtins.h"
 #include "replication/origin.h"


### PR DESCRIPTION
…check logic

Fixes a compilation issue introduced by PR#60 that prevented building on older versions of PostgreSQL 15 and 16.

Also includes minor refinements:
- Renamed index_keys_match() to index_keys_have_nonnulls() to clarify that the function does not perform value equality checks.
- Simplified NULL check logic and improved comments to align with SQL semantics, where NULLs are never considered equal—even when both sides are NULL.