### PR TITLE
fix: add DESTDIR prefix to spockctrl install

### DIFF
--- a/spockctrl/Makefile
+++ b/spockctrl/Makefile
@@ -57,8 +57,8 @@ clean-all: clean
 	find . \( -name '*~' -o -name '*.o' -o -name 'spockctrl' -o -name '*.log' -o -name '*.tmp' \) -exec rm -f {} +
 
 install:
-	install -d $(PG_BINDIR)
-	install -m 0755 $(EXEC) $(PG_BINDIR)/
+	install -d $(DESTDIR)$(PG_BINDIR)
+	install -m 0755 $(EXEC) $(DESTDIR)$(PG_BINDIR)/
 	install -d $(DESTDIR)$(SPOCK_DIR)
 	install -d $(DESTDIR)$(SPOCK_DIR)/workflows/
 	find . -type f -name '*.json' ! -name 'spockctrl.json' -exec install -m 644 {} $(DESTDIR)$(SPOCK_DIR)/workflows/ \;


### PR DESCRIPTION
DESTDIR is used in package builds to install Postgres and extensions to a build root. We already use this prefix elsewhere but it was missing from these two lines.

PLAT-173