### PR TITLE
TAP test helpers

### DIFF
--- a/tests/tap/t/001_basic.pl
+++ b/tests/tap/t/001_basic.pl
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More tests => 29;
 use lib '.';
-use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config);
+use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config scalar_query psql_or_bail);
 
 # =============================================================================
 # Test: 001_basic.pl - Basic Spock Extension Functionality
@@ -33,23 +33,16 @@ create_cluster(2, 'Create 2-node basic Spock test cluster');
 
 # Get cluster configuration
 my $config = get_test_config();
-my $node_count = $config->{node_count};
 my $node_ports = $config->{node_ports};
 my $host = $config->{host};
 my $dbname = $config->{db_name};
 my $db_user = $config->{db_user};
 my $db_password = $config->{db_password};
-my $pg_bin = $config->{pg_bin};
 
-# Test 1: Verify nodes were created
-my $node1_exists = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM spock.node WHERE node_name = 'n1')"`;
-chomp($node1_exists);
-$node1_exists =~ s/\s+//g;
+my $node1_exists = scalar_query(1, "SELECT EXISTS (SELECT 1 FROM spock.node WHERE node_name = 'n1')");
 is($node1_exists, 't', 'Node n1 exists');
 
-my $node2_exists = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM spock.node WHERE node_name = 'n2')"`;
-chomp($node2_exists);
-$node2_exists =~ s/\s+//g;
+my $node2_exists = scalar_query(2, "SELECT EXISTS (SELECT 1 FROM spock.node WHERE node_name = 'n2')");
 is($node2_exists, 't', 'Node n2 exists');
 
 # Test 2: Verify default replication sets exist (using different approach)
@@ -59,127 +52,97 @@ pass('Default insert only replication set exists (managed internally by Spock)')
 pass('DDL SQL replication set exists (managed internally by Spock)');
 
 # Test 3: Create a custom replication set
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "SELECT spock.repset_create('test_repset')";
+psql_or_bail(1, "SELECT spock.repset_create('test_repset')");
+
 # Custom replication set was created successfully (we can see it in the logs)
 pass('Custom replication set created successfully');
 
 # Test 4: Create a test table
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "
-    CREATE TABLE test_basic (
+psql_or_bail(1,
+    "CREATE TABLE test_basic (
         id SERIAL PRIMARY KEY,
         name VARCHAR(50),
         value INTEGER,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )
-";
+");
 
-my $table_exists = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'test_basic')"`;
-chomp($table_exists);
-$table_exists =~ s/\s+//g;
+my $table_exists = scalar_query(1, "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'test_basic')");
 is($table_exists, 't', 'Test table created successfully');
 
 # Test 5: Add table to custom replication set
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "SELECT spock.repset_add_table('test_repset', 'test_basic')";
+psql_or_bail(1, "SELECT spock.repset_add_table('test_repset', 'test_basic')");
 
 # Table was added to replication set successfully (we can see it in the logs)
 pass('Table added to custom replication set');
 
 # Test 6: Create subscription between nodes
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[1], '-d', $dbname, '-c', 
-    "SELECT spock.sub_create('test_sub', 'host=$host dbname=$dbname port=$node_ports->[0] user=$db_user password=$db_password', ARRAY['test_repset'], true, true)";
+my $conn_string = "host=$host dbname=$dbname port=$node_ports->[0] user=$db_user password=$db_password";
+psql_or_bail(2, "SELECT spock.sub_create('test_sub', '$conn_string', ARRAY['test_repset'], true, true)");
 
-my $sub_exists = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'test_sub')"`;
-chomp($sub_exists);
-$sub_exists =~ s/\s+//g;
+my $sub_exists = scalar_query(2, "SELECT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'test_sub')");
 is($sub_exists, 't', 'Subscription created successfully');
 
 # Wait for subscription to be ready
 system_or_bail 'sleep', '5';
 
 # Test 7: Check subscription status
-my $sub_status = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'test_sub'"`;
-chomp($sub_status);
-$sub_status =~ s/\s+//g;
+my $sub_status = scalar_query(2, "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'test_sub'");
 is($sub_status, 't', 'Subscription is enabled');
 
 # Test 8: Insert data on provider
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "INSERT INTO test_basic (name, value) VALUES ('test1', 100)";
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "INSERT INTO test_basic (name, value) VALUES ('test2', 200)";
+psql_or_bail(1, "INSERT INTO test_basic (name, value) VALUES ('test1', 100)");
+psql_or_bail(1, "INSERT INTO test_basic (name, value) VALUES ('test2', 200)");
 
 # Wait for replication
 system_or_bail 'sleep', '3';
 
 # Test 9: Verify data replicated to subscriber
-my $count_provider = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT COUNT(*) FROM test_basic"`;
-chomp($count_provider);
-$count_provider =~ s/\s+//g;
-
-my $count_subscriber = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT COUNT(*) FROM test_basic"`;
-chomp($count_subscriber);
-$count_subscriber =~ s/\s+//g;
+my $count_provider = scalar_query(1, "SELECT COUNT(*) FROM test_basic");
+my $count_subscriber = scalar_query(2, "SELECT COUNT(*) FROM test_basic");
 
 is($count_provider, '2', 'Provider has 2 rows');
 is($count_subscriber, '2', 'Subscriber has 2 rows (replication working)');
 
 # Test 10: Verify specific data replicated
-my $test1_provider = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT value FROM test_basic WHERE name = 'test1'"`;
-chomp($test1_provider);
-$test1_provider =~ s/\s+//g;
-
-my $test1_subscriber = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT value FROM test_basic WHERE name = 'test1'"`;
-chomp($test1_subscriber);
-$test1_subscriber =~ s/\s+//g;
+my $test1_provider = scalar_query(1, "SELECT value FROM test_basic WHERE name = 'test1'");
+my $test1_subscriber = scalar_query(2, "SELECT value FROM test_basic WHERE name = 'test1'");
 
 is($test1_provider, '100', 'Provider has correct value for test1');
 is($test1_subscriber, '100', 'Subscriber has correct value for test1 (replication working)');
 
 # Test 11: Test UPDATE operation
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "UPDATE test_basic SET value = 150 WHERE name = 'test1'";
+psql_or_bail(1, "UPDATE test_basic SET value = 150 WHERE name = 'test1'");
 
 # Wait for replication
 system_or_bail 'sleep', '3';
 
-my $test1_updated_provider = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT value FROM test_basic WHERE name = 'test1'"`;
-chomp($test1_updated_provider);
-$test1_updated_provider =~ s/\s+//g;
-
-my $test1_updated_subscriber = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT value FROM test_basic WHERE name = 'test1'"`;
-chomp($test1_updated_subscriber);
-$test1_updated_subscriber =~ s/\s+//g;
+my $test1_updated_provider = scalar_query(1, "SELECT value FROM test_basic WHERE name = 'test1'");
+my $test1_updated_subscriber = scalar_query(2, "SELECT value FROM test_basic WHERE name = 'test1'");
 
 is($test1_updated_provider, '150', 'Provider has updated value for test1');
 is($test1_updated_subscriber, '150', 'Subscriber has updated value for test1 (UPDATE replication working)');
 
 # Test 12: Test DELETE operation
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "DELETE FROM test_basic WHERE name = 'test2'";
+psql_or_bail(1, "DELETE FROM test_basic WHERE name = 'test2'");
 
 # Wait for replication
 system_or_bail 'sleep', '3';
 
-my $count_after_delete_provider = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT COUNT(*) FROM test_basic"`;
-chomp($count_after_delete_provider);
-$count_after_delete_provider =~ s/\s+//g;
-
-my $count_after_delete_subscriber = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT COUNT(*) FROM test_basic"`;
-chomp($count_after_delete_subscriber);
-$count_after_delete_subscriber =~ s/\s+//g;
+my $count_after_delete_provider = scalar_query(1, "SELECT COUNT(*) FROM test_basic");
+my $count_after_delete_subscriber = scalar_query(2, "SELECT COUNT(*) FROM test_basic");
 
 is($count_after_delete_provider, '1', 'Provider has 1 row after DELETE');
 is($count_after_delete_subscriber, '1', 'Subscriber has 1 row after DELETE (DELETE replication working)');
 
 # Test 13: Test TRUNCATE operation
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "TRUNCATE TABLE test_basic";
+psql_or_bail(1, "TRUNCATE TABLE test_basic");
 
 # Wait for replication
 system_or_bail 'sleep', '3';
 
-my $count_after_truncate_provider = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT COUNT(*) FROM test_basic"`;
-chomp($count_after_truncate_provider);
-$count_after_truncate_provider =~ s/\s+//g;
-
-my $count_after_truncate_subscriber = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT COUNT(*) FROM test_basic"`;
-chomp($count_after_truncate_subscriber);
-$count_after_truncate_subscriber =~ s/\s+//g;
+my $count_after_truncate_provider = scalar_query(1, "SELECT COUNT(*) FROM test_basic");
+my $count_after_truncate_subscriber = scalar_query(2, "SELECT COUNT(*) FROM test_basic");
 
 is($count_after_truncate_provider, '0', 'Provider has 0 rows after TRUNCATE');
 is($count_after_truncate_subscriber, '0', 'Subscriber has 0 rows after TRUNCATE (TRUNCATE replication working)');
@@ -187,30 +150,26 @@ is($count_after_truncate_subscriber, '0', 'Subscriber has 0 rows after TRUNCATE 
 # Test 14: Test DDL replication (CREATE TABLE)
 # Note: DDL replication might not work with custom replication sets
 # Let's test with a simpler approach
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "
+psql_or_bail(1, "
     CREATE TABLE test_ddl (
         id INTEGER PRIMARY KEY,
         description TEXT
     )
-";
+");
 
 # Wait for replication
 system_or_bail 'sleep', '3';
 
-my $ddl_table_provider = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'test_ddl')"`;
-chomp($ddl_table_provider);
-$ddl_table_provider =~ s/\s+//g;
+my $ddl_table_provider = scalar_query(1, "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'test_ddl')");
 
 # DDL replication might not work with custom replication sets, so we'll skip this test
 is($ddl_table_provider, 't', 'Provider has DDL table');
 pass('DDL replication test skipped (custom replication set limitation)');
 
 # Test 15: Clean up test subscription
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[1], '-d', $dbname, '-c', "SELECT spock.sub_drop('test_sub')";
+psql_or_bail(2, "SELECT spock.sub_drop('test_sub')");
 
-my $sub_cleaned = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "SELECT NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'test_sub')"`;
-chomp($sub_cleaned);
-$sub_cleaned =~ s/\s+//g;
+my $sub_cleaned = scalar_query(2, "SELECT NOT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = 'test_sub')");
 is($sub_cleaned, 't', 'Test subscription cleaned up successfully');
 
 # Clean up


### PR DESCRIPTION
Some new functions to make writing and reading the code for TAP tests a little easier.

`scalar_query` take the node number (starting from 1) and a statement to run, expecting one single value.

`psql_or_die` is like `system_or_die`, but runs a psql command.

`001_basic.pl` is changed to show using these. The other existing test files have not been modified yet.