### PR TITLE
[SPOC-91] Get functions.sql regression test working again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ SCRIPTS_built = spock_create_subscriber
 # FIXME: triggers, row_filter, multiple_upstreams
 REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondary_unique \
 		  toasted replication_set matview bidirectional primary_key \
-		  interfaces foreign_key copy sequence parallel \
+		  interfaces foreign_key copy sequence parallel functions \
 		  row_filter_sampling att_list column_filter apply_delay \
 		  extended node_origin_cascade drop
 

--- a/expected/functions.out
+++ b/expected/functions.out
@@ -272,17 +272,18 @@ SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 
 \c :subscriber_dsn
 ALTER TABLE public.not_nullcheck_tbl ADD COLUMN id2 integer not null;
+-- disable now to use pg_logical_slot_get_changes() later
+SELECT spock.sub_disable('test_subscription', true);
+ sub_disable 
+-------------
+ t
+(1 row)
+
 \c :provider_dsn
 SELECT quote_literal(pg_current_xlog_location()) as curr_lsn
 \gset
 INSERT INTO public.not_nullcheck_tbl(id,id1,name) VALUES (1,1,'name1');
 INSERT INTO public.not_nullcheck_tbl(id,id1,name) VALUES (2,2,'name2');
-SELECT spock.wait_slot_confirm_lsn(NULL, :curr_lsn);
- wait_slot_confirm_lsn 
------------------------
- 
-(1 row)
-
 \c :subscriber_dsn
 SELECT * FROM public.not_nullcheck_tbl;
  id | id1 | name | id2 
@@ -297,12 +298,6 @@ SELECT * FROM public.not_nullcheck_tbl;
 ----+-----+------+-----
 (0 rows)
 
-SELECT spock.sub_disable('test_subscription', true);
- sub_disable 
--------------
- t
-(1 row)
-
 \c :provider_dsn
 DO $$
 BEGIN
@@ -314,7 +309,7 @@ BEGIN
 	END LOOP;
 END;
 $$;
-SELECT data::json->'action' as action, CASE WHEN data::json->>'action' IN ('I', 'D', 'U') THEN data END as data FROM pg_logical_slot_get_changes((SELECT slot_name FROM pg_replication_slots), NULL, 1, 'min_proto_version', '1', 'max_proto_version', '1', 'startup_params_format', '1', 'proto_format', 'json', 'spock.replication_set_names', 'default');
+SELECT data::json->'action' as action, CASE WHEN data::json->>'action' IN ('I', 'D', 'U') THEN data END as data FROM pg_logical_slot_get_changes((SELECT slot_name FROM pg_replication_slots), NULL, 1, 'min_proto_version', '3', 'max_proto_version', '4', 'startup_params_format', '1', 'proto_format', 'json', 'spock.replication_set_names', 'default') WHERE LENGTH(data) > 0;
  action |                                                data                                                 
 --------+-----------------------------------------------------------------------------------------------------
  "S"    | 
@@ -323,7 +318,7 @@ SELECT data::json->'action' as action, CASE WHEN data::json->>'action' IN ('I', 
  "C"    | 
 (4 rows)
 
-SELECT data::json->'action' as action, CASE WHEN data::json->>'action' IN ('I', 'D', 'U') THEN data END as data FROM pg_logical_slot_get_changes((SELECT slot_name FROM pg_replication_slots), NULL, 1, 'min_proto_version', '1', 'max_proto_version', '1', 'startup_params_format', '1', 'proto_format', 'json', 'spock.replication_set_names', 'default');
+SELECT data::json->'action' as action, CASE WHEN data::json->>'action' IN ('I', 'D', 'U') THEN data END as data FROM pg_logical_slot_get_changes((SELECT slot_name FROM pg_replication_slots), NULL, 1, 'min_proto_version', '3', 'max_proto_version', '4', 'startup_params_format', '1', 'proto_format', 'json', 'spock.replication_set_names', 'default') WHERE LENGTH(data) > 0;
  action |                                                data                                                 
 --------+-----------------------------------------------------------------------------------------------------
  "S"    | 
@@ -389,8 +384,6 @@ CREATE TABLE public.prime_tbl (
 	num public.prime NOT NULL,
 	PRIMARY KEY(num)
 );
-
-INSERT INTO public.prime_tbl (num) VALUES(17), (31), (79);
 $$);
  replicate_ddl 
 ---------------
@@ -403,6 +396,7 @@ SELECT * FROM spock.repset_add_table('default', 'public.prime_tbl');
  t
 (1 row)
 
+INSERT INTO public.prime_tbl (num) VALUES(17), (31), (79);
 DELETE FROM public.prime_tbl WHERE num = 31;
 SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
  wait_slot_confirm_lsn 


### PR DESCRIPTION
Get `functions.sql` regression test working again and added to the regresscheck list.

I needed to make some adjustments: pulled an `INSERT` outside of replicating DDL, disable the subscription sooner, and check the data length when using `pg_logical_slot_get_changes()`.