### PR TITLE
SPOC-194: get_tuple_origin: initialize local timestamp and origin val…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondar
 		  toasted replication_set matview bidirectional primary_key \
 		  interfaces foreign_key copy sequence triggers parallel functions row_filter \
 		  row_filter_sampling att_list column_filter apply_delay \
-		  extended node_origin_cascade multiple_upstreams drop
+		  extended node_origin_cascade multiple_upstreams tuple_origin \
+		  drop
 
 # The following test cases are disabled while developing.
 #

--- a/src/spock_conflict.c
+++ b/src/spock_conflict.c
@@ -506,7 +506,12 @@ get_tuple_origin(SpockRelation *rel, HeapTuple local_tuple, ItemPointer tid,
 				 TransactionId *xmin,
 				 RepOriginId *local_origin, TimestampTz *local_ts)
 {
+	/* Initialize local origin and timestamp */
+	*local_origin = InvalidRepOriginId;
+	*local_ts = 0;
+
 	*xmin = HeapTupleHeaderGetXmin(local_tuple->t_data);
+
 	if (!track_commit_timestamp)
 	{
 		*local_origin = replorigin_session_origin;
@@ -536,17 +541,21 @@ get_tuple_origin(SpockRelation *rel, HeapTuple local_tuple, ItemPointer tid,
 		return TransactionIdGetCommitTsData(*xmin, local_ts, local_origin);
 	}
 
-	if (!TransactionIdEquals(*xmin, GetTopTransactionId()) &&
-		!TransactionIdGetCommitTsData(*xmin, local_ts, local_origin))
+	if (TransactionIdEquals(*xmin, GetTopTransactionId()))
 	{
 		/*
-		 * The commit timestamp info for this transaction was trimmed already.
-		 * Nothing much we can do.
+		 * The tuple was created by current xact, no commit timestamp yet.
 		 */
-		return false;
+		*local_origin = replorigin_session_origin;
+		*local_ts = replorigin_session_origin_timestamp;
+		return true;
 	}
 
-	return true;
+	/* Try to get real commit timestamp */
+	if (TransactionIdGetCommitTsData(*xmin, local_ts, local_origin))
+		return true;
+
+	return false;
 }
 
 /*
@@ -871,7 +880,12 @@ spock_conflict_log_table(SpockConflictType conflict_type,
 		nulls[9] = true;
 
 	/* local_timestamp */
-	values[10] = TimestampTzGetDatum(local_tuple_commit_ts);
+   /* local_timestamp. If 0, it is a missing local tuple, so use NULL */
+	if (local_tuple_commit_ts == 0)
+       nulls[10] = true;
+	else
+       values[10] = TimestampTzGetDatum(local_tuple_commit_ts);
+
 	/* remote_origin */
 	values[11] = Int32GetDatum((int) replorigin_session_origin);
 

--- a/tests/regress/expected/tuple_origin.out
+++ b/tests/regress/expected/tuple_origin.out
@@ -1,0 +1,79 @@
+--Tuple Origin
+SELECT * FROM spock_regress_variables()
+\gset
+\c :provider_dsn
+ALTER SYSTEM SET spock.save_resolutions = on;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+SELECT spock.replicate_ddl($$
+    CREATE TABLE users (id int PRIMARY KEY, mgr_id int);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'users');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+BEGIN;
+INSERT INTO USERS SELECT 1, 5;
+UPDATE USERS SET id = id + 1 WHERE mgr_id < 10; 
+UPDATE USERS SET id = id + 1 WHERE mgr_id < 10;
+END;
+\c :subscriber_dsn
+SELECT * FROM users ORDER BY id;
+ id | mgr_id 
+----+--------
+  3 |      5
+(1 row)
+
+-- Expect 2 rows in spock.resolutions
+SELECT COUNT(*) FROM spock.resolutions
+    WHERE relname='public.users'
+    AND local_timestamp = remote_timestamp;
+ count 
+-------
+     2
+(1 row)
+
+-- DELETE the row from subscriber first, in order to create a conflict
+DELETE FROM users where id = 3;
+\c :provider_dsn
+-- This will create a conflict on the subscriber
+DELETE FROM users where id = 3;
+\c :subscriber_dsn
+-- Expect 1 row in spock.resolutions with NULL local_timestamp
+SELECT COUNT(*) FROM spock.resolutions
+    WHERE relname='public.users'
+    AND local_timestamp IS NULL;
+ count 
+-------
+     1
+(1 row)
+
+-- cleanup
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+    DROP TABLE users CASCADE;
+$$);
+NOTICE:  drop cascades to table users membership in replication set default
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+ALTER SYSTEM SET spock.save_resolutions = off;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+

--- a/tests/regress/sql/tuple_origin.sql
+++ b/tests/regress/sql/tuple_origin.sql
@@ -1,0 +1,48 @@
+--Tuple Origin
+SELECT * FROM spock_regress_variables()
+\gset
+
+\c :provider_dsn
+ALTER SYSTEM SET spock.save_resolutions = on;
+SELECT pg_reload_conf();
+
+SELECT spock.replicate_ddl($$
+    CREATE TABLE users (id int PRIMARY KEY, mgr_id int);
+$$);
+SELECT * FROM spock.repset_add_table('default', 'users');
+
+BEGIN;
+INSERT INTO USERS SELECT 1, 5;
+UPDATE USERS SET id = id + 1 WHERE mgr_id < 10; 
+UPDATE USERS SET id = id + 1 WHERE mgr_id < 10;
+END;
+
+\c :subscriber_dsn
+SELECT * FROM users ORDER BY id;
+
+-- Expect 2 rows in spock.resolutions
+SELECT COUNT(*) FROM spock.resolutions
+    WHERE relname='public.users'
+    AND local_timestamp = remote_timestamp;
+
+-- DELETE the row from subscriber first, in order to create a conflict
+DELETE FROM users where id = 3;
+
+\c :provider_dsn
+-- This will create a conflict on the subscriber
+DELETE FROM users where id = 3;
+
+\c :subscriber_dsn
+-- Expect 1 row in spock.resolutions with NULL local_timestamp
+SELECT COUNT(*) FROM spock.resolutions
+    WHERE relname='public.users'
+    AND local_timestamp IS NULL;
+
+
+-- cleanup
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+    DROP TABLE users CASCADE;
+$$);
+ALTER SYSTEM SET spock.save_resolutions = off;
+SELECT pg_reload_conf();


### PR DESCRIPTION
…ues; Handl… (#127)

* get_tuple_origin: initialize local timestamp and origin values; Handle tuples from current in-progress xact.

* Prevent setting local_timestamp to epoch in DELETE-DELETE case; set to NULL instead when invalid.

  Also added a test case.

  (cherry picked from commit 1cc5dc3b)