### PR TITLE
Always log apply conflicts; remove unused before-trigger flag

### DIFF
--- a/spock_conflict.h
+++ b/spock_conflict.h
@@ -82,8 +82,7 @@ extern void spock_report_conflict(SpockConflictType conflict_type,
 						  bool found_local_origin,
 						  RepOriginId local_tuple_origin,
 						  TimestampTz local_tuple_timestamp,
-						  Oid conflict_idx_id,
-						  bool has_before_triggers);
+						  Oid conflict_idx_id);
 
 extern void spock_conflict_log_table(SpockConflictType conflict_type,
 						  SpockRelation *rel,
@@ -96,8 +95,7 @@ extern void spock_conflict_log_table(SpockConflictType conflict_type,
 						  bool found_local_origin,
 						  RepOriginId local_tuple_origin,
 						  TimestampTz local_tuple_timestamp,
-						  Oid conflict_idx_id,
-						  bool has_before_triggers);
+						  Oid conflict_idx_id);
 extern Oid get_conflict_log_table_oid(void);
 extern Oid get_conflict_log_seq(void);
 extern bool spock_conflict_resolver_check_hook(int *newval, void **extra,


### PR DESCRIPTION
Changed spock_report_conflict() to always log conflict information, regardless of which tuple (local or remote) wins the resolution. This improves observability and debugging.

Improved delete conflict handling by logging instead of erroring when the target row is missing. Also removed the unused 'has_before_triggers' flag from conflict logging APIs.