### PR TITLE
Fix compiler warnings from PostgreSQL 18: add 'static' to internal sy…

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -207,7 +207,7 @@ typedef struct SPKFlushPosition
 	XLogRecPtr	remote_end;
 } SPKFlushPosition;
 
-dlist_head	lsn_mapping = DLIST_STATIC_INIT(lsn_mapping);
+static dlist_head	lsn_mapping = DLIST_STATIC_INIT(lsn_mapping);
 
 typedef struct ApplyExecState
 {
@@ -217,14 +217,14 @@ typedef struct ApplyExecState
 	TupleTableSlot *slot;
 } ApplyExecState;
 
-struct ActionErrCallbackArg
+typedef struct ActionErrCallbackArg
 {
 	const char *action_name;
 	SpockRelation *rel;
 	bool		is_ddl_or_drop;
-};
+} ActionErrCallbackArg;
 
-struct ActionErrCallbackArg errcallback_arg;
+static ActionErrCallbackArg errcallback_arg;
 TransactionId remote_xid;
 
 /*
@@ -243,7 +243,7 @@ typedef struct RemoteSyncPosition
  * Queue of structure RemoteSyncPosition to Save the LSN in
  * case of Synchronous replica is attached
  */
-dlist_head sync_replica_lsn = DLIST_STATIC_INIT(sync_replica_lsn);
+static dlist_head sync_replica_lsn = DLIST_STATIC_INIT(sync_replica_lsn);
 
 /*
  * We enable skipping all data modification changes (INSERT, UPDATE, etc.) for
@@ -261,7 +261,7 @@ static XLogRecPtr skip_xact_finish_lsn = InvalidXLogRecPtr;
  * Whereas MessageContext is used for the duration of a transaction,
  * ApplyOperationContext can be used for individual operations
  */
-MemoryContext ApplyOperationContext = NULL;
+static MemoryContext ApplyOperationContext = NULL;
 
 /* Functions for skipping changes */
 static void maybe_start_skipping_changes(XLogRecPtr finish_lsn);

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -107,29 +107,6 @@ typedef struct ApplyMIState
 	int			nbuffered_tuples;
 } ApplyMIState;
 
-typedef struct ApplyErrorCallbackArg
-{
-	LogicalRepMsgType command;	/* 0 if invalid */
-	LogicalRepRelMapEntry *rel;
-
-	/* Remote node information */
-	int			remote_attnum;	/* -1 if invalid */
-	TransactionId remote_xid;
-	XLogRecPtr	finish_lsn;
-	char	   *origin_name;
-} ApplyErrorCallbackArg;
-
-/* errcontext tracker */
-ApplyErrorCallbackArg apply_error_callback_arg =
-{
-	.command = 0,
-	.rel = NULL,
-	.remote_attnum = -1,
-	.remote_xid = InvalidTransactionId,
-	.finish_lsn = InvalidXLogRecPtr,
-	.origin_name = NULL,
-};
-
 #define TTS_TUP(slot) (((HeapTupleTableSlot *)slot)->tuple)
 
 static ApplyMIState *spkmistate = NULL;

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -89,18 +89,17 @@ typedef struct FailoverSlotFilter
 /* Used for physical-before-logical ordering */
 static char *standby_slot_names_raw;
 static char *standby_slot_names_string = NULL;
-List *pg_standby_slot_names = NIL;
-int standby_slots_min_confirmed;
-XLogRecPtr standby_slot_names_oldest_flush_lsn = InvalidXLogRecPtr;
+static List *pg_standby_slot_names = NIL;
+static int standby_slots_min_confirmed;
+static XLogRecPtr standby_slot_names_oldest_flush_lsn = InvalidXLogRecPtr;
 
 /* Slots to sync */
-char *spock_failover_slots_dsn;
-char *spock_failover_slot_names;
+static char *spock_failover_slots_dsn;
+static char *spock_failover_slot_names;
 static char *spock_failover_slot_names_str = NULL;
 static List *spock_failover_slot_names_list = NIL;
 static bool spock_failover_slots_drop = true;
 
-char *spock_failover_slots_version_str;
 void spock_init_failover_slot(void);
 
 PGDLLEXPORT void spock_failover_slots_main(Datum main_arg);

--- a/src/spock_jsonb_utils.c
+++ b/src/spock_jsonb_utils.c
@@ -84,7 +84,7 @@ datum_to_json_cstring(Datum val, Oid type, bool isnull)
 		elog(ERROR, "datum_to_json_cstring: SPI query '%s' returned %d",
 			 query, rc);
 	if (SPI_processed != 1)
-		elog(ERROR, "datum_to_json_cstring: query returned %lu tupes - "
+		elog(ERROR, "datum_to_json_cstring: query returned " UINT64_FORMAT " tupes - "
 			 "expected 1", SPI_processed);
 
 	/* Get the binary text datum */

--- a/src/spock_output_config.c
+++ b/src/spock_output_config.c
@@ -50,7 +50,7 @@ static int32 parse_param_int32(DefElem *elem);
 static void
 process_parameters_v1(List *options, SpockOutputData *data);
 
-enum {
+typedef enum OutputPluginParamKey {
 	PARAM_UNRECOGNISED,
 	PARAM_MAX_PROTOCOL_VERSION,
 	PARAM_MIN_PROTOCOL_VERSION,


### PR DESCRIPTION
…mbols.

Recent PostgreSQL 18 changes introduced stricter compiler flags, notably '-Wmissing-variable-declarations', which flagged several global symbols without declarations.