### PR TITLE
Spock resource manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ spock_create_subscriber
 /postgres
 spock.control
 tags
+.vscode

--- a/include/spock_apply.h
+++ b/include/spock_apply.h
@@ -12,8 +12,6 @@
 #ifndef SPOCK_APPLY_H
 #define SPOCK_APPLY_H
 
-#include "storage/condition_variable.h"
-
 #include "spock_relcache.h"
 #include "spock_proto_native.h"
 
@@ -40,20 +38,5 @@ extern int my_exception_log_index;
 
 extern void wait_for_previous_transaction(void);
 extern void awake_transaction_waiters(void);
-
-extern void create_progress_entry(Oid target_node_id,
-								Oid remote_node_id,
-								TimestampTz remote_commit_ts);
-extern TimestampTz get_progress_entry_ts(Oid target_node_id,
-								Oid remote_node_id,
-								XLogRecPtr *lsn,
-								XLogRecPtr *remote_insert_lsn,
-								bool *missing);
-extern void get_apply_group_entry(Oid dbid,
-								RepOriginId replorigin,
-								int *indexPtr,
-								bool *foundPtr);
-
-extern void spock_apply_group_shmem_init(void);
 
 #endif /* SPOCK_APPLY_H */

--- a/include/spock_common.h
+++ b/include/spock_common.h
@@ -79,5 +79,7 @@ extern bool SpockRelationFindReplTupleByIndex(EState *estate,
 
 extern void read_buf(int fd, void *buf, size_t nbytes, const char *filename);
 extern void write_buf(int fd, const void *buf, size_t nbytes, const char *filename);
+extern TimestampTz str_to_timestamptz(const char *s);
+extern XLogRecPtr str_to_lsn(const char *s);
 
 #endif /* SPOCK_COMMON_H */

--- a/include/spock_common.h
+++ b/include/spock_common.h
@@ -77,4 +77,7 @@ extern bool SpockRelationFindReplTupleByIndex(EState *estate,
 								 TupleTableSlot *searchslot,
 								 TupleTableSlot *outslot);
 
+extern void read_buf(int fd, void *buf, size_t nbytes, const char *filename);
+extern void write_buf(int fd, const void *buf, size_t nbytes, const char *filename);
+
 #endif /* SPOCK_COMMON_H */

--- a/include/spock_group.h
+++ b/include/spock_group.h
@@ -23,6 +23,8 @@
 #include "spock_rmgr.h"
 
 
+extern HTAB *SpockGroupHash;
+
 /* Hash Key */
 typedef struct SpockGroupKey
 {

--- a/include/spock_group.h
+++ b/include/spock_group.h
@@ -1,0 +1,77 @@
+/*-------------------------------------------------------------------------
+ *
+ * spock_group.h
+ * 		spock group function declarations
+ *
+ * Copyright (c) 2022-2025, pgEdge, Inc.
+ * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef SPOCK_GROUP_H
+#define SPOCK_GROUP_H
+
+#include "postgres.h"
+
+#include "storage/condition_variable.h"
+#include "storage/lock.h"
+#include "storage/lwlock.h"
+#include "storage/spin.h"
+#include "utils/hsearch.h"
+
+#include "spock_rmgr.h"
+
+
+/* Hash Key */
+typedef struct SpockGroupKey
+{
+	Oid			dbid;
+	Oid			node_id;
+	Oid			remote_node_id;
+} SpockGroupKey;
+
+typedef struct SpockApplyProgress
+{
+	SpockGroupKey key;			/* common elements */
+	TimestampTz remote_commit_ts;	/* committed remote txn ts */
+
+	/*
+	 * Bit of duplication of remote_commit_ts. Serves the same purpose, except
+	 * keep the last updated value
+	 */
+	TimestampTz prev_remote_ts;
+	XLogRecPtr	remote_commit_lsn;	/* LSN of remote commit on origin */
+	XLogRecPtr	remote_insert_lsn;	/* origin insert/end LSN reported */
+	TimestampTz last_updated_ts;	/* when we set this */
+	bool		updated_by_decode;	/* set by decode or apply */
+} SpockApplyProgress;
+
+/* Hash entry: one per group (stable pointer; not moved by dynahash) */
+typedef struct SpockGroupEntry
+{
+	SpockGroupKey key;			/* hash key */
+	SpockApplyProgress progress;
+	pg_atomic_uint32 nattached;
+	ConditionVariable prev_processed_cv;
+} SpockGroupEntry;
+
+/* shmem setup */
+void		spock_group_shmem_init(void);
+
+SpockGroupEntry *spock_group_attach(Oid dbid, Oid node_id, Oid remote_node_id,
+									bool *created);
+void		spock_group_detach(void);
+bool		spock_group_progress_update(const SpockApplyProgress *sap);
+void		spock_group_progress_update_ptr(SpockGroupEntry *e, const SpockApplyProgress *sap);
+
+bool		spock_group_get_progress(Oid dbid, Oid node_id, Oid remote_node_id,
+									 SpockApplyProgress *out /* nullable */ );
+extern SpockApplyProgress *apply_worker_get_progress(void);
+SpockGroupEntry *spock_group_lookup(Oid dbid, Oid node_id, Oid remote_node_id);
+
+/* Iterate all groups */
+typedef void (*SpockGroupIterCB) (const SpockGroupEntry *e, void *arg);
+void		spock_group_foreach(SpockGroupIterCB cb, void *arg);
+
+#endif							/* SPOCK_GROUP_H */

--- a/include/spock_group.h
+++ b/include/spock_group.h
@@ -97,17 +97,14 @@ SpockGroupEntry *spock_group_attach(Oid dbid, Oid node_id, Oid remote_node_id,
 void		spock_group_detach(void);
 bool		spock_group_progress_update(const SpockApplyProgress *sap);
 void		spock_group_progress_update_ptr(SpockGroupEntry *e, const SpockApplyProgress *sap);
-
-bool		spock_group_get_progress(Oid dbid, Oid node_id, Oid remote_node_id,
-									 SpockApplyProgress *out /* nullable */ );
-extern SpockApplyProgress *apply_worker_get_progress(void);
+SpockApplyProgress *apply_worker_get_progress(void);
 SpockGroupEntry *spock_group_lookup(Oid dbid, Oid node_id, Oid remote_node_id);
 
 /* Iterate all groups */
 typedef void (*SpockGroupIterCB) (const SpockGroupEntry *e, void *arg);
 void		spock_group_foreach(SpockGroupIterCB cb, void *arg);
 
-void		spock_group_resource_dump(void);
-void		spock_group_resource_load(void);
+extern void		spock_group_resource_dump(void);
+extern void		spock_group_resource_load(void);
 
 #endif							/* SPOCK_GROUP_H */

--- a/include/spock_group.h
+++ b/include/spock_group.h
@@ -22,8 +22,37 @@
 
 #include "spock_rmgr.h"
 
-
 extern HTAB *SpockGroupHash;
+
+/* numeric version to store on disk */
+#define SPOCK_RES_VERSION   202508251
+
+#define SPOCK_RES_DIRNAME   "spock"
+#define SPOCK_RES_DUMPFILE  "resource.dat"
+#define SPOCK_RES_TMPNAME   SPOCK_RES_DUMPFILE ".tmp"
+
+typedef struct SpockResFileHeader
+{
+	/* Identify File format */
+	uint32		version;
+
+	/* Unique system identifier; from pg_control */
+	uint64		system_identifier;
+
+	/* reserved */
+	uint16		flags;
+
+	/* how many ProgressInfoEntry */
+	uint32		entry_count;
+} SpockResFileHeader;
+
+/* context for foreach loop */
+typedef struct DumpCtx
+{
+	int			fd;
+	uint32		count;
+} DumpCtx;
+
 
 /* Hash Key */
 typedef struct SpockGroupKey
@@ -60,6 +89,8 @@ typedef struct SpockGroupEntry
 
 /* shmem setup */
 void		spock_group_shmem_init(void);
+extern void spock_group_shmem_request(void);
+extern void spock_group_shmem_startup(int napply_groups, bool found);
 
 SpockGroupEntry *spock_group_attach(Oid dbid, Oid node_id, Oid remote_node_id,
 									bool *created);
@@ -75,5 +106,8 @@ SpockGroupEntry *spock_group_lookup(Oid dbid, Oid node_id, Oid remote_node_id);
 /* Iterate all groups */
 typedef void (*SpockGroupIterCB) (const SpockGroupEntry *e, void *arg);
 void		spock_group_foreach(SpockGroupIterCB cb, void *arg);
+
+void		spock_group_resource_dump(void);
+void		spock_group_resource_load(void);
 
 #endif							/* SPOCK_GROUP_H */

--- a/include/spock_rmgr.h
+++ b/include/spock_rmgr.h
@@ -1,0 +1,51 @@
+/*-------------------------------------------------------------------------
+ *
+ * spock_rmgr.h
+ * 		spock resource manager declarations
+ *
+ * Copyright (c) 2022-2025, pgEdge, Inc.
+ * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef SPOCK_RMGR_H
+#define SPOCK_RMGR_H
+
+#include "access/xlog.h"
+#include "access/xlog_internal.h"
+
+#include "spock_group.h"
+
+/* Spock resouce manager */
+#define SPOCK_RMGR_NAME             	    "spock_custom_rmgr"
+#define SPOCK_RMGR_ID		    	        RM_EXPERIMENTAL_ID
+
+/* Spock RMGR tags. */
+#define SPOCK_RMGR_APPLY_PROGRESS			0x10
+#define SPOCK_RMGR_SUBTRANS_COMMIT_TS       0x20
+
+typedef struct SpockApplyProgress SpockApplyProgress;
+
+#if 0
+typedef struct SubTransactionCommitTsEntry
+{
+	TransactionId xid;
+	TimestampTz time;
+	RepOriginId nodeid;
+} SubTransactionCommitTsEntry;
+#endif
+
+/* RMGR function declarations */
+extern void spock_rmgr_init(void);
+extern void spock_rmgr_desc(StringInfo buf, XLogReaderState *record);
+extern const char *spock_rmgr_identify(uint8 info);
+extern void spock_rmgr_redo(XLogReaderState *record);
+extern void spock_rmgr_startup(void);
+extern void spock_rmgr_cleanup(void);
+
+/* WAL helpers */
+extern XLogRecPtr spock_apply_progress_add_to_wal(const SpockApplyProgress *sap);
+
+
+#endif							/* SPOCK_RMGR_H */

--- a/include/spock_rmgr.h
+++ b/include/spock_rmgr.h
@@ -19,7 +19,7 @@
 
 /* Spock resouce manager */
 #define SPOCK_RMGR_NAME             	    "spock_custom_rmgr"
-#define SPOCK_RMGR_ID		    	        RM_EXPERIMENTAL_ID
+#define SPOCK_RMGR_ID		    	        144
 
 /* Spock RMGR tags. */
 #define SPOCK_RMGR_APPLY_PROGRESS			0x10

--- a/sql/spock--5.0.4--6.0.0-devel.sql
+++ b/sql/spock--5.0.4--6.0.0-devel.sql
@@ -2,3 +2,46 @@
 
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION spock UPDATE TO '6.0.0-devel'" to load this file. \quit
+
+DROP VIEW IF EXISTS spock.lag_tracker;
+DROP TABLE IF EXISTS spock.progress;
+
+CREATE FUNCTION spock.apply_group_progress (
+	OUT dbid oid,
+	OUT node_id oid,
+	OUT remote_node_id oid,
+	OUT remote_commit_ts timestamptz,
+	OUT prev_remote_ts timestamptz,
+	OUT remote_commit_lsn pg_lsn,
+	OUT remote_insert_lsn pg_lsn,
+	OUT last_updated_ts timestamptz,
+	OUT updated_by_decode bool
+) RETURNS SETOF record
+LANGUAGE c AS 'MODULE_PATHNAME', 'get_apply_group_progress';
+
+CREATE VIEW spock.progress AS
+	SELECT node_id, remote_node_id, remote_commit_ts,
+		   remote_commit_lsn AS remote_lsn, remote_insert_lsn,
+		   last_updated_ts, updated_by_decode
+	FROM spock.apply_group_progress();
+
+CREATE VIEW spock.lag_tracker AS
+	SELECT
+		origin.node_name AS origin_name,
+		n.node_name AS receiver_name,
+		MAX(p.remote_commit_ts) AS commit_timestamp,
+		MAX(p.remote_lsn) AS last_received_lsn,
+		MAX(p.remote_insert_lsn) AS remote_insert_lsn,
+		CASE
+			WHEN CAST(MAX(CAST(p.updated_by_decode as int)) as bool) THEN pg_wal_lsn_diff(MAX(p.remote_insert_lsn), MAX(p.remote_lsn))
+			ELSE 0
+		END AS replication_lag_bytes,
+		CASE
+			WHEN CAST(MAX(CAST(p.updated_by_decode as int)) as bool) THEN now() - MAX(p.remote_commit_ts)
+			ELSE now() - MAX(p.last_updated_ts)
+		END AS replication_lag
+	FROM spock.progress p
+	LEFT JOIN spock.subscription sub ON (p.node_id = sub.sub_target and p.remote_node_id = sub.sub_origin)
+	LEFT JOIN spock.node origin ON sub.sub_origin = origin.node_id
+	LEFT JOIN spock.node n ON n.node_id = p.node_id
+	GROUP BY origin.node_name, n.node_name;

--- a/src/spock.c
+++ b/src/spock.c
@@ -55,6 +55,7 @@
 #include "spock_executor.h"
 #include "spock_node.h"
 #include "spock_conflict.h"
+#include "spock_rmgr.h"
 #include "spock_worker.h"
 #include "spock_output_plugin.h"
 #include "spock_exception_handler.h"
@@ -917,7 +918,7 @@ _PG_init(void)
 	if (!process_shared_preload_libraries_in_progress)
 		elog(ERROR, "spock is not in shared_preload_libraries");
 
-	DefineCustomEnumVariable("spock.conflict_resolution",
+    DefineCustomEnumVariable("spock.conflict_resolution",
 							 gettext_noop("Sets method used for conflict resolution for resolvable conflicts."),
 							 NULL,
 							 &spock_conflict_resolver,
@@ -1155,6 +1156,9 @@ _PG_init(void)
 	if (IsBinaryUpgrade)
 		return;
 
+	/* Spock resource manager */
+	spock_rmgr_init();
+
 	/* Init workers. */
 	spock_worker_shmem_init();
 
@@ -1162,7 +1166,7 @@ _PG_init(void)
 	spock_output_plugin_shmem_init();
 
 	/* Init output plugin shmem */
-	spock_apply_group_shmem_init();
+	spock_group_shmem_init();
 
 	/* Init executor module */
 	spock_executor_init();

--- a/src/spock_common.c
+++ b/src/spock_common.c
@@ -14,6 +14,7 @@
 
 #include "postgres.h"
 #include "miscadmin.h"
+#include "fmgr.h"
 
 #include "executor/executor.h"
 #include "storage/ipc.h"
@@ -22,6 +23,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/pg_lsn.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
@@ -522,6 +524,7 @@ spock_build_replindex_scan_key(ScanKey skey, Relation rel, Relation idxrel,
 	return skey_attoff;
 }
 
+
 /*
  * Read exactly nbytes into buf or ERROR out. Never returns partial.
  */
@@ -593,4 +596,19 @@ write_buf(int fd, const void *buf, size_t nbytes, const char *filename)
 		}
 		off += (size_t)n;
 	}
+}
+
+TimestampTz
+str_to_timestamptz(const char *s)
+{
+	return DatumGetTimestampTz(DirectFunctionCall3(timestamptz_in,
+												   CStringGetDatum(s),
+												   ObjectIdGetDatum(InvalidOid),
+												   Int32GetDatum(-1)));
+}
+
+XLogRecPtr
+str_to_lsn(const char *s)
+{
+	return DatumGetLSN(DirectFunctionCall1(pg_lsn_in, CStringGetDatum(s)));
 }

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -581,7 +581,7 @@ Datum spock_create_subscription(PG_FUNCTION_ARGS)
 	create_subscription(&sub);
 
 	/* Create progress entry to track commit ts per local/remote origin */
-	create_progress_entry(localnode->node->id, originif.nodeid, GetCurrentIntegerTimestamp());
+	spock_group_attach(MyDatabaseId, localnode->node->id, originif.nodeid, NULL);
 
 
 	/* Create synchronization status for the subscription. */

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -96,6 +96,7 @@
 #include "spock_rpc.h"
 #include "spock_sync.h"
 #include "spock_worker.h"
+#include "spock_group.h"
 
 #include "spock.h"
 
@@ -186,6 +187,9 @@ PG_FUNCTION_INFO_V1(spock_repair_mode);
 
 /* Function to get a LSN based on commit timestamp */
 PG_FUNCTION_INFO_V1(spock_get_lsn_from_commit_ts);
+
+/* Apply Group */
+PG_FUNCTION_INFO_V1(get_apply_group_progress);
 
 static void gen_slot_name(Name slot_name, char *dbname,
 						  const char *provider_name,
@@ -3277,4 +3281,80 @@ get_apply_worker_status(PG_FUNCTION_ARGS)
     LWLockRelease(SpockCtx->lock);
 
     PG_RETURN_VOID();
+}
+
+/*
+ * get_apply_group_progress
+ *
+ * SQL function to show info about apply group progress.
+ */
+Datum
+get_apply_group_progress(PG_FUNCTION_ARGS)
+{
+	ReturnSetInfo *rsinfo = (ReturnSetInfo *) fcinfo->resultinfo;
+	TupleDesc	tupdesc;
+	Tuplestorestate *tupstore;
+	MemoryContext per_query_ctx;
+	MemoryContext oldcontext;
+	HASH_SEQ_STATUS it;
+	SpockGroupEntry *e;
+
+	if (!SpockCtx || !SpockHash)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("spock must be loaded via shared_preload_libraries")));
+
+	/* check to see if caller supports us returning a tuplestore */
+	if (rsinfo == NULL || !IsA(rsinfo, ReturnSetInfo))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("set-valued function called in context that cannot accept a set")));
+
+	if (!(rsinfo->allowedModes & SFRM_Materialize))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("materialize mode required, but it is not "
+						"allowed in this context")));
+
+
+	/* Switch into long-lived context to construct returned data structures */
+	per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+	oldcontext = MemoryContextSwitchTo(per_query_ctx);
+
+	/* Build the tuple descriptor from caller’s column definition list */
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+
+	tupstore = tuplestore_begin_heap(true, false, work_mem);
+	rsinfo->returnMode = SFRM_Materialize;
+	rsinfo->setResult = tupstore;
+	rsinfo->setDesc = tupdesc;
+
+	MemoryContextSwitchTo(oldcontext);
+
+	LWLockAcquire(SpockCtx->apply_group_master_lock, LW_SHARED);
+
+	/* Iterate the hash and emit rows */
+	hash_seq_init(&it, SpockGroupHash);
+	while ((e = (SpockGroupEntry *) hash_seq_search(&it)) != NULL)
+	{
+		Datum		values[9];
+		bool		nulls[9] = {false};
+
+		values[0] = ObjectIdGetDatum(e->progress.key.dbid);
+		values[1] = ObjectIdGetDatum(e->progress.key.node_id);
+		values[2] = ObjectIdGetDatum(e->progress.key.remote_node_id);
+		values[3] = TimestampTzGetDatum(e->progress.remote_commit_ts);
+		values[4] = TimestampTzGetDatum(e->progress.prev_remote_ts);
+		values[5] = LSNGetDatum(e->progress.remote_commit_lsn);
+		values[6] = LSNGetDatum(e->progress.remote_insert_lsn);
+		values[7] = TimestampTzGetDatum(e->progress.last_updated_ts);
+		values[8] = BoolGetDatum(e->progress.updated_by_decode);
+
+		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
+	}
+
+	LWLockRelease(SpockCtx->apply_group_master_lock);
+
+	return (Datum) 0;
 }

--- a/src/spock_group.c
+++ b/src/spock_group.c
@@ -1,0 +1,282 @@
+/*-------------------------------------------------------------------------
+ *
+ * spock_group.c
+ * 		spock group functions definitions
+ *
+ * Copyright (c) 2022-2025, pgEdge, Inc.
+ * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "miscadmin.h"
+
+#include "utils/guc.h"
+#include "utils/builtins.h"
+#include "datatype/timestamp.h"
+#include "storage/ipc.h"
+#include "storage/shmem.h"
+#include "utils/hsearch.h"
+#include "common/hashfn.h"
+
+#include "spock_worker.h"
+#include "spock_compat.h"
+#include "spock_group.h"
+
+#if PG_VERSION_NUM >= 150000
+static shmem_request_hook_type prev_shmem_request_hook = NULL;
+#endif
+static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
+
+#define SPOCK_GROUP_TRANCHE_NAME   "spock_apply_groups"
+
+static HTAB *SpockGroupHash = NULL;
+
+static void spock_group_shmem_request(void);
+static void spock_group_shmem_startup(void);
+
+/*
+ * Install hooks to request shared resources for apply workers
+ */
+void
+spock_group_shmem_init(void)
+{
+#if PG_VERSION_NUM < 150000
+	spock_group_shmem_request();
+#else
+	prev_shmem_request_hook = shmem_request_hook;
+	shmem_request_hook = spock_group_shmem_request;
+#endif
+	prev_shmem_startup_hook = shmem_startup_hook;
+	shmem_startup_hook = spock_group_shmem_startup;
+}
+
+static void
+spock_group_shmem_request(void)
+{
+	int			napply_groups;
+	Size		size;
+
+#if PG_VERSION_NUM >= 150000
+	if (prev_shmem_request_hook != NULL)
+		prev_shmem_request_hook();
+#endif
+
+	/*
+	 * This is cludge for Windows (Postgres des not define the GUC variable as
+	 * PGDDLIMPORT)
+	 */
+	napply_groups = atoi(GetConfigOptionByName("max_worker_processes", NULL,
+											   false));
+	if (napply_groups <= 0)
+		napply_groups = 9;
+
+	/*
+	 * Request enough shared memory for napply_groups (dbid and origin id)
+	 */
+	size = hash_estimate_size(napply_groups, sizeof(SpockGroupEntry));
+	size += mul_size(16, sizeof(LWLockPadded));
+	RequestAddinShmemSpace(size);
+
+	/*
+	 * Request the LWlocks needed
+	 */
+	RequestNamedLWLockTranche(SPOCK_GROUP_TRANCHE_NAME, napply_groups + 1);
+}
+
+/*
+ * Initialize shared resources for db-origin management
+ */
+static void
+spock_group_shmem_startup(void)
+{
+	HASHCTL		hctl;
+	int			napply_groups;
+
+	if (prev_shmem_startup_hook != NULL)
+		prev_shmem_startup_hook();
+
+	if (SpockGroupHash)
+		return;
+
+	/*
+	 * This is kludge for Windows (Postgres does not define the GUC variable
+	 * as PGDLLIMPORT)
+	 */
+	napply_groups = atoi(GetConfigOptionByName("max_worker_processes", NULL,
+											   false));
+	if (napply_groups <= 0)
+		napply_groups = 9;
+
+	MemSet(&hctl, 0, sizeof(hctl));
+	hctl.keysize = sizeof(SpockGroupKey);
+	hctl.entrysize = sizeof(SpockGroupEntry);
+	hctl.hash = tag_hash;
+	hctl.num_partitions = 16;
+
+	/* Get the shared resources */
+	LWLockAcquire(AddinShmemInitLock, LW_EXCLUSIVE);
+	SpockCtx->apply_group_master_lock = &((GetNamedLWLockTranche(SPOCK_GROUP_TRANCHE_NAME)[0]).lock);
+	SpockGroupHash = ShmemInitHash("spock group hash",
+								   napply_groups,
+								   napply_groups,
+								   &hctl,
+								   HASH_ELEM | HASH_BLOBS |
+								   HASH_SHARED_MEM | HASH_PARTITION |
+								   HASH_FIXED_SIZE);
+
+	if (!SpockGroupHash)
+		elog(ERROR, "spock_group_shmem_startup: failed to init group map");
+
+	LWLockRelease(AddinShmemInitLock);
+}
+
+static inline SpockGroupKey
+make_key(Oid dbid, Oid node_id, Oid remote_node_id)
+{
+	SpockGroupKey k = {dbid, node_id, remote_node_id};
+
+	return k;
+}
+
+/*
+ * spock_group_attach
+ */
+SpockGroupEntry *
+spock_group_attach(Oid dbid, Oid node_id, Oid remote_node_id, bool *created)
+{
+	SpockGroupKey key = make_key(dbid, node_id, remote_node_id);
+	SpockGroupEntry *e;
+	bool		found;
+
+	e = (SpockGroupEntry *) hash_search(SpockGroupHash, &key, HASH_ENTER, &found);
+	if (!found)
+	{
+		/* initialize new entry */
+		e->key = key;
+
+		/* initialize key values; Other entries will be updated later */
+		memset(&e->progress, 0, sizeof(e->progress));
+		e->progress.key = e->key;
+
+		pg_atomic_init_u32(&e->nattached, 0);
+		ConditionVariableInit(&e->prev_processed_cv);
+		if (created)
+			*created = true;
+	}
+	else
+	{
+		if (created)
+			*created = false;
+	}
+
+	pg_atomic_add_fetch_u32(&e->nattached, 1);
+
+	return e;
+}
+
+/*
+ * spock_group_detach
+ *
+ * Remove a worker from it's group.
+ */
+void
+spock_group_detach(void)
+{
+	if (MyApplyWorker->apply_group)
+		pg_atomic_sub_fetch_u32(&MyApplyWorker->apply_group->nattached, 1);
+
+	MyApplyWorker->apply_group = NULL;
+}
+
+/*
+ * spock_group_progress_update
+ *
+ * update progress - used by apply worker, REDO, file loader
+ */
+bool
+spock_group_progress_update(const SpockApplyProgress *sap)
+{
+	SpockGroupKey key;
+	SpockGroupEntry *e;
+	bool		found;
+
+	if (!sap)
+		return false;
+
+	key = make_key(sap->key.dbid, sap->key.node_id, sap->key.remote_node_id);
+	e = (SpockGroupEntry *) hash_search(SpockGroupHash, &key, HASH_ENTER, &found);
+
+	if (!found)					/* New Entry */
+	{
+		e->key = key;
+		/* Initialize key values; Other entries will be updated later */
+		memset(&e->progress, 0, sizeof(e->progress));
+		e->progress.key = e->key;
+
+		pg_atomic_init_u32(&e->nattached, 0);
+		ConditionVariableInit(&e->prev_processed_cv);
+	}
+
+	LWLockAcquire(SpockCtx->apply_group_master_lock, LW_EXCLUSIVE);
+	e->progress = *sap;
+	LWLockRelease(SpockCtx->apply_group_master_lock);
+	return true;
+}
+
+/* Fast update when you already hold the pointer (apply hot path) */
+void
+spock_group_progress_update_ptr(SpockGroupEntry *e, const SpockApplyProgress *sap)
+{
+	Assert(e && sap);
+	LWLockAcquire(SpockCtx->apply_group_master_lock, LW_EXCLUSIVE);
+	e->progress = *sap;
+	LWLockRelease(SpockCtx->apply_group_master_lock);
+}
+
+/*
+ * apply_worker_get_progress
+ */
+SpockApplyProgress *
+apply_worker_get_progress(void)
+{
+	Assert(MyApplyWorker != NULL);
+	Assert(MyApplyWorker->apply_group != NULL);
+	if (MyApplyWorker && MyApplyWorker->apply_group)
+		return &MyApplyWorker->apply_group->progress;
+	return NULL;
+}
+
+/*
+ * spock_group_get_progress
+ */
+bool
+spock_group_get_progress(Oid dbid, Oid node_id, Oid remote_node_id,
+						 SpockApplyProgress *out)
+{
+	SpockGroupKey key = make_key(dbid, node_id, remote_node_id);
+	SpockGroupEntry *e;
+
+	e = (SpockGroupEntry *) hash_search(SpockGroupHash, &key, HASH_FIND, NULL);
+	if (!e)
+		return false;
+
+	if (out)
+		*out = e->progress;
+	return true;
+}
+
+/*
+ * spock_group_lookup
+ */
+SpockGroupEntry *
+spock_group_lookup(Oid dbid, Oid node_id, Oid remote_node_id)
+{
+	SpockGroupKey key = make_key(dbid, node_id, remote_node_id);
+	SpockGroupEntry *e;
+
+	e = (SpockGroupEntry *) hash_search(SpockGroupHash, &key, HASH_FIND, NULL);
+	return e;					/* may be NULL */
+}

--- a/src/spock_group.c
+++ b/src/spock_group.c
@@ -32,7 +32,7 @@ static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 
 #define SPOCK_GROUP_TRANCHE_NAME   "spock_apply_groups"
 
-static HTAB *SpockGroupHash = NULL;
+HTAB	   *SpockGroupHash = NULL;
 
 static void spock_group_shmem_request(void);
 static void spock_group_shmem_startup(void);

--- a/src/spock_rmgr.c
+++ b/src/spock_rmgr.c
@@ -1,0 +1,133 @@
+/*-------------------------------------------------------------------------
+ *
+ * spock_rmgr.c
+ * 		spock resource manager definitions
+ *
+ * Copyright (c) 2022-2025, pgEdge, Inc.
+ * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "access/xlog.h"
+#include "access/xlog_internal.h"
+#include "access/xloginsert.h"
+#include "access/xlogreader.h"
+#include "access/xlogrecord.h"
+#include "utils/pg_lsn.h"
+
+#include "spock_rmgr.h"
+#include "spock_worker.h"
+#include "spock_apply.h"
+
+const RmgrData spock_custom_rmgr = {
+	.rm_name = SPOCK_RMGR_NAME,
+	.rm_redo = spock_rmgr_redo,
+	.rm_desc = spock_rmgr_desc,
+	.rm_identify = spock_rmgr_identify,
+	.rm_startup = spock_rmgr_startup,
+	.rm_cleanup = spock_rmgr_cleanup,
+};
+
+void
+spock_rmgr_init(void)
+{
+	RegisterCustomRmgr(SPOCK_RMGR_ID, &spock_custom_rmgr);
+}
+
+void
+spock_rmgr_redo(XLogReaderState *record)
+{
+	uint8		info = XLogRecGetInfo(record) & XLR_RMGR_INFO_MASK;
+
+	switch (info)
+	{
+		case SPOCK_RMGR_APPLY_PROGRESS:
+			{
+				SpockApplyProgress *sap;
+
+				sap = (SpockApplyProgress *) XLogRecGetData(record);
+
+				/* LWLockAcquire(SpockCtx->lock, LW_EXCLUSIVE); */
+
+				spock_group_progress_update(sap);
+				/* LWLockRelease(SpockCtx->lock); */
+			}
+			break;
+
+		case SPOCK_RMGR_SUBTRANS_COMMIT_TS:
+			break;
+
+		default:
+			elog(PANIC, "spock_rmgr_redo: unknown op code %u", info);
+	}
+}
+
+void
+spock_rmgr_desc(StringInfo buf, XLogReaderState *record)
+{
+	uint8		info = XLogRecGetInfo(record) & XLR_RMGR_INFO_MASK;
+
+	switch (info)
+	{
+		case SPOCK_RMGR_APPLY_PROGRESS:
+			{
+				SpockApplyProgress *sap;
+
+				sap = (SpockApplyProgress *) XLogRecGetData(record);
+				appendStringInfo(buf, "spock apply progress for db %u, node %u, remote_node %u",
+								 sap->key.dbid,
+								 sap->key.node_id,
+								 sap->key.remote_node_id);
+			}
+			break;
+		case SPOCK_RMGR_SUBTRANS_COMMIT_TS:
+			appendStringInfo(buf, "spock rmgr: sub transaction commit ts");
+			break;
+
+		default:
+			appendStringInfo(buf, "spock rmgr: unknown(%u)", info);
+	}
+}
+
+const char *
+spock_rmgr_identify(uint8 info)
+{
+	switch (info)
+	{
+		case SPOCK_RMGR_APPLY_PROGRESS:
+			return "APPLY_PROGRESS";
+			break;
+		case SPOCK_RMGR_SUBTRANS_COMMIT_TS:
+			return "SUBTRANS_COMMIT_TS";
+			break;
+	}
+
+	return NULL;
+}
+
+void
+spock_rmgr_startup(void)
+{
+}
+
+void
+spock_rmgr_cleanup(void)
+{
+}
+
+XLogRecPtr
+spock_apply_progress_add_to_wal(const SpockApplyProgress *sap)
+{
+	XLogRecPtr	lsn;
+
+	Assert(sap != NULL);
+
+	XLogBeginInsert();
+	XLogRegisterData((char *) sap, sizeof(SpockApplyProgress));
+	lsn = XLogInsert(SPOCK_RMGR_ID, SPOCK_RMGR_APPLY_PROGRESS);
+
+	return lsn;
+}

--- a/src/spock_rmgr.c
+++ b/src/spock_rmgr.c
@@ -7,6 +7,29 @@
  * Portions Copyright (c) 1996-2025, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, The Regents of the University of California
  *
+ *
+ * Spock Resource Manager (RMGR)
+ * -----------------------------
+ *
+ * This module implements the WAL side of Spock's apply progress persistence.
+ *
+ *   - WAL is authoritative for progress. We emit compact progress records
+ *     after each locally-committed, remotely-originated transaction on the
+ *     subscriber, and REDO replays them into shared memory after crash/restart.
+ *   - Shared memory holds a hash map keyed by (dbid, node_id, remote_node_id),
+ *     storing the latest SpockApplyProgress snapshot for each group.
+ *   - On clean shutdowns we also take a file snapshot (resource.dat) so restarts
+ *     can seed shmem quickly; WAL REDO still runs after load and will overwrite
+ *     any stale entries.
+ *
+ * Startup ordering:
+ *   1) postmaster creates shared memory and runs shmem_startup_hook
+ *        -> shmem_init()
+ *        -> spock_group_resource_load() to load file snapshot (if any)
+ *   2) startup process begins WAL recovery
+ *        -> calls spock_rmgr_redo() for our records
+ *        -> redo update the same shmem hash (wins over file load)
+ *
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
@@ -31,12 +54,27 @@ const RmgrData spock_custom_rmgr = {
 	.rm_cleanup = spock_rmgr_cleanup,
 };
 
+/*
+ * spock_rmgr_init
+ *
+ * Register Spock's resource manager so our WAL records are recognized during
+ * recovery. Called in _PG_init() before recovery can begin;
+ * do not allocate shmem here.
+ */
 void
 spock_rmgr_init(void)
 {
 	RegisterCustomRmgr(SPOCK_RMGR_ID, &spock_custom_rmgr);
 }
 
+/*
+ * spock_rmgr_redo
+ *
+ * Redo handler for Spock WAL records. For APPLY_PROGRESS records, decode the
+ * payload (SpockApplyProgress) and upsert into the shmem group registry via
+ * spock_group_update_progress(). This runs during recovery and overwrites any
+ * shmem contents previously seeded by file load.
+ */
 void
 spock_rmgr_redo(XLogReaderState *record)
 {
@@ -118,6 +156,18 @@ spock_rmgr_cleanup(void)
 {
 }
 
+/*
+ * spock_apply_progress_add_to_wal
+ *
+ * Emit and flush a progress record to WAL after committing a remote-origin
+ * transaction locally. This makes the progress update durable and guarantees
+ * redo will restore it after crash.
+ *
+ *   - Must be called *after* CommitTransactionCommand() of the applied txn.
+ *   - Uses info code SPOCK_RMGR_APPLY_PROGRESS (0x10).
+ *
+ * Returns: the LSN of the inserted record.
+ */
 XLogRecPtr
 spock_apply_progress_add_to_wal(const SpockApplyProgress *sap)
 {

--- a/src/spock_worker.c
+++ b/src/spock_worker.c
@@ -308,14 +308,31 @@ wait_for_worker_startup(SpockWorker *worker,
 
 /*
  * Cleanup function.
- *
- * Called on process exit.
+ */
+
+/*
+ * Called on shmem exit.
+ */
+static void
+spock_on_shmem_exit(int code, Datum arg)
+{
+	/* Only dump data if exiting cleanly */
+	if (code != 0)
+		return;
+
+	elog(DEBUG1, "spock_on_shmem_exit: dumping apply group data");
+	spock_group_resource_dump();
+}
+
+/*
+ * Called for worker process exit.
  */
 static void
 spock_worker_on_exit(int code, Datum arg)
 {
 	spock_worker_detach(code != 0);
 }
+
 
 /*
  * Attach the current master process to the SpockCtx.
@@ -744,6 +761,9 @@ spock_worker_shmem_request(void)
 
 	/* Allocate the number of LW-locks needed for Spock. */
 	RequestNamedLWLockTranche("spock", 2);
+
+	/* Request shmem for Apply Group */
+	spock_group_shmem_request();
 }
 
 /*
@@ -758,6 +778,9 @@ spock_worker_shmem_startup(void)
 
 	if (prev_shmem_startup_hook != NULL)
 		prev_shmem_startup_hook();
+
+	if (!IsUnderPostmaster)
+		on_shmem_exit(spock_on_shmem_exit, (Datum) 0);
 
 	/*
 	 * This is kludge for Windows (Postgres does not define the GUC variable
@@ -802,6 +825,9 @@ spock_worker_shmem_startup(void)
 							  HASH_ELEM | HASH_FUNCTION | HASH_FIXED_SIZE);
 
 	LWLockRelease(AddinShmemInitLock);
+
+	/* Apply Group shmem startup */
+	spock_group_shmem_startup(nworkers, found);
 }
 
 /*

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -12,3 +12,4 @@ test: 004_non_default_repset
 # Advanced functionality tests
 # test: 005_daylight_savings
 # test: 006_sync_during_write
+test: 008_rmgr

--- a/tests/tap/t/008_rmgr.pl
+++ b/tests/tap/t/008_rmgr.pl
@@ -1,0 +1,155 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(
+  create_cluster destroy_cluster system_or_bail command_ok get_test_config scalar_query psql_or_bail
+);
+
+
+sub wait_until {
+  my ($timeout_s, $probe) = @_;
+  my $deadline = time() + $timeout_s;
+  while (time() < $deadline) {
+    return 1 if $probe->();
+    select(undef, undef, undef, 0.20); # 200ms
+  }
+  return 0;
+}
+
+
+# 1) create 2-node cluster (provider n1, subscriber n2) with Spock
+create_cluster(2, 'Create a 2-node cluster');
+
+# DSN for provider
+my $conf = get_test_config();
+my $host = $conf->{host};
+my $pg_bin = $conf->{pg_bin};
+my $ports = $conf->{node_ports};
+my $datadirs = $conf->{node_datadirs};
+my $dbname = $conf->{db_name};
+my $user   = $conf->{db_user};
+
+my $prov_port = $ports->[0];
+my $sub_port  = $ports->[1];
+
+my $prov_dsn = "host=$host port=$prov_port dbname=$dbname user=$user";
+
+# Create a table on provider and a subscription on subscriber
+psql_or_bail(1, "CREATE TABLE public.test_progress (id int primary key, data text)");
+psql_or_bail(2, "SELECT spock.sub_create('test_sub', '$prov_dsn', ARRAY['default'], true, true)");
+
+# Wait for structure to appear on subscriber
+ok(wait_until(30, sub {
+  scalar_query(2, "SELECT to_regclass('public.test_progress') IS NOT NULL") eq 't'
+}), 'subscriber has table after initial sync');
+
+
+# 2) DML on provider; progress on subscriber;
+psql_or_bail(1, "INSERT INTO public.test_progress SELECT g, 'Test Val' FROM generate_series(1,3) g");
+
+# Save provider LSN after insert
+my $prov_lsn_after_insert = scalar_query(1, "SELECT pg_current_wal_lsn()");
+ok($prov_lsn_after_insert =~ /^[0-9A-F]+\/[0-9A-F]+$/, "provider LSN after insert: $prov_lsn_after_insert");
+
+# wait for rows to replicate
+ok(wait_until(30, sub {
+  scalar_query(2, "SELECT count(*) FROM public.test_progress") eq '3'
+}), 'subscriber has 3 rows');
+
+# progress rows should exist on subscriber
+my $rows = scalar_query(2, q{
+  SELECT count(*) FROM spock.apply_group_progress()
+});
+ok($rows ne '' && $rows >= 1, "apply_group_progress() yields at least one row");
+
+# fetch latest progress and compare LSNs against provider current LSN
+my $prog = scalar_query(2, q{
+  SELECT remote_commit_lsn || '|' || remote_insert_lsn
+  FROM spock.apply_group_progress()
+  ORDER BY last_updated_ts DESC LIMIT 1
+});
+ok($prog =~ /\S+\|\S+/, "fetched progress LSNs from subscriber: $prog");
+
+# compare LSN's of provider and subscriber
+my ($commit_lsn, $insert_lsn) = split(/\|/, $prog, 2);
+# Make sure progress LSNs are <= provider current LSN
+my $cmp_commit = scalar_query(2, "SELECT (pg_lsn '$commit_lsn') <= (pg_lsn '$prov_lsn_after_insert')");
+is($cmp_commit, 't', "remote_commit_lsn <= provider current LSN");
+
+my $cmp_insert = scalar_query(2, "SELECT (pg_lsn '$insert_lsn') <= (pg_lsn '$prov_lsn_after_insert')");
+is($cmp_insert, 't', "remote_insert_lsn <= provider current LSN");
+
+
+# 3) Clean restart subscriber; File load should seed shmem;
+
+# capture latest progress timestamp
+my $before_ts = scalar_query(2, q{ SELECT max(remote_commit_ts) FROM spock.apply_group_progress() });
+ok($before_ts ne '', "captured remote_commit_ts before clean restart: $before_ts");
+
+# stop subscriber cleanly; dump file should be written;
+system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-m', 'fast', 'stop';
+ok((-f $datadirs->[1] . "/spock/resource.dat"), "resource.dat exists on subscriber after clean stop");
+
+# start subscriber again
+system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-o', "-p $sub_port", 'start';
+
+# after restart; progress should be present, seeded;
+ok(wait_until(30, sub {
+  my $ts = scalar_query(2, q{ SELECT max(remote_commit_ts) FROM spock.apply_group_progress() });
+  ($ts ne '');
+}), 'progress present after clean restart');
+
+my $after_ts = scalar_query(2, q{
+  SELECT max(remote_commit_ts)
+  FROM spock.apply_group_progress()
+});
+ok($after_ts ge $before_ts, "progress is same before and after clean restart");
+
+# 4) Crash restart; WAL REDO must advance progress
+
+# generate more WAL on provider
+psql_or_bail(1, "INSERT INTO public.test_progress SELECT g, 'x' FROM generate_series(4,60) g");
+my $prov_lsn_after_bulk = scalar_query(1, "SELECT pg_current_wal_lsn()");
+ok($prov_lsn_after_bulk =~ /^[0-9A-F]+\/[0-9A-F]+$/, "provider LSN after bulk: $prov_lsn_after_bulk");
+
+# stop subscriber immediately (simulate crash)
+system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-m', 'immediate', 'stop';
+
+# start subscriber; redo should replay our progress
+system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-o', "-p $sub_port", 'start';
+
+# wait until counts match again
+ok(wait_until(40, sub {
+  scalar_query(1, "SELECT count(*) FROM public.test_progress") eq
+  scalar_query(2, "SELECT count(*) FROM public.test_progress")
+}), 'subscriber caught up after crash via WAL REDO');
+
+# verify progress advanced and still <= provider LSN
+my $final_prog = scalar_query(2, q{
+  SELECT remote_commit_lsn || '|' || remote_insert_lsn || '|' || remote_commit_ts
+  FROM spock.apply_group_progress()
+  ORDER BY remote_commit_ts DESC LIMIT 1
+});
+ok($final_prog =~ /\S+\|\S+\|\S+/, "latest progress after crash restart: $final_prog");
+
+my ($commit_lsn, $insert_lsn, $commit_ts) = split (/\|/, $final_prog, 3);
+ok($commit_ts ge $after_ts, "remote_commit_ts advanced after crash restart");
+
+my $cmp_f_commit = scalar_query(2, "SELECT (pg_lsn '$commit_lsn') <= (pg_lsn '$prov_lsn_after_bulk')");
+is($cmp_f_commit, 't', "remote_commit_lsn <= provider current LSN");
+
+my $cmp_f_insert = scalar_query(2, "SELECT (pg_lsn '$insert_lsn') <= (pg_lsn '$prov_lsn_after_bulk')");
+is($cmp_f_insert, 't', "remote_insert_lsn <= provider current LSN");
+
+my $q1 = scalar_query(2, "SELECT count(*) FROM public.test_progress");
+my $q2 = scalar_query(1, "SELECT count(*) FROM public.test_progress");
+
+# Final sanity
+is($q1, $q2, "row counts equal at end");
+# psql_or_bail(1, "SELECT spock.wait_slot_confirm_lsn(NULL, NULL)");
+
+# Cleanup
+psql_or_bail(2, "SELECT spock.sub_drop('test_sub')");
+destroy_cluster('Destroy 2-node cluster');
+done_testing();


### PR DESCRIPTION
**Spock: Custom WAL RMGR + shmem apply-progress; clean-shutdown snapshot**

- Add Spock-specific WAL resource manager and log apply-progress records.
- Keep progress in shmem (per-group entry) and Removed the catalog table spock.progress
- On clean shutdown, snapshot progress to $PGDATA/spock/resource.dat; reload on startup.

**Design**

- WAL -> shmem pipeline:
  - Apply emits a compact progress record via the Spock RMGR.
  - Shmem group entry is the live state workers read/update.
  - Crash case - Redo rebuilds shmem from WAL. Clean restart - Load from resource.dat.

- Grouped progress:
  - Each subscription attaches to a group entry tracking last remote commit ts/LSNs, etc.
  - Workers reference the entry directly (attach/detach); no per-commit catalog DML.

- Clean-shutdown snapshot:
  - on_shmem_exit walks the group table and writes a versioned snapshot.
  - write-temp + fsync + durable_rename to avoid torn files.
  - Startup validates version/system_identifier; on mismatch/corruption, ignore snapshot and continue.


**Rationale**

Catalog writes in the apply hot path were heavyweight and would cause
    locking and bloating issues, under heavy loads. By WAL-logging
    progress and rebuilding in-memory state during redo:
      * Apply path is lighter weight (no catalog DML per commit).
      * Progress tracking is isolated from user activity and schema changes.
      
