### PR TITLE
Add predicate filtering for partial unique indexes in conflict resolu…

### DIFF
--- a/regress-postgresql.conf
+++ b/regress-postgresql.conf
@@ -24,7 +24,7 @@ spock.orig_provider_dsn = 'dbname=sourcedb'
 spock.provider_dsn = 'dbname=regression'
 spock.provider1_dsn = 'dbname=regression1'
 spock.subscriber_dsn = 'dbname=postgres'
-
+spock.check_all_uc_indexes = true
 # Uncomment to test SPI and multi-insert
 #spock.use_spi = true
 #spock.conflict_resolution = error

--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -508,7 +508,7 @@ FindReplTupleByUCIndex(ApplyExecutionData *edata,
 			continue;
 		}
 
-		found = SpockRelationFindReplTupleByIndex(localrel, idxrel,
+		found = SpockRelationFindReplTupleByIndex(edata->estate, localrel, idxrel,
 											 LockTupleExclusive,
 											 remoteslot, *localslot);
 		if (found)

--- a/spock_common.h
+++ b/spock_common.h
@@ -70,7 +70,8 @@ extern void SPKExecARInsertTriggers(EState *estate,
 								 List *recheckIndexes);
 
 extern bool IsIndexUsableForInsertConflict(Relation idxrel);
-extern bool SpockRelationFindReplTupleByIndex(Relation rel,
+extern bool SpockRelationFindReplTupleByIndex(EState *estate,
+								 Relation rel,
 								 Relation idxrel,
 								 LockTupleMode lockmode,
 								 TupleTableSlot *searchslot,


### PR DESCRIPTION
…tion

Conflict detection now evaluates the index predicate on both the remote and local tuples. This prevents false positives when a partial unique index applies only to a subset of rows.

If the remote tuple does not match the index predicate, we skip scanning the index altogether, as no conflict is possible in that case.