### PR TITLE
SPOC-179: Update patches for PG 18 to apply cleanly

### DIFF
--- a/patches/pg18-015-attoptions.diff
+++ b/patches/pg18-015-attoptions.diff
@@ -1,5 +1,5 @@
 diff --git a/src/backend/access/common/reloptions.c b/src/backend/access/common/reloptions.c
-index 49fd35bfc5..51111663c6 100644
+index 50747c16396..6cdbbe1d0dd 100644
 --- a/src/backend/access/common/reloptions.c
 +++ b/src/backend/access/common/reloptions.c
 @@ -166,6 +166,15 @@ static relopt_bool boolRelOpts[] =
@@ -18,7 +18,7 @@ index 49fd35bfc5..51111663c6 100644
  	/* list terminator */
  	{{NULL}}
  };
-@@ -546,6 +555,19 @@ static relopt_enum enumRelOpts[] =
+@@ -557,6 +566,19 @@ static relopt_enum enumRelOpts[] =
  
  static relopt_string stringRelOpts[] =
  {
@@ -38,7 +38,7 @@ index 49fd35bfc5..51111663c6 100644
  	/* list terminator */
  	{{NULL}}
  };
-@@ -2070,7 +2092,9 @@ attribute_reloptions(Datum reloptions, bool validate)
+@@ -2106,7 +2128,9 @@ attribute_reloptions(Datum reloptions, bool validate)
  {
  	static const relopt_parse_elt tab[] = {
  		{"n_distinct", RELOPT_TYPE_REAL, offsetof(AttributeOpts, n_distinct)},
@@ -50,7 +50,7 @@ index 49fd35bfc5..51111663c6 100644
  
  	return (bytea *) build_reloptions(reloptions, validate,
 diff --git a/src/backend/access/heap/heapam.c b/src/backend/access/heap/heapam.c
-index 9a31cdcd09..8c1274028e 100644
+index 0dcd6ee817e..49cd71d1a7d 100644
 --- a/src/backend/access/heap/heapam.c
 +++ b/src/backend/access/heap/heapam.c
 @@ -48,6 +48,7 @@
@@ -59,9 +59,9 @@ index 9a31cdcd09..8c1274028e 100644
  #include "storage/procarray.h"
 +#include "utils/attoptcache.h"
  #include "utils/datum.h"
+ #include "utils/injection_point.h"
  #include "utils/inval.h"
- #include "utils/spccache.h"
-@@ -65,6 +66,7 @@ static void check_lock_if_inplace_updateable_rel(Relation relation,
+@@ -67,6 +68,7 @@ static void check_lock_if_inplace_updateable_rel(Relation relation,
  												 HeapTuple newtup);
  static void check_inplace_rel_lock(HeapTuple oldtup);
  #endif
@@ -69,7 +69,7 @@ index 9a31cdcd09..8c1274028e 100644
  static Bitmapset *HeapDetermineColumnsInfo(Relation relation,
  										   Bitmapset *interesting_cols,
  										   Bitmapset *external_cols,
-@@ -101,6 +103,7 @@ static void index_delete_sort(TM_IndexDeleteOp *delstate);
+@@ -104,6 +106,7 @@ static void index_delete_sort(TM_IndexDeleteOp *delstate);
  static int	bottomup_sort_and_shrink(TM_IndexDeleteOp *delstate);
  static XLogRecPtr log_heap_new_cid(Relation relation, HeapTuple tup);
  static HeapTuple ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
@@ -77,7 +77,7 @@ index 9a31cdcd09..8c1274028e 100644
  										bool *copy);
  
  
-@@ -2918,7 +2921,7 @@ l1:
+@@ -3016,7 +3019,7 @@ l1:
  	 * Compute replica identity tuple before entering the critical section so
  	 * we don't PANIC upon a memory allocation failure.
  	 */
@@ -86,7 +86,7 @@ index 9a31cdcd09..8c1274028e 100644
  
  	/*
  	 * If this is the first possibly-multixact-able operation in the current
-@@ -3151,6 +3154,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
+@@ -3249,6 +3252,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
  	Bitmapset  *id_attrs;
  	Bitmapset  *interesting_attrs;
  	Bitmapset  *modified_attrs;
@@ -94,7 +94,7 @@ index 9a31cdcd09..8c1274028e 100644
  	ItemId		lp;
  	HeapTupleData oldtup;
  	HeapTuple	heaptup;
-@@ -3273,6 +3277,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
+@@ -3418,6 +3422,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
  	modified_attrs = HeapDetermineColumnsInfo(relation, interesting_attrs,
  											  id_attrs, &oldtup,
  											  newtup, &id_has_external);
@@ -102,7 +102,7 @@ index 9a31cdcd09..8c1274028e 100644
  
  	/*
  	 * If we're not updating any "key" column, we can grab a weaker lock type.
-@@ -3547,6 +3552,7 @@ l2:
+@@ -3692,6 +3697,7 @@ l2:
  		bms_free(key_attrs);
  		bms_free(id_attrs);
  		bms_free(modified_attrs);
@@ -110,7 +110,7 @@ index 9a31cdcd09..8c1274028e 100644
  		bms_free(interesting_attrs);
  		return result;
  	}
-@@ -3896,6 +3902,7 @@ l2:
+@@ -4041,6 +4047,7 @@ l2:
  	old_key_tuple = ExtractReplicaIdentity(relation, &oldtup,
  										   bms_overlap(modified_attrs, id_attrs) ||
  										   id_has_external,
@@ -118,7 +118,7 @@ index 9a31cdcd09..8c1274028e 100644
  										   &old_key_copied);
  
  	/* NO EREPORT(ERROR) from here till changes are logged */
-@@ -4062,6 +4069,7 @@ l2:
+@@ -4207,6 +4214,7 @@ l2:
  	bms_free(key_attrs);
  	bms_free(id_attrs);
  	bms_free(modified_attrs);
@@ -126,7 +126,7 @@ index 9a31cdcd09..8c1274028e 100644
  	bms_free(interesting_attrs);
  
  	return TM_Ok;
-@@ -4234,6 +4242,26 @@ heap_attr_equals(TupleDesc tupdesc, int attrnum, Datum value1, Datum value2,
+@@ -4379,6 +4387,26 @@ heap_attr_equals(TupleDesc tupdesc, int attrnum, Datum value1, Datum value2,
  	}
  }
  
@@ -153,7 +153,7 @@ index 9a31cdcd09..8c1274028e 100644
  /*
   * Check which columns are being updated.
   *
-@@ -8978,6 +9006,7 @@ log_heap_new_cid(Relation relation, HeapTuple tup)
+@@ -9132,6 +9160,7 @@ log_heap_new_cid(Relation relation, HeapTuple tup)
   */
  static HeapTuple
  ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
@@ -161,7 +161,7 @@ index 9a31cdcd09..8c1274028e 100644
  					   bool *copy)
  {
  	TupleDesc	desc = RelationGetDescr(relation);
-@@ -9010,13 +9039,16 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
+@@ -9164,13 +9193,16 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
  	}
  
  	/* if the key isn't required and we're only logging the key, we're done */
@@ -180,7 +180,7 @@ index 9a31cdcd09..8c1274028e 100644
  	 * If there's no defined replica identity columns, treat as !key_required.
  	 * (This case should not be reachable from heap_update, since that should
 diff --git a/src/include/utils/attoptcache.h b/src/include/utils/attoptcache.h
-index a1a9bfc0fb..e9b6dfab47 100644
+index f684a772af5..6c965fede13 100644
 --- a/src/include/utils/attoptcache.h
 +++ b/src/include/utils/attoptcache.h
 @@ -21,6 +21,8 @@ typedef struct AttributeOpts

--- a/patches/pg18-020-LOG-to-DEBUG1.diff
+++ b/patches/pg18-020-LOG-to-DEBUG1.diff
@@ -1,8 +1,8 @@
 diff --git a/src/backend/executor/execReplication.c b/src/backend/executor/execReplication.c
-index 54025c9f15..b70805269d 100644
+index f262e7a66f7..0d24b056216 100644
 --- a/src/backend/executor/execReplication.c
 +++ b/src/backend/executor/execReplication.c
-@@ -185,7 +185,7 @@ should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
+@@ -142,7 +142,7 @@ should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
  		case TM_Updated:
  			/* XXX: Improve handling here */
  			if (ItemPointerIndicatesMovedPartitions(&tmfd->ctid))
@@ -11,7 +11,7 @@ index 54025c9f15..b70805269d 100644
  						(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
  						 errmsg("tuple to be locked was already moved to another partition due to concurrent update, retrying")));
  			else
-@@ -196,7 +196,7 @@ should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
+@@ -153,7 +153,7 @@ should_refetch_tuple(TM_Result res, TM_FailureData *tmfd)
  			break;
  		case TM_Deleted:
  			/* XXX: Improve handling here */

--- a/patches/pg18-025-logical_commit_clock.diff
+++ b/patches/pg18-025-logical_commit_clock.diff
@@ -1,5 +1,5 @@
 diff --git a/src/backend/access/transam/xact.c b/src/backend/access/transam/xact.c
-index 004f7e10e5..e35da3d6a5 100644
+index b885513f765..62219cc44eb 100644
 --- a/src/backend/access/transam/xact.c
 +++ b/src/backend/access/transam/xact.c
 @@ -135,6 +135,15 @@ static TransactionId *ParallelCurrentXids;
@@ -60,7 +60,7 @@ index 004f7e10e5..e35da3d6a5 100644
  	ShowTransactionState("StartTransaction");
  }
  
-@@ -5837,6 +5867,7 @@ XactLogCommitRecord(TimestampTz commit_time,
+@@ -5830,6 +5860,7 @@ XactLogCommitRecord(TimestampTz commit_time,
  	xl_xact_twophase xl_twophase;
  	xl_xact_origin xl_origin;
  	uint8		info;
@@ -68,7 +68,7 @@ index 004f7e10e5..e35da3d6a5 100644
  
  	Assert(CritSectionCount > 0);
  
-@@ -5980,7 +6011,20 @@ XactLogCommitRecord(TimestampTz commit_time,
+@@ -5973,7 +6004,20 @@ XactLogCommitRecord(TimestampTz commit_time,
  	/* we allow filtering by xacts */
  	XLogSetRecordFlags(XLOG_INCLUDE_ORIGIN);
  
@@ -90,7 +90,7 @@ index 004f7e10e5..e35da3d6a5 100644
  }
  
  /*
-@@ -6451,3 +6495,60 @@ xact_redo(XLogReaderState *record)
+@@ -6444,3 +6488,60 @@ xact_redo(XLogReaderState *record)
  	else
  		elog(PANIC, "xact_redo: unknown op code %u", info);
  }
@@ -152,7 +152,7 @@ index 004f7e10e5..e35da3d6a5 100644
 +	XLogSetLastTransactionStopTimestamp(logical_clock);
 +}
 diff --git a/src/backend/access/transam/xlog.c b/src/backend/access/transam/xlog.c
-index f14d3933ae..960d4ae70b 100644
+index 184de54f3a1..91934885af8 100644
 --- a/src/backend/access/transam/xlog.c
 +++ b/src/backend/access/transam/xlog.c
 @@ -156,6 +156,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
@@ -172,7 +172,7 @@ index f14d3933ae..960d4ae70b 100644
  /* Estimated distance between checkpoints, in bytes */
  static double CheckPointDistanceEstimate = 0;
  static double PrevCheckPointDistance = 0;
-@@ -552,6 +562,14 @@ typedef struct XLogCtlData
+@@ -563,6 +573,14 @@ typedef struct XLogCtlData
  	XLogRecPtr	lastFpwDisableRecPtr;
  
  	slock_t		info_lck;		/* locks shared variables shown above */
@@ -187,7 +187,7 @@ index f14d3933ae..960d4ae70b 100644
  } XLogCtlData;
  
  /*
-@@ -701,6 +719,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
+@@ -712,6 +730,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
  								XLogRecData *rdata,
  								XLogRecPtr StartPos, XLogRecPtr EndPos,
  								TimeLineID tli);
@@ -195,7 +195,7 @@ index f14d3933ae..960d4ae70b 100644
  static void ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos,
  									  XLogRecPtr *EndPos, XLogRecPtr *PrevPtr);
  static bool ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos,
-@@ -779,6 +798,13 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -790,6 +809,13 @@ XLogInsertRecord(XLogRecData *rdata,
  	if (!XLogInsertAllowed())
  		elog(ERROR, "cannot make new WAL entries during recovery");
  
@@ -209,7 +209,7 @@ index f14d3933ae..960d4ae70b 100644
  	/*
  	 * Given that we're not in recovery, InsertTimeLineID is set and can't
  	 * change, so we can read it without a lock.
-@@ -907,6 +933,17 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -918,6 +944,17 @@ XLogInsertRecord(XLogRecData *rdata,
  
  	if (inserted)
  	{
@@ -227,7 +227,7 @@ index f14d3933ae..960d4ae70b 100644
  		/*
  		 * Now that xl_prev has been filled in, calculate CRC of the record
  		 * header.
-@@ -1087,6 +1124,27 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -1101,6 +1138,27 @@ XLogInsertRecord(XLogRecData *rdata,
  	return EndPos;
  }
  
@@ -255,7 +255,7 @@ index f14d3933ae..960d4ae70b 100644
  /*
   * Reserves the right amount of space for a record of given size from the WAL.
   * *StartPos is set to the beginning of the reserved section, *EndPos to
-@@ -1131,6 +1189,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
+@@ -1145,6 +1203,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
  	 */
  	SpinLockAcquire(&Insert->insertpos_lck);
  
@@ -269,7 +269,7 @@ index f14d3933ae..960d4ae70b 100644
  	startbytepos = Insert->CurrBytePos;
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
-@@ -1190,6 +1255,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
+@@ -1204,6 +1269,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
  		return false;
  	}
  
@@ -282,7 +282,7 @@ index f14d3933ae..960d4ae70b 100644
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
  
-@@ -9517,3 +9588,15 @@ SetWalWriterSleeping(bool sleeping)
+@@ -9684,3 +9755,15 @@ SetWalWriterSleeping(bool sleeping)
  	XLogCtl->WalWriterSleeping = sleeping;
  	SpinLockRelease(&XLogCtl->info_lck);
  }
@@ -299,7 +299,7 @@ index f14d3933ae..960d4ae70b 100644
 +	XLogCtl->lastTransactionStopTimestamp = ts;
 +}
 diff --git a/src/include/access/xact.h b/src/include/access/xact.h
-index fb64d7413a..965d19b892 100644
+index b2bc10ee041..0ab9948b4cf 100644
 --- a/src/include/access/xact.h
 +++ b/src/include/access/xact.h
 @@ -95,6 +95,13 @@ extern PGDLLIMPORT bool bsysscan;
@@ -317,7 +317,7 @@ index fb64d7413a..965d19b892 100644
   * XACT_FLAGS_ACCESSEDTEMPNAMESPACE - set when a temporary object is accessed.
   * We don't allow PREPARE TRANSACTION in that case.
 diff --git a/src/include/access/xlog.h b/src/include/access/xlog.h
-index 34ad46c067..fb841feeda 100644
+index d313099c027..5d6e6831a08 100644
 --- a/src/include/access/xlog.h
 +++ b/src/include/access/xlog.h
 @@ -199,6 +199,18 @@ typedef enum WALAvailability
@@ -339,7 +339,7 @@ index 34ad46c067..fb841feeda 100644
  extern XLogRecPtr XLogInsertRecord(struct XLogRecData *rdata,
  								   XLogRecPtr fpw_lsn,
  								   uint8 flags,
-@@ -270,6 +282,14 @@ extern void SetInstallXLogFileSegmentActive(void);
+@@ -271,6 +283,14 @@ extern void SetInstallXLogFileSegmentActive(void);
  extern bool IsInstallXLogFileSegmentActive(void);
  extern void XLogShutdownWalRcv(void);
  

--- a/patches/pg18-030-per-subtrans-commit-ts.diff
+++ b/patches/pg18-030-per-subtrans-commit-ts.diff
@@ -1,10 +1,10 @@
 diff --git a/src/backend/access/rmgrdesc/committsdesc.c b/src/backend/access/rmgrdesc/committsdesc.c
-index f5f09a1bc7..c12352a239 100644
+index a6ab9dd78de..423c236e7cc 100644
 --- a/src/backend/access/rmgrdesc/committsdesc.c
 +++ b/src/backend/access/rmgrdesc/committsdesc.c
 @@ -37,6 +37,13 @@ commit_ts_desc(StringInfo buf, XLogReaderState *record)
- 		appendStringInfo(buf, "pageno %lld, oldestXid %u",
- 						 (long long) trunc->pageno, trunc->oldestXid);
+ 		appendStringInfo(buf, "pageno %" PRId64 ", oldestXid %u",
+ 						 trunc->pageno, trunc->oldestXid);
  	}
 +	else if (info == COMMIT_TS_SUBTRANS_TS)
 +	{
@@ -26,7 +26,7 @@ index f5f09a1bc7..c12352a239 100644
  			return NULL;
  	}
 diff --git a/src/backend/access/transam/commit_ts.c b/src/backend/access/transam/commit_ts.c
-index 77e1899d7a..235030624a 100644
+index 225ff7ca9f2..4235350db90 100644
 --- a/src/backend/access/transam/commit_ts.c
 +++ b/src/backend/access/transam/commit_ts.c
 @@ -84,6 +84,14 @@ static SlruCtlData CommitTsCtlData;
@@ -155,7 +155,7 @@ index 77e1899d7a..235030624a 100644
  static void
  error_commit_ts_disabled(void)
  {
-@@ -1009,6 +1094,23 @@ WriteTruncateXlogRec(int64 pageno, TransactionId oldestXid)
+@@ -1016,6 +1101,23 @@ WriteTruncateXlogRec(int64 pageno, TransactionId oldestXid)
  	(void) XLogInsert(RM_COMMIT_TS_ID, COMMIT_TS_TRUNCATE);
  }
  
@@ -179,7 +179,7 @@ index 77e1899d7a..235030624a 100644
  /*
   * CommitTS resource manager's routines
   */
-@@ -1052,6 +1154,19 @@ commit_ts_redo(XLogReaderState *record)
+@@ -1059,6 +1161,19 @@ commit_ts_redo(XLogReaderState *record)
  
  		SimpleLruTruncate(CommitTsCtl, trunc->pageno);
  	}
@@ -200,7 +200,7 @@ index 77e1899d7a..235030624a 100644
  		elog(PANIC, "commit_ts_redo: unknown op code %u", info);
  }
 diff --git a/src/include/access/commit_ts.h b/src/include/access/commit_ts.h
-index 82d3aa8627..12d75fc4ab 100644
+index b8294e41b97..dacade2a216 100644
 --- a/src/include/access/commit_ts.h
 +++ b/src/include/access/commit_ts.h
 @@ -1,3 +1,4 @@

--- a/patches/pg18-090-init_template_fix.diff
+++ b/patches/pg18-090-init_template_fix.diff
@@ -1,8 +1,8 @@
 diff --git a/src/Makefile.global.in b/src/Makefile.global.in
-index 4859343153..1ad94b316d 100644
+index 8b1b357beaa..227004fcd36 100644
 --- a/src/Makefile.global.in
 +++ b/src/Makefile.global.in
-@@ -410,10 +410,15 @@ ld_library_path_var = LD_LIBRARY_PATH
+@@ -425,10 +425,15 @@ ld_library_path_var = LD_LIBRARY_PATH
  # with_temp_install_extra is for individual ports to define if they
  # need something more here. If not defined then the expansion does
  # nothing.


### PR DESCRIPTION
Update patches for PG 18 so that they do not fail and apply cleanly.

Will do a follow up to add Postgres 18 to the automated tests once it is released.