### PR TITLE
SPOC-99: Remove fixed replay queue size limit and eliminate worker restarts on overflow.

### DIFF
--- a/include/spock.h
+++ b/include/spock.h
@@ -53,7 +53,7 @@ extern bool	spock_include_ddl_repset;
 extern bool	allow_ddl_from_functions;
 extern int	restart_delay_default;
 extern int	restart_delay_on_exception;
-extern int	spock_replay_queue_size;
+extern int	spock_replay_queue_size;  /* Deprecated - no longer used */
 extern bool check_all_uc_indexes;
 extern char *shorten_hash(const char *str, int maxlen);
 

--- a/src/spock.c
+++ b/src/spock.c
@@ -130,7 +130,7 @@ bool	spock_include_ddl_repset = false;
 bool	allow_ddl_from_functions = false;
 int		restart_delay_default;
 int		restart_delay_on_exception;
-int		spock_replay_queue_size;
+int		spock_replay_queue_size;  /* Deprecated - no longer used */
 bool	check_all_uc_indexes = false;
 
 
@@ -997,8 +997,9 @@ _PG_init(void)
 							NULL);
 
 	DefineCustomIntVariable("spock.exception_replay_queue_size",
-							"apply-worker replay queue size for exception",
-							NULL,
+							"DEPRECATED: apply-worker replay queue size (no longer used)",
+							"This setting is deprecated and has no effect. "
+							"The replay queue now dynamically allocates memory as needed.",
 							&spock_replay_queue_size,
 							4194304,
 							0,


### PR DESCRIPTION
Previously, apply workers used a fixed-size replay queue (spock.exception_replay_queue_size, default 4MB) that would cause worker restarts when exceeded by large transactions. This created unpredictable behavior and replication delays.

Old behavior:
- Apply worker queues replication messages up to spock.exception_replay_queue_size (4MB)
- Large transactions exceeding this limit set apply_replay_overflow flag
- Any subsequent exception triggered worker restart via PG_RE_THROW()
- Manager process would restart the failed worker
- Large transactions could cause restart loops, leading to replication lag

New behavior:
- Replay queue now uses dynamic memory allocation with no fixed size limit
- Queue grows as needed to accommodate transactions of any size
- Memory allocation failures are handled as regular exceptions
- Exception handling follows only spock.exception_behavior GUC:
  * 'discard': Skip failed transaction and continue
  * 'transdiscard': Rollback transaction and continue
  * 'sub_disable': Disable subscription and exit cleanly
- No worker restarts due to queue overflow

Changes:
- Deprecated spock.exception_replay_queue_size GUC (kept for compatibility)
- Removed fixed size check in apply worker queue logic
- Removed overflow-triggered restart code from exception handler
- Added clear comments explaining new behavior follows exception_behavior

Benefits:
- Eliminates unpredictable worker restarts on large transactions
- Improves replication reliability and performance
- Makes exception handling behavior more predictable
- Reduces operational complexity

Trade-offs:
- Higher memory usage for very large transactions
- Memory allocation failures possible (but handled gracefully)

The spock.exception_replay_queue_size GUC remains available but is deprecated and has no effect. It will be removed in a future major version.