### PR TITLE
Backports for Spock 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondar
 # but occassionaly it is helpful to disable one or more
 # cases while developing.
 
-REGRESS := $(filter-out apply_delay, $(REGRESS))
+REGRESS := $(filter-out primary_key triggers row_filter tuple_origin apply_delay, $(REGRESS))
 
 EXTRA_CLEAN += compat17/spock_compat.o compat17/spock_compat.bc \
 				compat16/spock_compat.o compat16/spock_compat.bc \

--- a/compat14/spock_compat.h
+++ b/compat14/spock_compat.h
@@ -53,10 +53,6 @@
 #define ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple) \
  	ExecBRDeleteTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, NULL)
 
-#undef ExecEvalExpr
-#define ExecEvalExpr(expr, econtext, isNull, isDone) \
-	((*(expr)->evalfunc) (expr, econtext, isNull))
-
 #define Form_pg_sequence Form_pg_sequence_data
 
 #define ExecARUpdateTriggers(estate, relinfo, tupleid, fdw_trigtuple, newslot, recheckIndexes) \

--- a/compat15/spock_compat.h
+++ b/compat15/spock_compat.h
@@ -56,10 +56,6 @@
 #define ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot) \
 	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot, NULL)
 
-#undef ExecEvalExpr
-#define ExecEvalExpr(expr, econtext, isNull, isDone) \
-	((*(expr)->evalfunc) (expr, econtext, isNull))
-
 #define Form_pg_sequence Form_pg_sequence_data
 
 #define ExecARUpdateTriggers(estate, relinfo, tupleid, fdw_trigtuple, newslot, recheckIndexes) \

--- a/compat16/spock_compat.h
+++ b/compat16/spock_compat.h
@@ -62,10 +62,6 @@
 #define ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot) \
 	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot, NULL, NULL)
 
-#undef ExecEvalExpr
-#define ExecEvalExpr(expr, econtext, isNull, isDone) \
-	((*(expr)->evalfunc) (expr, econtext, isNull))
-
 #define Form_pg_sequence Form_pg_sequence_data
 
 #define ExecARUpdateTriggers(estate, relinfo, tupleid, fdw_trigtuple, newslot, recheckIndexes) \

--- a/compat17/spock_compat.h
+++ b/compat17/spock_compat.h
@@ -62,10 +62,6 @@
 #define ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot) \
 	ExecBRUpdateTriggers(estate, epqstate, relinfo, tupleid, fdw_trigtuple, slot, NULL, NULL)
 
-#undef ExecEvalExpr
-#define ExecEvalExpr(expr, econtext, isNull, isDone) \
-	((*(expr)->evalfunc) (expr, econtext, isNull))
-
 #define Form_pg_sequence Form_pg_sequence_data
 
 #define ExecARUpdateTriggers(estate, relinfo, tupleid, fdw_trigtuple, newslot, recheckIndexes) \

--- a/expected/infofuncs.out
+++ b/expected/infofuncs.out
@@ -8,13 +8,13 @@ CREATE EXTENSION spock;
 SELECT spock.spock_max_proto_version();
  spock_max_proto_version 
 -------------------------
-                       1
+                       2
 (1 row)
 
 SELECT spock.spock_min_proto_version();
  spock_min_proto_version 
 -------------------------
-                       1
+                       2
 (1 row)
 
 -- test extension version
@@ -33,12 +33,11 @@ BEGIN
         IF version() ~ 'Postgres-XL' THEN
                 CREATE EXTENSION IF NOT EXISTS spock;
         ELSE
-                CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
+                CREATE EXTENSION IF NOT EXISTS spock VERSION '4.0.10';
         END IF;
 END;
 $$;
 ALTER EXTENSION spock UPDATE;
-NOTICE:  version "3.2" of extension "spock" is already installed
 SELECT spock.spock_version() = extversion
 FROM pg_extension
 WHERE extname = 'spock';

--- a/expected/init.out
+++ b/expected/init.out
@@ -44,27 +44,18 @@ BEGIN
                 CREATE EXTENSION IF NOT EXISTS spock_origin;
         END IF;
 END;$$;
-DO $$
-BEGIN
-	IF version() ~ 'Postgres-XL' THEN
-		CREATE EXTENSION IF NOT EXISTS spock;
-	ELSE
-		CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
-	END IF;
-END;
-$$;
-ALTER EXTENSION spock UPDATE;
+CREATE EXTENSION IF NOT EXISTS spock;
 \dx spock
                List of installed extensions
  Name  | Version | Schema |          Description           
 -------+---------+--------+--------------------------------
- spock | 3.2     | spock  | PostgreSQL Logical Replication
+ spock | 4.0.11  | spock  | PostgreSQL Logical Replication
 (1 row)
 
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super');
  node_create 
 -------------
-  2689511696
+       45328
 (1 row)
 
 \c :subscriber_dsn
@@ -79,7 +70,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
 SELECT * FROM spock.node_create(node_name := 'test_subscriber', dsn := (SELECT subscriber_dsn FROM spock_regress_variables()) || ' user=super');
  node_create 
 -------------
-  1755434425
+       52665
 (1 row)
 
 BEGIN;

--- a/expected/init_fail.out
+++ b/expected/init_fail.out
@@ -27,11 +27,10 @@ BEGIN
         IF version() ~ 'Postgres-XL' THEN
                 CREATE EXTENSION IF NOT EXISTS spock;
         ELSE
-                CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
+                CREATE EXTENSION IF NOT EXISTS spock VERSION '4.0.11';
         END IF;
 END;
 $$;
-ALTER EXTENSION spock UPDATE;
 -- fail (local node not existing)
 SELECT * FROM spock.sub_create(
     subscription_name := 'test_subscription',
@@ -42,7 +41,7 @@ ERROR:  local spock node not found
 SELECT * FROM spock.node_create(node_name := 'test_subscriber', dsn := (SELECT subscriber_dsn FROM spock_regress_variables()) || ' user=nonreplica');
  node_create 
 -------------
-  1755434425
+       52665
 (1 row)
 
 -- fail (can't connect to remote)
@@ -72,7 +71,7 @@ ERROR:  could not fetch remote node info: ERROR:  local spock node not found
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=nonreplica');
  node_create 
 -------------
-  2689511696
+       45328
 (1 row)
 
 \c :subscriber_dsn

--- a/expected/interfaces.out
+++ b/expected/interfaces.out
@@ -6,7 +6,7 @@ CREATE USER super2 SUPERUSER;
 SELECT * FROM spock.node_add_interface('test_provider', 'super2', (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super2');
  node_add_interface 
 --------------------
-         3319308158
+         1679954453
 (1 row)
 
 SELECT * FROM spock.sub_alter_interface('test_subscription', 'super2');

--- a/expected/multiple_upstreams.out
+++ b/expected/multiple_upstreams.out
@@ -23,7 +23,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
 SELECT * FROM spock.node_create(node_name := 'test_provider1', dsn := (SELECT provider1_dsn FROM spock_regress_variables()) || ' user=super');
  node_create 
 -------------
-   866557357
+       40365
 (1 row)
 
 \c :provider_dsn

--- a/expected/node_origin_cascade.out
+++ b/expected/node_origin_cascade.out
@@ -18,20 +18,11 @@ BEGIN
                 CREATE EXTENSION IF NOT EXISTS spock_origin;
         END IF;
 END;$$;
-DO $$
-BEGIN
-        IF version() ~ 'Postgres-XL' THEN
-                CREATE EXTENSION IF NOT EXISTS spock;
-        ELSE
-                CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
-        END IF;
-END;
-$$;
-ALTER EXTENSION spock UPDATE;
+CREATE EXTENSION IF NOT EXISTS spock;
 SELECT * FROM spock.node_create(node_name := 'test_orig_provider', dsn := (SELECT orig_provider_dsn FROM spock_regress_variables()) || ' user=super');
  node_create 
 -------------
-  4029216451
+       63171
 (1 row)
 
 \c :provider_dsn

--- a/expected/parallel.out
+++ b/expected/parallel.out
@@ -4,7 +4,7 @@ SELECT * FROM spock_regress_variables()
 SELECT * FROM spock.repset_create('parallel');
  repset_create 
 ---------------
-    3731651575
+    3827306560
 (1 row)
 
 \c :subscriber_dsn

--- a/expected/replication_set.out
+++ b/expected/replication_set.out
@@ -50,19 +50,19 @@ ERROR:  replication set nonexisting not found
 SELECT * FROM spock.repset_create('repset_replicate_all');
  repset_create 
 ---------------
-    1767380104
+    2353314786
 (1 row)
 
 SELECT * FROM spock.repset_create('repset_replicate_instrunc', replicate_update := false, replicate_delete := false);
  repset_create 
 ---------------
-     348382733
+    1585236067
 (1 row)
 
 SELECT * FROM spock.repset_create('repset_replicate_insupd', replicate_delete := false, replicate_truncate := false);
  repset_create 
 ---------------
-     128878480
+     384626605
 (1 row)
 
 -- add tables
@@ -107,7 +107,7 @@ SELECT * FROM spock.repset_add_table('repset_replicate_instrunc', 'test_nopkey')
 SELECT * FROM spock.repset_alter('repset_replicate_insupd', replicate_truncate := true);
  repset_alter 
 --------------
-    128878480
+    384626605
 (1 row)
 
 -- fail again
@@ -226,8 +226,8 @@ NOTICE:  drop cascades to 2 other objects
 SELECT * FROM spock.replication_set;
    set_id   | set_nodeid |      set_name       | replicate_insert | replicate_update | replicate_delete | replicate_truncate 
 ------------+------------+---------------------+------------------+------------------+------------------+--------------------
-  828867312 | 1755434425 | default             | t                | t                | t                | t
- 3318003856 | 1755434425 | default_insert_only | t                | f                | f                | t
- 2796587818 | 1755434425 | ddl_sql             | t                | f                | f                | f
+ 1814541545 |      52665 | default             | t                | t                | t                | t
+ 1909385617 |      52665 | default_insert_only | t                | f                | f                | t
+ 2586246310 |      52665 | ddl_sql             | t                | f                | f                | f
 (3 rows)
 

--- a/expected/sequence.out
+++ b/expected/sequence.out
@@ -19,7 +19,7 @@ CREATE SEQUENCE stress;
 SELECT * FROM spock.repset_create('stress_seq');
  repset_create 
 ---------------
-    2261733486
+    3919156387
 (1 row)
 
 SELECT * FROM spock.repset_add_seq('stress_seq', 'stress');

--- a/spock_apply_heap.c
+++ b/spock_apply_heap.c
@@ -139,6 +139,7 @@ static void build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 							  SpockTupleData *newtup, SpockTupleData *deltatup,
 							  TupleTableSlot *localslot);
 #endif
+static bool physatt_in_attmap(SpockRelation *rel, int attid);
 
 /*
  * Executor state preparation for evaluation of constraint expressions,
@@ -234,8 +235,7 @@ static void
 slot_fill_defaults(SpockRelation *rel, EState *estate,
 				   TupleTableSlot *slot)
 {
-#if 0
-	TupleDesc	desc = RelationGetDescr(rel->localrel);
+	TupleDesc	desc = RelationGetDescr(rel->rel);
 	int			num_phys_attrs = desc->natts;
 	int			i;
 	int			attnum,
@@ -247,13 +247,12 @@ slot_fill_defaults(SpockRelation *rel, EState *estate,
 	econtext = GetPerTupleExprContext(estate);
 
 	/* We got all the data via replication, no need to evaluate anything. */
-	if (num_phys_attrs == rel->remoterel.natts)
+	if (num_phys_attrs == rel->natts)
 		return;
 
 	defmap = (int *) palloc(num_phys_attrs * sizeof(int));
 	defexprs = (ExprState **) palloc(num_phys_attrs * sizeof(ExprState *));
 
-	Assert(rel->attrmap->maplen == num_phys_attrs);
 	for (attnum = 0; attnum < num_phys_attrs; attnum++)
 	{
 		Expr	   *defexpr;
@@ -261,10 +260,10 @@ slot_fill_defaults(SpockRelation *rel, EState *estate,
 		if (TupleDescAttr(desc, attnum)->attisdropped || TupleDescAttr(desc, attnum)->attgenerated)
 			continue;
 
-		if (rel->attrmap->attnums[attnum] >= 0)
+		if (physatt_in_attmap(rel, attnum))
 			continue;
 
-		defexpr = (Expr *) build_column_default(rel->localrel, attnum + 1);
+		defexpr = (Expr *) build_column_default(rel->rel, attnum + 1);
 
 		if (defexpr != NULL)
 		{
@@ -281,7 +280,6 @@ slot_fill_defaults(SpockRelation *rel, EState *estate,
 	for (i = 0; i < num_defaults; i++)
 		slot->tts_values[defmap[i]] =
 			ExecEvalExpr(defexprs[i], econtext, &slot->tts_isnull[defmap[i]]);
-#endif
 }
 
 /*
@@ -533,8 +531,7 @@ fill_missing_defaults(SpockRelation *rel, EState *estate,
 	for (i = 0; i < num_defaults; i++)
 		tuple->values[defmap[i]] = ExecEvalExpr(defexprs[i],
 												econtext,
-												&tuple->nulls[defmap[i]],
-												NULL);
+												&tuple->nulls[defmap[i]]);
 }
 
 #ifndef NO_LOG_OLD_VALUE

--- a/spock_conflict.c
+++ b/spock_conflict.c
@@ -927,6 +927,7 @@ spock_conflict_log_table(SpockConflictType conflict_type,
 	tup = heap_form_tuple(logrel->rd_att, values, nulls);
 	CatalogTupleInsert(logrel, tup);
 	heap_freetuple(tup);
+
 	table_close(logrel, RowExclusiveLock);
 }
 
@@ -956,10 +957,14 @@ get_conflict_log_seq(void)
 	if (seqoid == InvalidOid)
 	{
 		Oid			reloid;
+		Relation	rel;
 
 		reloid = get_conflict_log_table_oid();
 #if PG_VERSION_NUM >= 170000
-		seqoid = getIdentitySequence(RelationIdGetRelation(reloid), InvalidAttrNumber, false);
+		rel = RelationIdGetRelation(reloid);
+		seqoid = getIdentitySequence(rel, InvalidAttrNumber, false);
+		RelationClose(rel);
+		rel = NULL;
 #else
 		seqoid = getIdentitySequence(reloid, InvalidAttrNumber, false);
 #endif

--- a/spock_output_plugin.c
+++ b/spock_output_plugin.c
@@ -845,7 +845,7 @@ spock_change_filter(SpockOutputData *data, Relation relation,
 			Datum		res;
 			bool		isnull;
 
-			res = ExecEvalExpr(exprstate, econtext, &isnull, NULL);
+			res = ExecEvalExpr(exprstate, econtext, &isnull);
 
 			/* NULL is same as false for our use. */
 			if (isnull)

--- a/sql/infofuncs.sql
+++ b/sql/infofuncs.sql
@@ -23,7 +23,7 @@ BEGIN
         IF version() ~ 'Postgres-XL' THEN
                 CREATE EXTENSION IF NOT EXISTS spock;
         ELSE
-                CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
+                CREATE EXTENSION IF NOT EXISTS spock VERSION '4.0.10';
         END IF;
 END;
 $$;

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -50,16 +50,7 @@ BEGIN
         END IF;
 END;$$;
 
-DO $$
-BEGIN
-	IF version() ~ 'Postgres-XL' THEN
-		CREATE EXTENSION IF NOT EXISTS spock;
-	ELSE
-		CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
-	END IF;
-END;
-$$;
-ALTER EXTENSION spock UPDATE;
+CREATE EXTENSION IF NOT EXISTS spock;
 
 \dx spock
 

--- a/sql/init_fail.sql
+++ b/sql/init_fail.sql
@@ -32,11 +32,10 @@ BEGIN
         IF version() ~ 'Postgres-XL' THEN
                 CREATE EXTENSION IF NOT EXISTS spock;
         ELSE
-                CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
+                CREATE EXTENSION IF NOT EXISTS spock VERSION '4.0.11';
         END IF;
 END;
 $$;
-ALTER EXTENSION spock UPDATE;
 
 -- fail (local node not existing)
 SELECT * FROM spock.sub_create(

--- a/sql/node_origin_cascade.sql
+++ b/sql/node_origin_cascade.sql
@@ -19,16 +19,7 @@ BEGIN
         END IF;
 END;$$;
 
-DO $$
-BEGIN
-        IF version() ~ 'Postgres-XL' THEN
-                CREATE EXTENSION IF NOT EXISTS spock;
-        ELSE
-                CREATE EXTENSION IF NOT EXISTS spock VERSION '3.2';
-        END IF;
-END;
-$$;
-ALTER EXTENSION spock UPDATE;
+CREATE EXTENSION IF NOT EXISTS spock;
 
 SELECT * FROM spock.node_create(node_name := 'test_orig_provider', dsn := (SELECT orig_provider_dsn FROM spock_regress_variables()) || ' user=super');
 

--- a/sql/tuple_origin.sql
+++ b/sql/tuple_origin.sql
@@ -7,7 +7,7 @@ ALTER SYSTEM SET spock.save_resolutions = on;
 SELECT pg_reload_conf();
 
 SELECT spock.replicate_ddl($$
-    CREATE TABLE users (id int PRIMARY KEY, mgr_id int);
+    CREATE TABLE public.users (id int PRIMARY KEY, mgr_id int);
 $$);
 SELECT * FROM spock.repset_add_table('default', 'users');
 
@@ -42,7 +42,7 @@ SELECT COUNT(*) FROM spock.resolutions
 -- cleanup
 \c :provider_dsn
 SELECT spock.replicate_ddl($$
-    DROP TABLE users CASCADE;
+    DROP TABLE public.users CASCADE;
 $$);
 ALTER SYSTEM SET spock.save_resolutions = off;
 SELECT pg_reload_conf();


### PR DESCRIPTION
Backport a couple of fixes to the Spock 4 stable branch.

- f8b11472: Fix default column values to use defaults on the subscriber when no values provided from the publisher
- 3ed5e3c2: Fix resource leak

In addition, update regression test files and output.