### PR TITLE
SPOC-216: Add skip_schema functionality and added support in zodan.sql and zodan.py.

### DIFF
--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -55,6 +55,7 @@ typedef struct SpockSubscription
 	List	   *forward_origins;
 	bool		force_text_transfer;
 	XLogRecPtr	skiplsn;	/* All changes finished at this LSN are skipped */
+	List	   *skip_schema;	/* Array of schema names to skip */
 } SpockSubscription;
 
 extern void create_node(SpockNode *node);

--- a/sql/spock--6.0.0-devel.sql
+++ b/sql/spock--6.0.0-devel.sql
@@ -34,7 +34,8 @@ CREATE TABLE spock.subscription (
     sub_forward_origins text[],
     sub_apply_delay interval NOT NULL DEFAULT '0',
     sub_force_text_transfer boolean NOT NULL DEFAULT 'f',
-	sub_skip_lsn pg_lsn NOT NULL DEFAULT '0/0'
+	sub_skip_lsn pg_lsn NOT NULL DEFAULT '0/0',
+	sub_skip_schema text[]
 );
 
 CREATE TABLE spock.local_sync_status (
@@ -121,7 +122,7 @@ CREATE FUNCTION spock.sub_create(subscription_name name, provider_dsn text,
     replication_sets text[] = '{default,default_insert_only,ddl_sql}', synchronize_structure boolean = false,
     synchronize_data boolean = false, forward_origins text[] = '{}', apply_delay interval DEFAULT '0',
     force_text_transfer boolean = false,
-	enabled boolean = true)
+	enabled boolean = true, skip_schema text[] = '{}')
 RETURNS oid STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_create_subscription';
 CREATE FUNCTION spock.sub_drop(subscription_name name, ifexists boolean DEFAULT false)
 RETURNS oid STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_drop_subscription';

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -455,6 +455,7 @@ Datum spock_create_subscription(PG_FUNCTION_ARGS)
 	Interval *apply_delay = PG_GETARG_INTERVAL_P(6);
 	bool force_text_transfer = PG_GETARG_BOOL(7);
 	bool enabled = PG_GETARG_BOOL(8);
+	ArrayType *skip_schema_names = PG_GETARG_ARRAYTYPE_P(9);
 	PGconn *conn;
 	SpockSubscription sub;
 	SpockSyncStatus sync;
@@ -572,6 +573,10 @@ Datum spock_create_subscription(PG_FUNCTION_ARGS)
 	sub.apply_delay = apply_delay;
 	sub.force_text_transfer = force_text_transfer;
 	sub.skiplsn	= InvalidXLogRecPtr;
+	if (PG_ARGISNULL(9))
+		sub.skip_schema = NIL;
+	else
+		sub.skip_schema = textarray_to_list(skip_schema_names);
 
 	create_subscription(&sub);
 


### PR DESCRIPTION
The skip_schema functionality automatically detects existing schemas on the new node and excludes them from replication when synchronize_structure is enabled, preventing schema conflicts during node addition.

1. SPOC-216: Add skip_schema functionality to Spock core:
   - Add skip_schema column to spock.subscription table
   - Update spock_create_subscription function to accept skip_schema parameter
   - Add schema filtering in pg_dump and data copy operations
   - Update subscription creation to handle the skip_schema field

2. SPOC-216: Update zodan.sql with skip_schema auto-detection:
   - Add automatic schema detection on new nodes when synchronize_structure=true
   - Query existing schemas excluding system schemas (information_schema, pg_catalog, etc.)
   - Convert detected schemas to PostgreSQL array format for the skip_schema parameter
   - Add proper error handling for schema detection failures

3. SPOC-211: Add zodan.py - Complete Python implementation:
   - 100% feature parity with zodan.sql using psql subprocess calls
   - Comprehensive error handling and connection management