### PR TITLE
SPOC-102 - INSERT into an absent table shouldn't halt the apply worker

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1338,7 +1338,7 @@ handle_relation(StringInfo s)
 }
 
 static void
-log_insert_exception(bool failed, ErrorData *edata, SpockRelation *rel,
+log_insert_exception(bool failed, char *errmsg, SpockRelation *rel,
 					 SpockTupleData *oldtup, SpockTupleData *newtup,
 					 const char *action_name)
 {
@@ -1374,7 +1374,7 @@ log_insert_exception(bool failed, ErrorData *edata, SpockRelation *rel,
 							   rel, localtup, oldtup, newtup,
 							   NULL, NULL,
 							   action_name,
-							   (failed && edata) ? edata->message : NULL);
+							   (failed) ? errmsg : NULL);
 }
 
 static void
@@ -1382,7 +1382,7 @@ handle_insert(StringInfo s)
 {
 	SpockTupleData newtup;
 	SpockRelation *rel;
-	ErrorData  *edata;
+	ErrorData  *edata = NULL;
 	MemoryContext	oldcontext;
 	bool		started_tx;
 	bool		failed = false;
@@ -1397,11 +1397,28 @@ handle_insert(StringInfo s)
 
 	started_tx = begin_replication_step();
 
-	errcallback_arg.action_name = "INSERT";
-	xact_action_counter++;
-
 	rel = spock_read_insert(s, RowExclusiveLock, &newtup);
+	if (unlikely(rel == NULL))
+	{
+		Assert(MyApplyWorker->use_try_block);
+
+		/*
+		 * Correctly interrupt the process: set exception flag and log the
+		 * exception itself.
+		 */
+		xact_had_exception = true;
+		exception_command_counter++;
+		log_insert_exception(true, "Spock can't find relation", NULL,
+							 NULL, NULL, "INSERT");
+		end_replication_step();
+		MemoryContextSwitchTo(oldcontext);
+		MemoryContextReset(ApplyOperationContext);
+		return;
+	}
+
+	errcallback_arg.action_name = "INSERT";
 	errcallback_arg.rel = rel;
+	xact_action_counter++;
 
 	/* If in list of relations which are being synchronized, skip. */
 	if (!should_apply_changes_for_rel(rel->nspname, rel->relname))
@@ -1481,7 +1498,8 @@ handle_insert(StringInfo s)
 		}
 
 		/* Let's create an exception log entry if true. */
-		log_insert_exception(failed, edata, rel, NULL, &newtup, "INSERT");
+		log_insert_exception(failed, edata ? edata->message : NULL, rel,
+							 NULL, &newtup, "INSERT");
 	}
 	else
 	{
@@ -1617,7 +1635,8 @@ handle_update(StringInfo s)
 		}
 
 		/* Let's create an exception log entry if true. */
-		log_insert_exception(failed, edata, rel, hasoldtup ? &oldtup : NULL, &newtup, "UPDATE");
+		log_insert_exception(failed, edata ? edata->message : NULL, rel,
+							 hasoldtup ? &oldtup : NULL, &newtup, "UPDATE");
 	}
 	else
 	{
@@ -1634,7 +1653,7 @@ handle_delete(StringInfo s)
 {
 	SpockTupleData oldtup;
 	SpockRelation *rel;
-	ErrorData  *edata;
+	ErrorData  *edata = NULL;
 	bool		failed = false;
 
 	/*
@@ -1688,7 +1707,8 @@ handle_delete(StringInfo s)
 		}
 
 		/* Let's create an exception log entry if true. */
-		log_insert_exception(failed, edata, rel, &oldtup, NULL, "DELETE");
+		log_insert_exception(failed, edata ? edata->message : NULL, rel,
+							 &oldtup, NULL, "DELETE");
 	}
 	else
 	{
@@ -2826,7 +2846,7 @@ stream_replay:
 			{
 				MySpockWorker->worker_status = SPOCK_WORKER_STATUS_STOPPED;
 								proc_exit(1);
-			}	
+			}
 			if (rc & WL_SOCKET_READABLE)
 				PQconsumeInput(applyconn);
 
@@ -3136,12 +3156,13 @@ stream_replay:
 			 */
 			if (MyApplyWorker->use_try_block)
 			{
-				elog(LOG, "SPOCK: caught exception while use_try_block=true");
+				elog(LOG, "SPOCK: caught exception while use_try_block=true. The exception was:\n'%s'",
+					 edata->message);
 				PG_RE_THROW();
 			}
 		}
 
-		/* 
+		/*
 		 * Note: Replay queue overflow handling removed - dynamic allocation prevents overflow.
 		 * We no longer kill and restart apply workers for queue overflow.
 		 * Exception handling now follows spock.exception_behavior setting.

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -92,7 +92,9 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 
 		rv->schemaname = (char *) entry->nspname;
 		rv->relname = (char *) entry->relname;
-		entry->rel = table_openrv(rv, lockmode);
+		entry->rel = table_openrv_extended(rv, lockmode, true);
+		if (unlikely(entry->rel == NULL))
+			return NULL;
 
 		desc = RelationGetDescr(entry->rel);
 		for (i = 0; i < entry->natts; i++)
@@ -158,7 +160,11 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 		}
 	}
 	else if (!entry->rel)
-		entry->rel = table_open(entry->reloid, lockmode);
+	{
+		entry->rel = try_table_open(entry->reloid, lockmode);
+		if (unlikely(entry->rel == NULL))
+			return NULL;
+	}
 
 	return entry;
 }

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -231,3 +231,201 @@ SELECT * FROM spock.replication_set;
  2586246310 |      52665 | ddl_sql             | t                | f                | f                | f
 (3 rows)
 
+-- Issue SPOC-102
+-- Being on subscriber, set the exception behaviour to transdiscard
+ALTER SYSTEM SET spock.exception_behaviour = 'transdiscard';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+ -- Table spoc_102g must be on each node and inside the replication set.
+SELECT spock.replicate_ddl('CREATE TABLE spoc_102g (x integer PRIMARY KEY);');
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT spock.repset_add_table('default', 'spoc_102g');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+-- Must be disabled
+SHOW spock.enable_ddl_replication;
+ spock.enable_ddl_replication 
+------------------------------
+ off
+(1 row)
+
+SHOW spock.include_ddl_repset;
+ spock.include_ddl_repset 
+--------------------------
+ off
+(1 row)
+
+CREATE TABLE spoc_102l (x integer PRIMARY KEY); -- local for the publisher
+INSERT INTO spoc_102l VALUES (1); -- Should be invisible for the subscriber node.
+INSERT INTO spoc_102g VALUES (-1);
+SELECT spock.repset_add_table('default', 'spoc_102l');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO spoc_102g VALUES (-2);
+INSERT INTO spoc_102l VALUES (2); -- Should cause an error that will be just skipped
+INSERT INTO spoc_102g VALUES (-3);
+BEGIN; -- All its changes must be skipped
+INSERT INTO spoc_102l VALUES (3);
+INSERT INTO spoc_102g VALUES (-4); -- NOT replicated
+END;
+INSERT INTO spoc_102g VALUES (-5);
+\c :subscriber_dsn
+-- Check replication state before the problem fixation
+SELECT * FROM spoc_102g ORDER BY x;
+ x  
+----
+ -5
+ -3
+ -2
+ -1
+(4 rows)
+
+SELECT * FROM spoc_102l ORDER BY x; -- ERROR, does not exist yet
+ERROR:  relation "spoc_102l" does not exist at character 15
+-- Now, fix the issue with absent table
+BEGIN;
+SELECT spock.repair_mode(true) \gset
+CREATE TABLE spoc_102l (x integer PRIMARY KEY);
+END;
+-- Check that replication works
+INSERT INTO spoc_102l VALUES (4);
+-- XXX: Why we don't synchronize the state of the table and don't see rows
+-- publisher has added before?
+SELECT * FROM spoc_102l ORDER BY x;
+ x 
+---
+ 4
+(1 row)
+
+-- Return to provider and check that it doesn't see value (4).
+-- Afterwards, add value 5 that must be replicated
+\c :provider_dsn
+SELECT * FROM spoc_102l ORDER BY x;
+ x 
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+INSERT INTO spoc_102l VALUES (5);
+-- Re-check that subscription works properly
+\c :subscriber_dsn
+SELECT * FROM spoc_102l ORDER BY x;
+ x 
+---
+ 4
+ 5
+(2 rows)
+
+--
+-- Now, let's check the 'discard' mode
+--
+ALTER SYSTEM SET spock.exception_behaviour = 'discard';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+TRUNCATE spoc_102g;
+SELECT spock.replicate_ddl('DROP TABLE spoc_102l CASCADE');
+NOTICE:  drop cascades to table spoc_102l membership in replication set default
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+CREATE TABLE spoc_102l (x integer PRIMARY KEY); -- local for the publisher
+INSERT INTO spoc_102l VALUES (1);
+INSERT INTO spoc_102g VALUES (-1);
+SELECT spock.repset_add_table('default', 'spoc_102l');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO spoc_102g VALUES (-2);
+INSERT INTO spoc_102l VALUES (2); -- table does not exist yet, skip
+INSERT INTO spoc_102g VALUES (-3);
+BEGIN; -- Skip INSERT to spoc_102l and apply INSERT to spoc_102g
+INSERT INTO spoc_102l VALUES (3);
+INSERT INTO spoc_102g VALUES (-4);
+END;
+INSERT INTO spoc_102g VALUES (-5);
+\c :subscriber_dsn
+-- Check replication state before the problem fixation
+SELECT * FROM spoc_102g ORDER BY x;
+ x  
+----
+ -5
+ -4
+ -3
+ -2
+ -1
+(5 rows)
+
+SELECT * FROM spoc_102l ORDER BY x; -- ERROR, does not exist yet
+ERROR:  relation "spoc_102l" does not exist at character 15
+-- Now, fix the issue with absent table. Use 'IF NOT EXISTS' hack to create
+-- the table where it is absent.
+\c :provider_dsn
+SELECT spock.replicate_ddl('CREATE TABLE IF NOT EXISTS spoc_102l (x integer PRIMARY KEY)');
+NOTICE:  relation "spoc_102l" already exists, skipping
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+INSERT INTO spoc_102l VALUES (4);
+INSERT INTO spoc_102g VALUES (-6);
+\c :subscriber_dsn
+SELECT * FROM spoc_102g ORDER BY x;
+ x  
+----
+ -6
+ -5
+ -4
+ -3
+ -2
+ -1
+(6 rows)
+
+SELECT * FROM spoc_102l ORDER BY x;
+ x 
+---
+ 4
+(1 row)
+
+-- Check exception log format
+SELECT
+  command_counter,table_schema,table_name,operation,
+  remote_new_tup,error_message
+FROM spock.exception_log
+ORDER BY command_counter;
+ command_counter | table_schema | table_name | operation |                   remote_new_tup                   |       error_message       
+-----------------+--------------+------------+-----------+----------------------------------------------------+---------------------------
+               1 |              |            | INSERT    |                                                    | Spock can't find relation
+               2 |              |            | INSERT    |                                                    | Spock can't find relation
+               3 | public       | spoc_102g  | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | unknown
+               4 |              |            | INSERT    |                                                    | Spock can't find relation
+               5 |              |            | INSERT    |                                                    | Spock can't find relation
+               6 | public       | spoc_102g  | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | unknown
+(6 rows)
+


### PR DESCRIPTION
TODO: UPDATE and DELETE should be processed the same way if we agree it is a right way.