### PR TITLE
make PG_CONFIG overridable and pass it to sub-make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ spock_version=$(shell grep "^\#define \<SPOCK_VERSION\>" $(realpath $(srcdir)/sp
 abs_top_builddir = .
 NO_TEMP_INSTALL = yes
 
-PG_CONFIG ?= pg_config
+export PG_CONFIG ?= pg_config
 
 PGVER := $(shell $(PG_CONFIG) --version | sed 's/[^0-9]//g' | cut -c 1-2)
 
@@ -115,7 +115,7 @@ spock.control: spock.control.in spock.h
 	sed 's/__SPOCK_VERSION__/$(spock_version)/;s/__REQUIRES__/$(requires)/' $(realpath $(srcdir)/spock.control.in) > $(control_path)
 
 spockctrl:
-	$(MAKE) -C spockctrl
+	$(MAKE) -C $(srcdir)/spockctrl
 
 all: spock.control spockctrl
 
@@ -166,12 +166,12 @@ check_prove:
 clean: clean-spockctrl
 
 clean-spockctrl:
-	$(MAKE) -C spockctrl clean
+	$(MAKE) -C $(srcdir)/spockctrl clean
 
 install: install-spockctrl
 
 install-spockctrl:
-	$(MAKE) -C spockctrl install
+	$(MAKE) -C $(srcdir)/spockctrl install
 
 .PHONY: all check regresscheck spock.control spockctrl
 

--- a/spockctrl/Makefile
+++ b/spockctrl/Makefile
@@ -2,11 +2,11 @@
 CC = gcc
 
 # PostgreSQL include and library directories
-PG_INCDIR = $(shell pg_config --includedir)
-PG_LIBDIR = $(shell pg_config --libdir)
-PG_BINDIR = $(shell pg_config --bindir)
+PG_INCDIR = $(shell $(PG_CONFIG) --includedir)
+PG_LIBDIR = $(shell $(PG_CONFIG) --libdir)
+PG_BINDIR = $(shell $(PG_CONFIG) --bindir)
 
-PG_SHAREDIR = $(shell pg_config --sharedir)
+PG_SHAREDIR = $(shell $(PG_CONFIG) --sharedir)
 SPOCK_DIR = $(PG_SHAREDIR)/spock
 
 UNAME_S := $(shell uname -s)


### PR DESCRIPTION
- export PG_CONFIG in the top-level Makefile so it's visible to sub-make
- replace hardcoded pg_config calls in spockctrl/Makefile with $(PG_CONFIG) so the correct binary gets used when PG_CONFIG is set externally or if pg_config is available in the PATH.