### PR TITLE
[SPOC-66] Fix segfault on constraint violation

### DIFF
--- a/spock_apply.c
+++ b/spock_apply.c
@@ -1342,27 +1342,24 @@ log_insert_exception(bool failed, ErrorData *edata, SpockRelation *rel,
 	TimestampTz		local_commit_ts = 0;
 	TransactionId	xmin = InvalidTransactionId;
 	bool			local_origin_found = false;
-	HeapTuple		localtup = NULL;
+	HeapTuple		localtup;
 
 	if (!should_log_exception(failed))
 		return;
 
-	if (oldtup)
+	localtup = exception_log_ptr[my_exception_log_index].local_tuple;
+	if (localtup != NULL)
 	{
-		localtup = exception_log_ptr[my_exception_log_index].local_tuple;
-		if (localtup != NULL)
-		{
-			local_origin_found = get_tuple_origin(rel, localtup,
-												  &(localtup->t_self),
-												  &xmin,
-												  &local_origin,
-												  &local_commit_ts);
+		local_origin_found = get_tuple_origin(rel, localtup,
+											  &(localtup->t_self),
+											  &xmin,
+											  &local_origin,
+											  &local_commit_ts);
 
-			if (local_origin_found && local_origin == 0)
-			{
-				SpockLocalNode *local_node = get_local_node(false, false);
-				local_origin = local_node->node->id;
-			}
+		if (local_origin_found && local_origin == 0)
+		{
+			SpockLocalNode *local_node = get_local_node(false, false);
+			local_origin = local_node->node->id;
 		}
 	}
 

--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -984,6 +984,11 @@ spock_apply_heap_insert(SpockRelation *rel, SpockTupleData *newtup)
 	}
 	else
 	{
+		SpockExceptionLog *exception_log = &exception_log_ptr[my_exception_log_index];
+
+		/* Clear out any old value for when logging it in the resolutions table. */
+		exception_log->local_tuple = NULL;
+
 		/* Make sure that any user-supplied code runs as the table owner. */
 		SwitchToUntrustedUser(rel->rel->rd_rel->relowner, &ucxt);
 		/* Do the actual INSERT */


### PR DESCRIPTION
If there is a violation on a second unique index, a segfault was occurring. It was trying to compare against the old tuple, but since the problem happened on the non-PK, the pointer to the old tuple should not be used.

Also took care of a compilation warning.