### PR TITLE
Show test status badge in README on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spock Multi-Master Replication for PostgreSQL
 
+[![Regression Tests and Spockbench](https://github.com/pgEdge/spock/actions/workflows/spockbench.yml/badge.svg)](https://github.com/pgEdge/spock/actions/workflows/spockbench.yml)
+
 ## Table of Contents
 - [Building the Spock Extension](README.md#building-the-spock-extension)
 - [Basic Configuration and Usage](README.md#basic-configuration-and-usage)


### PR DESCRIPTION
Show the current status of CI tests by adding it to the README. It will appear as:

<img width="1121" height="733" alt="Screenshot 2025-07-29 at 11 02 23 AM" src="https://github.com/user-attachments/assets/f545348c-c60a-47cb-97c9-3f88ab009603" />