### PR TITLE
Update links in spock work branch (v5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,4 @@ You cannot roll back an upgrade because of changes to the catalog tables; before
 Then, to upgrade the version of Spock that you use to manage your replication cluster, you can remove, build, and upgrade the Spock extension like you would any other [PostgreSQL extension](https://www.postgresql.org/docs/17/extend-extensions.html#EXTEND-EXTENSIONS-UPDATES).
 
 
-
-
-Spock is licensed under the [pgEdge Community License v1.0](PGEDGE-COMMUNITY-LICENSE.md)
+To review the Spock license, visit [here](LICENSE.md).

--- a/docs/creating_subscriber_nodes.md
+++ b/docs/creating_subscriber_nodes.md
@@ -30,8 +30,8 @@ You can use the following options to override the location of the configuration 
 
 | Option   | Description
 |----------|-------------
-|`--hba-conf` | path to the new pg_hba.conf
-| `--postgresql-conf` | path to the new postgresql.conf
+|`--hba-conf` | path to the new `pg_hba.conf`
+| `--postgresql-conf` | path to the new `postgresql.conf`
 | `--recovery-conf` | path to the template recovery configuration
 
-Unlike `spock.sub_create`'s other data sync options, this method of cloning ignores replication sets and copies all tables on all databases. However, it's often much faster, especially over high-bandwidth links.
+Unlike `spock.sub_create`'s other data sync options, this method of cloning ignores replication sets and copies all tables on all databases. However, it's often much faster, especially over high-bandwidth connections.

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,11 +86,7 @@ You can use a `row_filter` clause with a partitioned table, as well as with indi
 
 Conflicts can arise if a node is subscribed to multiple providers, or when local writes happen on a subscriber node.  Without Spock, logical replication can also encounter issues when resolving the value of a running sum (such as a YTD balance). 
 
-import {Callout} from 'nextra/components'
-
-<Callout type="info">
-Suppose that a running bank account sum contains a balance of `$1,000`.   Two transactions "conflict" because they overlap with each from two different multi-master nodes.   Transaction A is a `$1,000` withdrawal from the account.  Transaction B is also a `$1,000` withdrawal from the account.  The correct balance is `$-1,000`.  Our Delta-Apply algorithm fixes this problem and highly conflicting workloads with this scenario (like a tpc-c like benchmark) now run correctly at lightning speeds.
-</Callout>
+*Suppose that a running bank account sum contains a balance of `$1,000`.   Two transactions "conflict" because they overlap with each from two different multi-master nodes.   Transaction A is a `$1,000` withdrawal from the account.  Transaction B is also a `$1,000` withdrawal from the account.  The correct balance is `$-1,000`.  Our Delta-Apply algorithm fixes this problem and highly conflicting workloads with this scenario (like a tpc-c like benchmark) now run correctly at lightning speeds.*
 
  In the past, Postgres users have relied on special data types and numbering schemes to help prevent conflicts. Unlike other solutions, Spock's powerful and simple conflict-free delta-apply columns instead manage data update conflicts with logic:
 
@@ -111,6 +107,7 @@ ALTER TABLE pgbench_tellers ALTER COLUMN tbalance SET (log_old_value=true, delta
 ```
 
 As a special safety-valve feature, if you ever need to re-set a `log_old_value` column you can temporarily alter the column to `log_old_value` is `false`.
+
 
 ### Conflict Configuration Options
 
@@ -191,7 +188,7 @@ process.
 
 We strongly recommend that you use Snowflake Sequences instead of legacy PostgreSQL sequences.
 
-[Snowflake](https://github.com/pgEdge/snowflake-sequences) is a PostgreSQL extension that provides an `int8` and sequence based unique ID solution to optionally replace the PostgreSQL built-in `bigserial` data type. This extension allows Snowflake IDs that are unique within one sequence across multiple PostgreSQL instances in a distributed cluster.
+[Snowflake](https://github.com/pgEdge/snowflake) is a PostgreSQL extension that provides an `int8` and sequence based unique ID solution to optionally replace the PostgreSQL built-in `bigserial` data type. This extension allows Snowflake IDs that are unique within one sequence across multiple PostgreSQL instances in a distributed cluster.
 
 The Spock extension includes the following functions to help you manage Snowflake sequences:
 

--- a/docs/guc_settings.md
+++ b/docs/guc_settings.md
@@ -46,7 +46,7 @@ To enable conflict resolution, the `track_commit_timestamp` PostgreSQL setting m
 
 **`spock.enable_ddl_replication`**
 
-`spock.enable_ddl_replication` enables [automatic replication](../spock_ext/managing/spock_autoddl.mdx) of ddl statements through the `default` replication set.
+`spock.enable_ddl_replication` enables [automatic replication](https://github.com/pgEdge/spock/blob/main/docs/features.md#automatic-ddl-replication) of ddl statements through the `default` replication set.
 
 **`spock.exception_behaviour`** 
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -33,7 +33,7 @@ You can have additional unique constraints upstream if the downstream consumer g
 
 Partial secondary unique indexes are permitted, but will be ignored for conflict resolution purposes.
 
-`spock.check_all_uc_indexes` is an experimental GUC that adds `INSERT` conflict resolution by allowing Spock to consider all unique constraints, not just the primary key or replica identity. [For more information, visit](guc_settings.md).
+`spock.check_all_uc_indexes` is an experimental [GUC](https://github.com/pgEdge/spock/blob/main/docs/guc_settings.md) that adds `INSERT` conflict resolution by allowing Spock to consider all unique constraints, not just the primary key or replica identity. 
 
 ### Unique constraints must not be deferrable
 
@@ -86,8 +86,7 @@ not replicated to the replica.
 
 ### Sequences
 
-We strongly recommend that you use pgEdge [Snowflake Sequences](features.md) rather
-than using the legacy sequences described below.
+We strongly recommend that you use pgEdge [Snowflake Sequences](https://github.com/pgEdge/snowflake) rather than using the legacy sequences described below.
 
 The state of sequences added to replication sets is replicated periodically
 and not in real-time. Dynamic buffer is used for the value being replicated so
@@ -138,7 +137,7 @@ encoding. We recommend using `UTF-8` encoding in all replicated databases.
 ### Large objects
 
 PostgreSQL's logical decoding facility does not support decoding changes
-to [large objects](https://www.postgresql.org/docs/current/largeobjects.html); we recommend instead using the [LOLOR extension](features.md) to manage large objects.
+to [large objects](https://www.postgresql.org/docs/current/largeobjects.html); we recommend instead using the [LOLOR extension](https://github.com/pgEdge/lolor) to manage large objects.
 
 Note that DDL limitations apply, so extra care needs to be taken when using
 `replicate_ddl_command()`.

--- a/docs/spock_functions.md
+++ b/docs/spock_functions.md
@@ -5,7 +5,7 @@ The following user functions are available via the Spock extension:
 | Command  | Description |
 |----------|-------------| 
 | **Node Management Functions** | You can add and remove nodes dynamically using Spock interfaces.|
-| [spock.node_info]() | Returns information about the node on which the function is invoked.
+| spock.node_info | Returns information about the node on which the function is invoked.
 | [spock.node_create](functions/spock_node_create.md) | Define a node for spock.
 | [spock.node_drop](functions/spock_node_drop.md) | Remove a spock node.
 | [node_add_interface](functions/spock_node_add_interface.md) | Add a new node interface.
@@ -19,11 +19,10 @@ The following user functions are available via the Spock extension:
 | [spock.repset_add_table](functions/spock_repset_add_table.md) | Add table(s) to replication set.
 | [spock.repset_add_all_tables](functions/spock_repset_add_all_tables.md) | Add all existing table(s) to the replication set.
 | [spock.repset_remove_table](functions/spock_repset_remove_table.md) | Remove table from replication set.
-| [spock.repset_show_table] |   
 | [repset_add_seq](functions/spock_repset_add_seq.md) | Deprecated; Adds a sequence to a replication set.
 | [repset_add_all_seqs](functions/spock_repset_add_all_seqs.md) | Deprecated; Adds all sequences from the specified schemas to a replication set.
 | [repset_remove_seq](functions/spock_repset_remove_seq.md) | Deprecated; Remove a sequence from a replication set.
-| [spock.sync_seq] | Synchronize the specified sequence.
+| [spock.sync_seq](functions/spock_seq_sync.md) | Synchronize the specified sequence.
 | **Subscription Management Functions** | |
 | [spock.sub_create](functions/spock_sub_create.md) | Create a subscription.
 | [spock.sub_drop](functions/spock_sub_drop.md) | Delete a subscription.
@@ -31,32 +30,33 @@ The following user functions are available via the Spock extension:
 | [spock.sub_enable](functions/spock_sub_enable.md) | Make a subscription live.
 | [spock.sub_add_repset](functions/spock_sub_add_repset.md) | Add a replication set to a subscription.
 | [spock.sub_remove_repset](functions/spock_sub_remove_repset.md) | Drop a replication set from a subscription.
+| [spock.sub_resync_table](functions/spock_sub_resync_table.md) | Resynchronize one existing table.
 | [spock.sub_show_status](functions/spock_sub_show_status.md) | Display the status of the subcription.
 | [spock.sub_show_table](functions/spock_sub_show_table.md) | Show subscription tables.
+| [spock.sub_sync](functions/spock_sync.md) | Call this function to synchronize all unsynchronized tables in all sets in a single operation.
 | [spock.sub_alter_interface](functions/spock_sub_alter_interface.md) | Modify an interface to a subscription.
 | [spock.sub_wait_for_sync](functions/spock_sub_wait_for_sync.md) | Pause until the subscription is synchronized.
-| [spock.sub_alter_skiplsn] | Skip transactions until the specified lsn. 
-| [spock.sub_alter_sync] | Synchronize all missing tables.
-| [spock.sub_resync_table] | Synchronize a specific table.
+| spock.sub_alter_skiplsn | Skip transactions until the specified lsn. 
+| spock.sub_alter_sync | Synchronize all missing tables.
 | **Miscellaneous Management Functions** | |
 | [spock.table_wait_for_sync](functions/spock_table_wait_for_sync.md) | Pause until a table finishes synchronizing.
 | [spock.replicate_ddl](functions/spock_replicate_ddl.md) | Enable DDL replication.
-| [set_readonly](functions/spock_set_readonly.md) | Turn PostgreSQL read_only mode 'on' or 'off'.
-| [spock.spock_version]() | Returns the Spock version in a major/minor version form: `4.0.10`.
-| [spock.spock_version_num]() | Returns the Spock version in a single numeric form: `40010`.
-| [spock.convert_sequence_to_snowflake] | Convert a Postgres native sequence to a Snowflake sequence.
-| [spock.get_channel_stats]() | Returns tuple traffic statistics.
-| [spock.get_country]() | Returns the country code if explicitly set; returns `??` if not set.
-| [spock.lag_tracker]() | Returns a list of slots, with commit_lsn and commit_timestamp for each.
-| [spock.repair_mode] | Used to manage the state of replication - If set to `true`, stops replicating statements; when `false`, resumes replication.
-| [spock.replicate_ddl] | Replicate a specific statement.
-| [spock.reset_channel_stats] | Reset the channel statistics.
-| [spock.spock_max_proto_version] | The highest Spock native protocol supported by the current binary/build.
-| [spock.spock_min_proto_version] | The lowest build for which this Spock binary is backward compatible. 
-| [spock.table_data_filtered] | Scans the specified table and returns rows that match the row filter from the specified replication set(s).  Row filters are added to a replication set when adding a table with `repset_add_table`.
-| [spock.terminate_active_transactions] | Terminates all active transactions.
-| [spock.wait_slot_confirm_lsn] | Wait for the `confirmed_flush_lsn` of the specified slot, or all logical slots if none given.
-| [spock.xact_commit_timestamp_origin] | Returns the commit timestamp and origin of the specified transaction.
+| spock.set_readonly | Turn PostgreSQL read_only mode 'on' or 'off'.
+| spock.spock_version | Returns the Spock version in a major/minor version form: `4.0.10`.
+| spock.spock_version_num | Returns the Spock version in a single numeric form: `40010`.
+| spock.convert_sequence_to_snowflake | Convert a Postgres native sequence to a Snowflake sequence.
+| spock.get_channel_stats | Returns tuple traffic statistics.
+| spock.get_country | Returns the country code if explicitly set; returns `??` if not set.
+| spock.lag_tracker | Returns a list of slots, with commit_lsn and commit_timestamp for each.
+| spock.repair_mode | Used to manage the state of replication - If set to `true`, stops replicating statements; when `false`, resumes replication.
+| spock.replicate_ddl | Replicate a specific statement.
+| spock.reset_channel_stats | Reset the channel statistics.
+| spock.spock_max_proto_version | The highest Spock native protocol supported by the current binary/build.
+| spock.spock_min_proto_version | The lowest build for which this Spock binary is backward compatible. 
+| spock.table_data_filtered | Scans the specified table and returns rows that match the row filter from the specified replication set(s).  Row filters are added to a replication set when adding a table with `repset_add_table`.
+| spock.terminate_active_transactions | Terminates all active transactions.
+| spock.wait_slot_confirm_lsn | Wait for the `confirmed_flush_lsn` of the specified slot, or all logical slots if none given.
+| spock.xact_commit_timestamp_origin | Returns the commit timestamp and origin of the specified transaction.
 
 
  

--- a/docs/spock_info.md
+++ b/docs/spock_info.md
@@ -25,7 +25,7 @@ a single row in this table implies that a command to create a subscription on th
 
 You can connect to the database server and query the `spock.node` table to return information about configured nodes:
 
-```json
+```sql
 select * from spock.node;
 -[ RECORD 1 ]--------
 node_id   | 673694252

--- a/docs/spockctrl.md
+++ b/docs/spockctrl.md
@@ -220,7 +220,7 @@ The following is sample content from a `spockctrl.json` file; customize the `spo
 Spockctrl provides functions to manage different aspects of your Spock replication setup. The functions are grouped by the type of object they manage:
 
 * [Spockctrl node management](#spockctrl-node-management-functions) functions
-* [Spockctrl replication management](#spockctrl-node-management-functions) functions
+* [Spockctrl replication management](#spockctrl-replication-set-management-functions) functions
 * [Spockctrl subscription management](#spockctrl-subscription-management-functions) functions
 * [Spockctrl SQL execution](#spockctrl-sql-execution-functions) functions
 
@@ -921,8 +921,6 @@ After starting replication, we check the lag time between the new node and each 
         "on_failure": {}
       }
     }
-  ]
-}
 ```
 
 The SQL command from the last step (in a more readable format) is:


### PR DESCRIPTION
Updated links in README.md, guc_settings.md, limitations.md, spock_functions.md, spockctrl.md, Removed callout in features.md, Formatting changes in creating_subscriber_nodes.md, spock_info.md - adding link repairs to this branch so the changes are passed along with our other work.