### PR TITLE
Replaced secrets.READ_SPOCKBENCH_PAT with secrets.GITHUB_TOKEN for

### DIFF
--- a/.github/workflows/spockbench.yml
+++ b/.github/workflows/spockbench.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: pgedge/spockbench
-          token: ${{ secrets.READ_SPOCKBENCH_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: spockbench
           ref: master
 


### PR DESCRIPTION
checking out the pgedge/spockbench repository. This allows the workflow to run in pull requests from forks now that spockbench is public.