### PR TITLE
SPOC-218: Add health-check command to ZODAN for pre and post validation.

### DIFF
--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -655,9 +655,235 @@ BEGIN
 END;
 $$;
 
+-- ============================================================================
+-- Procedure: verify_subscription_replicating
+-- Purpose : Verifies that a subscription is actively replicating after being enabled
+-- Arguments:
+--   node_dsn           - DSN of the node where subscription exists
+--   subscription_name  - Name of the subscription to verify
+--   verb              - Verbose output flag
+--   max_attempts      - Maximum verification attempts in seconds (default: 120 = 2 minutes)
+-- Usage    : CALL spock.verify_subscription_replicating(node_dsn, 'sub_name', true);
+-- Notes   : Raises exception if subscription fails to reach 'replicating' status within timeout
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.verify_subscription_replicating(
+    node_dsn text,
+    subscription_name text,
+    verb boolean DEFAULT true,
+    max_attempts integer DEFAULT 120  -- 2 minutes (120 seconds)
+) LANGUAGE plpgsql AS $$
+DECLARE
+    sub_status text;
+    verify_count integer := 0;
+BEGIN
+    LOOP
+        verify_count := verify_count + 1;
+
+        -- Check subscription status on the target node
+        SELECT status INTO sub_status
+        FROM dblink(node_dsn,
+            format('SELECT status FROM spock.sub_show_status() WHERE subscription_name = %L',
+                   subscription_name)) AS t(status text);
+
+        IF sub_status = 'replicating' THEN
+            IF verb THEN
+                RAISE NOTICE '    SUCCESS: %', rpad('Verified subscription ' || subscription_name || ' is replicating', 120, ' ');
+            END IF;
+            EXIT;
+        ELSIF verify_count >= max_attempts THEN
+            RAISE EXCEPTION 'Subscription % verification timeout after % seconds (final status: %)',
+                          subscription_name, max_attempts, COALESCE(sub_status, 'unknown');
+        ELSE
+            IF verb THEN
+                RAISE NOTICE '    ⏳ %', rpad('Waiting for subscription ' || subscription_name || ' to start replicating (status: ' || COALESCE(sub_status, 'unknown') || ', attempt ' || verify_count || '/' || max_attempts || ')', 120, ' ');
+            END IF;
+            PERFORM pg_sleep(1);
+        END IF;
+    END LOOP;
+END;
+$$;
 
 -- ============================================================================
+-- Procedure: show_all_nodes
+-- Purpose : Shows comprehensive node status across all nodes in cluster
+-- Arguments:
+--   cluster_dsn - DSN of any node in the cluster to query cluster state
+--   verb        - Verbose output flag
+-- Usage    : CALL spock.show_all_nodes('host=127.0.0.1 dbname=pgedge port=5431 user=pgedge password=pgedge', true);
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.show_all_nodes(
+    cluster_dsn text,
+    verb boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    node_rec RECORD;
+    total_nodes integer := 0;
+BEGIN
+    IF verb THEN
+        RAISE NOTICE '';
+        RAISE NOTICE 'COMPREHENSIVE NODE STATUS REPORT';
+        RAISE NOTICE '====================================';
+    END IF;
 
+    -- Get all nodes from the cluster using the provided DSN
+    FOR node_rec IN
+        SELECT node_id, node_name, location, country, info, dsn
+        FROM dblink(cluster_dsn, 'SELECT n.node_id, n.node_name, n.location, n.country, n.info, i.if_dsn FROM spock.node n JOIN spock.node_interface i ON n.node_id = i.if_nodeid ORDER BY n.node_name')
+        AS t(node_id integer, node_name text, location text, country text, info text, dsn text)
+    LOOP
+        total_nodes := total_nodes + 1;
+
+        IF verb THEN
+            RAISE NOTICE '    [NODE] %: % (%s, %s) - %s', node_rec.node_name, node_rec.node_id, node_rec.location, node_rec.country, regexp_replace(node_rec.dsn, ' password=pgedge', ' password=***');
+        END IF;
+    END LOOP;
+
+    -- Summary
+    IF verb THEN
+        RAISE NOTICE '';
+        RAISE NOTICE 'NODE STATUS SUMMARY';
+        RAISE NOTICE '==================';
+        RAISE NOTICE 'Total nodes: %', total_nodes;
+    END IF;
+
+    -- Raise exception if no nodes are found
+    IF total_nodes = 0 THEN
+        RAISE EXCEPTION 'No nodes found in the cluster';
+    END IF;
+END;
+$$;
+
+-- ============================================================================
+-- Procedure: show_all_subscription_status
+-- Purpose : Shows comprehensive subscription status across all nodes in the cluster
+-- Arguments:
+--   cluster_dsn - DSN of any node in the cluster to query cluster state
+--   verb        - Verbose output flag
+-- Usage    : CALL spock.show_all_subscription_status('host=127.0.0.1 dbname=pgedge port=5431 user=pgedge password=pgedge', true);
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.show_all_subscription_status(
+    cluster_dsn text,
+    verb boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    node_rec RECORD;
+    sub_rec RECORD;
+    total_subscriptions integer := 0;
+    replicating_count integer := 0;
+    error_count integer := 0;
+BEGIN
+    IF verb THEN
+        RAISE NOTICE '';
+        RAISE NOTICE 'COMPREHENSIVE SUBSCRIPTION STATUS REPORT';
+        RAISE NOTICE '==========================================';
+    END IF;
+
+    -- Get all nodes from the cluster using the provided DSN
+    FOR node_rec IN
+        SELECT node_id, node_name, location, country, info, dsn
+        FROM dblink(cluster_dsn, 'SELECT n.node_id, n.node_name, n.location, n.country, n.info, i.if_dsn FROM spock.node n JOIN spock.node_interface i ON n.node_id = i.if_nodeid ORDER BY n.node_name')
+        AS t(node_id integer, node_name text, location text, country text, info text, dsn text)
+    LOOP
+        IF verb THEN
+            RAISE NOTICE '';
+            RAISE NOTICE 'Node: % (DSN: %)', node_rec.node_name, node_rec.dsn;
+            RAISE NOTICE 'Subscriptions:';
+        END IF;
+
+        -- Get all subscriptions from this node
+        FOR sub_rec IN
+            SELECT subscription_name, status, provider_node, provider_dsn, slot_name, replication_sets, forward_origins
+            FROM dblink(node_rec.dsn, 'SELECT * FROM spock.sub_show_status() ORDER BY subscription_name')
+            AS t(subscription_name text, status text, provider_node text, provider_dsn text,
+                 slot_name text, replication_sets text[], forward_origins text)
+        LOOP
+            total_subscriptions := total_subscriptions + 1;
+
+            CASE sub_rec.status
+                WHEN 'replicating' THEN
+                    replicating_count := replicating_count + 1;
+                    IF verb THEN
+                        RAISE NOTICE '  [OK] %: % (provider: %, sets: %)',
+                            sub_rec.subscription_name, sub_rec.status,
+                            sub_rec.provider_node,
+                            array_to_string(sub_rec.replication_sets, ',');
+                    END IF;
+                WHEN 'disabled' THEN
+                    IF verb THEN
+                        RAISE NOTICE '  [DISABLED] %: % (provider: %, sets: %)',
+                            sub_rec.subscription_name, sub_rec.status,
+                            sub_rec.provider_node,
+                            array_to_string(sub_rec.replication_sets, ',');
+                    END IF;
+                WHEN 'initializing' THEN
+                    IF verb THEN
+                        RAISE NOTICE '  [INITIALIZING] %: % (provider: %, sets: %)',
+                            sub_rec.subscription_name, sub_rec.status,
+                            sub_rec.provider_node,
+                            array_to_string(sub_rec.replication_sets, ',');
+                    END IF;
+                WHEN 'syncing' THEN
+                    IF verb THEN
+                        RAISE NOTICE '  [INITIALIZING] %: % (provider: %, sets: %)',
+                            sub_rec.subscription_name, sub_rec.status,
+                            sub_rec.provider_node,
+                            array_to_string(sub_rec.replication_sets, ',');
+                    END IF;
+                WHEN 'down' THEN
+                    error_count := error_count + 1;
+                    IF verb THEN
+                        RAISE NOTICE '  [ERROR] %: % (provider: %, sets: %)',
+                            sub_rec.subscription_name, sub_rec.status,
+                            sub_rec.provider_node,
+                            array_to_string(sub_rec.replication_sets, ',');
+                    END IF;
+                ELSE
+                    IF verb THEN
+                        RAISE NOTICE '  [UNKNOWN] %: % (provider: %, sets: %)',
+                            sub_rec.subscription_name, sub_rec.status,
+                            sub_rec.provider_node,
+                            array_to_string(sub_rec.replication_sets, ',');
+                    END IF;
+            END CASE;
+        END LOOP;
+
+        -- Check if node has no subscriptions
+        IF NOT FOUND THEN
+            IF verb THEN
+                RAISE NOTICE '  (no subscriptions found)';
+            END IF;
+        END IF;
+    END LOOP;
+
+    -- Summary
+    IF verb THEN
+        RAISE NOTICE '';
+        RAISE NOTICE 'SUBSCRIPTION STATUS SUMMARY';
+        RAISE NOTICE '==========================';
+        RAISE NOTICE 'Total subscriptions: %', total_subscriptions;
+        RAISE NOTICE 'Replicating: %', replicating_count;
+        RAISE NOTICE 'With errors/issues: %', error_count;
+
+        IF total_subscriptions > 0 THEN
+            RAISE NOTICE 'Success rate: %%%',
+                round((replicating_count::numeric / total_subscriptions::numeric) * 100, 1);
+        END IF;
+
+        IF replicating_count = total_subscriptions AND total_subscriptions > 0 THEN
+            RAISE NOTICE 'SUCCESS: All subscriptions are replicating successfully!';
+        ELSIF error_count > 0 THEN
+            RAISE NOTICE 'WARNING: Some subscriptions have issues - check details above';
+        ELSE
+            RAISE NOTICE 'INFO: Subscriptions are in various states - check details above';
+        END IF;
+    END IF;
+
+    -- Raise exception if no subscriptions are replicating
+    IF total_subscriptions > 0 AND replicating_count = 0 THEN
+        RAISE EXCEPTION 'No subscriptions are in replicating state after node addition';
+    END IF;
+END;
+$$;
 
 -- ============================================================================
 -- Procedure: monitor_replication_lag
@@ -1069,9 +1295,9 @@ BEGIN
 
     IF lag_interval IS NOT NULL AND (extract(epoch FROM lag_interval) < 59 OR lag_bytes = 0) THEN
         IF lag_bytes = 0 THEN
-            RAISE NOTICE '    ✓ Replication lag monitoring completed (lag_bytes = 0)';
+            RAISE NOTICE '    OK: Replication lag monitoring completed (lag_bytes = 0)';
         ELSE
-            RAISE NOTICE '    ✓ Replication lag monitoring completed';
+            RAISE NOTICE '    OK: Replication lag monitoring completed';
         END IF;
     ELSE
         RAISE NOTICE '    - Replication lag monitoring timed out';
@@ -1115,21 +1341,21 @@ BEGIN
         RAISE NOTICE '    %[FAILED]', rpad('Checking new node "' || new_node_name || '" already exists', 60, ' ');
         RAISE EXCEPTION 'Exiting add_node: New node % already exists', new_node_name;
     ELSE
-        RAISE NOTICE '    ✓ %', rpad('Checking new node ' || new_node_name || ' does not exist', 120, ' ');
+        RAISE NOTICE '    OK: %', rpad('Checking new node ' || new_node_name || ' does not exist', 120, ' ');
     END IF;
     SELECT count(*) INTO new_sub_exists FROM spock.subscription s JOIN spock.node n ON s.sub_origin = n.node_id WHERE n.node_name = new_node_name;
     IF new_sub_exists > 0 THEN
         RAISE NOTICE '    %[FAILED]', rpad('Checking new node "' || new_node_name || '" has subscriptions', 60, ' ');
         RAISE EXCEPTION 'Exiting add_node: New node % has subscriptions', new_node_name;
     ELSE
-        RAISE NOTICE '    ✓ %', rpad('Checking new node ' || new_node_name || ' has no subscriptions', 120, ' ');
+        RAISE NOTICE '    OK: %', rpad('Checking new node ' || new_node_name || ' has no subscriptions', 120, ' ');
     END IF;
     SELECT count(*) INTO new_repset_exists FROM spock.replication_set rs JOIN spock.node n ON rs.set_nodeid = n.node_id WHERE n.node_name = new_node_name;
     IF new_repset_exists > 0 THEN
         RAISE NOTICE '    %[FAILED]', rpad('Checking new node "' || new_node_name || '" has replication sets', 60, ' ');
         RAISE EXCEPTION 'Exiting add_node: New node % has replication sets', new_node_name;
     ELSE
-        RAISE NOTICE '    ✓ %', rpad('Checking new node ' || new_node_name || ' has no replication sets', 120, ' ');
+        RAISE NOTICE '    OK: %', rpad('Checking new node ' || new_node_name || ' has no replication sets', 120, ' ');
     END IF;
 END;
 $$;
@@ -1153,7 +1379,7 @@ BEGIN
     RAISE NOTICE 'Phase 2: Creating nodes';
     BEGIN
         CALL spock.create_node(src_node_name, src_dsn, verb);
-        RAISE NOTICE '    ✓ %', rpad('Creating source node ' || src_node_name || '...', 120, ' ');
+        RAISE NOTICE '    OK: %', rpad('Creating source node ' || src_node_name || '...', 120, ' ');
     EXCEPTION
         WHEN OTHERS THEN
             RAISE NOTICE '    ✗ %', rpad('Creating source node ' || src_node_name  || ' (error: ' || SQLERRM || ')', 120, ' ');
@@ -1162,7 +1388,7 @@ BEGIN
 
     BEGIN
         CALL spock.create_node(new_node_name, new_node_dsn, verb, new_node_location, new_node_country, new_node_info);
-        RAISE NOTICE '    ✓ %', rpad('Creating new node ' || new_node_name || '...', 120, ' ');
+        RAISE NOTICE '    OK: %', rpad('Creating new node ' || new_node_name || '...', 120, ' ');
     EXCEPTION
         WHEN OTHERS THEN
             RAISE NOTICE '    ✗ %', rpad('Creating new node ' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
@@ -1210,7 +1436,7 @@ BEGIN
                 verb,
                 'spock_output'
             );
-            RAISE NOTICE '    ✓ %', rpad('Creating replication slot ' || slot_name || '...', 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Creating replication slot ' || slot_name || '...', 120, ' ');
         END LOOP;
     EXCEPTION
         WHEN OTHERS THEN
@@ -1245,31 +1471,70 @@ BEGIN
     
     -- Check if there are any "other" nodes (not source, not new)
     IF (SELECT count(*) FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name) = 0 THEN
-        RAISE NOTICE '    - No other nodes exist, skipping disabled subscriptions';
+        -- 2-node scenario: trigger sync event on source node and store it
+        BEGIN
+            SELECT * INTO remotesql
+            FROM dblink(src_dsn, 'SELECT spock.sync_event()') AS t(sync_lsn text);
+
+            -- Store the sync LSN for later use when enabling subscriptions
+            INSERT INTO temp_sync_lsns (origin_node, sync_lsn)
+            VALUES (src_node_name, remotesql)
+            ON CONFLICT (origin_node) DO UPDATE SET sync_lsn = EXCLUDED.sync_lsn;
+
+            RAISE NOTICE '    OK: %', rpad('Triggering sync event on node ' || src_node_name || ' (LSN: ' || remotesql || ')', 120, ' ');
+        EXCEPTION
+            WHEN OTHERS THEN
+                RAISE NOTICE '    ✗ %', rpad('Triggering sync event on node ' || src_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+        END;
+
+        RAISE NOTICE '    - 2-node scenario: sync event stored, skipping disabled subscriptions';
         RETURN;
     END IF;
     
+    -- Create temporary table to store sync LSNs
+    CREATE TEMP TABLE IF NOT EXISTS temp_sync_lsns (
+        origin_node text PRIMARY KEY,
+        sync_lsn text NOT NULL
+    );
+
     -- For each "other" node (not source, not new), create disabled subscription and slot
     FOR rec IN SELECT * FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name LOOP
+        -- Trigger sync event on origin node and store LSN
+        BEGIN
+            SELECT * INTO remotesql
+            FROM dblink(rec.dsn, 'SELECT spock.sync_event()') AS t(sync_lsn text);
+
+            -- Store the sync LSN for later use when enabling subscriptions
+            INSERT INTO temp_sync_lsns (origin_node, sync_lsn)
+            VALUES (rec.node_name, remotesql)
+            ON CONFLICT (origin_node) DO UPDATE SET sync_lsn = EXCLUDED.sync_lsn;
+
+            RAISE NOTICE '    OK: %', rpad('Triggering sync event on node ' || rec.node_name || ' (LSN: ' || remotesql || ')', 120, ' ');
+        EXCEPTION
+            WHEN OTHERS THEN
+                RAISE NOTICE '    ✗ %', rpad('Triggering sync event on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+                CONTINUE;
+        END;
+
         -- Create replication slot on the "other" node
         BEGIN
             dbname := substring(rec.dsn from 'dbname=([^\s]+)');
             IF dbname IS NULL THEN dbname := 'pgedge'; END IF;
             slot_name := left('spk_' || dbname || '_' || rec.node_name || '_sub_' || rec.node_name || '_' || new_node_name, 64);
-            
+
             remotesql := format('SELECT slot_name, lsn FROM pg_create_logical_replication_slot(%L, ''spock_output'');', slot_name);
             IF verb THEN
                 RAISE NOTICE '    Remote SQL for slot creation: %', remotesql;
             END IF;
-            
+
             PERFORM * FROM dblink(rec.dsn, remotesql) AS t(slot_name text, lsn pg_lsn);
-            RAISE NOTICE '    ✓ %', rpad('Creating replication slot ' || slot_name || ' on node ' || rec.node_name, 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Creating replication slot ' || slot_name || ' on node ' || rec.node_name, 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
                 RAISE NOTICE '    ✗ %', rpad('Creating replication slot ' || slot_name || ' on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
                 CONTINUE;
         END;
-        
+
         -- Create disabled subscription on new node from "other" node
         BEGIN
             CALL spock.create_sub(
@@ -1285,7 +1550,7 @@ BEGIN
                 false,                                        -- force_text_transfer
                 verb                                          -- verbose
             );
-            RAISE NOTICE '    ✓ %', rpad('Creating initial subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name, 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Creating initial subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name, 120, ' ');
             PERFORM pg_sleep(5);
             subscription_count := subscription_count + 1;
         EXCEPTION
@@ -1325,7 +1590,44 @@ BEGIN
             verb,  -- verb
             true   -- immediate
         );
-            RAISE NOTICE '    ✓ %', rpad('Enabling subscription sub_' || src_node_name || '_' || new_node_name || '...', 120, ' ');
+
+            -- Wait for the sync event that was captured when subscription was created
+            -- This ensures the subscription starts replicating from the correct sync point
+            DECLARE
+                sync_lsn text;
+                timeout_ms integer := 1200;  -- 20 minutes
+            BEGIN
+                -- Get the stored sync LSN from when subscription was created
+                SELECT tsl.sync_lsn INTO sync_lsn
+                FROM temp_sync_lsns tsl
+                WHERE tsl.origin_node = src_node_name;
+
+                IF sync_lsn IS NOT NULL THEN
+                    IF verb THEN
+                        RAISE NOTICE '    OK: %', rpad('Using stored sync event from origin node ' || src_node_name || ' (LSN: ' || sync_lsn || ')...', 120, ' ');
+                    END IF;
+
+                    -- Wait for this sync event on the new node where the subscription exists
+                    CALL dblink(new_node_dsn,
+                        format('CALL spock.wait_for_sync_event(true, %L, %L::pg_lsn, %s)',
+                               src_node_name, sync_lsn, timeout_ms));
+
+                    IF verb THEN
+                        RAISE NOTICE '    OK: %', rpad('Waiting for sync event from ' || src_node_name || ' on new node ' || new_node_name || '...', 120, ' ');
+                    END IF;
+                ELSE
+                    RAISE NOTICE '    WARNING: %', rpad('No stored sync LSN found for ' || src_node_name || ', skipping sync wait', 120, ' ');
+                END IF;
+            END;
+
+            -- Verify subscription is replicating after enabling (2-node scenario)
+            CALL spock.verify_subscription_replicating(
+                new_node_dsn,
+                'sub_' || src_node_name || '_' || new_node_name,
+                verb
+            );
+
+            RAISE NOTICE '    OK: %', rpad('Enabling subscription sub_' || src_node_name || '_' || new_node_name || '...', 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
                 RAISE NOTICE '    ✗ %', rpad('Enabling subscription sub_' || src_node_name || '_' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
@@ -1354,7 +1656,44 @@ BEGIN
                     verb,  -- verb
                     true   -- immediate
                 );
-                RAISE NOTICE '    ✓ %', rpad('Enabling subscription sub_' || rec.node_name || '_' || new_node_name || '...', 120, ' ');
+
+                -- Wait for the sync event that was captured when subscription was created
+                -- This ensures the subscription starts replicating from the correct sync point
+                DECLARE
+                    sync_lsn text;
+                    timeout_ms integer := 1200;  -- 20 minutes
+                BEGIN
+                    -- Get the stored sync LSN from when subscription was created
+                    SELECT tsl.sync_lsn INTO sync_lsn
+                    FROM temp_sync_lsns tsl
+                    WHERE tsl.origin_node = rec.node_name;
+
+                    IF sync_lsn IS NOT NULL THEN
+                        IF verb THEN
+                            RAISE NOTICE '    OK: %', rpad('Using stored sync event from origin node ' || rec.node_name || ' (LSN: ' || sync_lsn || ')...', 120, ' ');
+                        END IF;
+
+                        -- Wait for this sync event on the new node where the subscription exists
+                        CALL dblink(new_node_dsn,
+                            format('CALL spock.wait_for_sync_event(true, %L, %L::pg_lsn, %s)',
+                                   rec.node_name, sync_lsn, timeout_ms));
+
+                        IF verb THEN
+                            RAISE NOTICE '    OK: %', rpad('Waiting for sync event from ' || rec.node_name || ' on new node ' || new_node_name || '...', 120, ' ');
+                        END IF;
+                    ELSE
+                        RAISE NOTICE '    WARNING: %', rpad('No stored sync LSN found for ' || rec.node_name || ', skipping sync wait', 120, ' ');
+                    END IF;
+                END;
+
+                -- Verify subscription is replicating after enabling
+                CALL spock.verify_subscription_replicating(
+                    new_node_dsn,
+                    'sub_'|| rec.node_name || '_' || new_node_name,
+                    verb
+                );
+
+                RAISE NOTICE '    OK: %', rpad('Enabling subscription sub_' || rec.node_name || '_' || new_node_name || '...', 120, ' ');
                 subscription_count := subscription_count + 1;
             END LOOP;
             
@@ -1405,7 +1744,7 @@ BEGIN
                 false,                                        -- force_text_transfer
                 verb                                          -- verbose
             );
-            RAISE NOTICE '    ✓ %', rpad('Creating subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name || '...', 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Creating subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name || '...', 120, ' ');
             PERFORM pg_sleep(5);
             subscription_count := subscription_count + 1;
         EXCEPTION
@@ -1417,7 +1756,7 @@ BEGIN
     IF subscription_count = 0 THEN
         RAISE NOTICE '    - No subscriptions created (no other nodes found)';
     ELSE
-        RAISE NOTICE '    ✓ Created % subscriptions from other nodes to new node', subscription_count;
+        RAISE NOTICE '    OK: Created % subscriptions from other nodes to new node', subscription_count;
     END IF;
 END;
 $$;
@@ -1449,7 +1788,7 @@ BEGIN
         false,   -- force_text_transfer
         verb
     );
-    RAISE NOTICE '    ✓ %', rpad('Creating subscription sub_' || new_node_name || '_' || src_node_name || ' on node ' || new_node_name || '...', 120, ' ');
+    RAISE NOTICE '    OK: %', rpad('Creating subscription sub_' || new_node_name || '_' || src_node_name || ' on node ' || new_node_name || '...', 120, ' ');
     PERFORM pg_sleep(5);
 END;
 $$;
@@ -1481,7 +1820,7 @@ BEGIN
         false,                                        -- force_text_transfer
         verb                                          -- verbose
     );
-    RAISE NOTICE '    ✓ %', rpad('Creating subscription sub_' || src_node_name || '_' || new_node_name || ' on node ' || new_node_name || '...', 120, ' ');
+    RAISE NOTICE '    OK: %', rpad('Creating subscription sub_' || src_node_name || '_' || new_node_name || ' on node ' || new_node_name || '...', 120, ' ');
     PERFORM pg_sleep(5);
 END;
 $$;
@@ -1499,7 +1838,7 @@ CREATE OR REPLACE PROCEDURE spock.trigger_sync_on_other_nodes_and_wait_on_source
 DECLARE
     rec RECORD;
     sync_lsn pg_lsn;
-    timeout_ms integer := 1200000;  -- 20 minutes timeout
+    timeout_ms integer := 1200;  -- 20 minutes timeout
     remotesql text;
 BEGIN
     RAISE NOTICE 'Phase 5: Triggering sync events on other nodes and waiting on source';
@@ -1520,7 +1859,7 @@ BEGIN
             END IF;
             
             SELECT * FROM dblink(rec.dsn, remotesql) AS t(lsn pg_lsn) INTO sync_lsn;
-            RAISE NOTICE '    ✓ %', rpad('Triggering sync event on node ' || rec.node_name || ' (LSN: ' || sync_lsn || ')...', 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Triggering sync event on node ' || rec.node_name || ' (LSN: ' || sync_lsn || ')...', 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
                 RAISE NOTICE '    ✗ %', rpad('Triggering sync event on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
@@ -1536,7 +1875,7 @@ BEGIN
             END IF;
             
             PERFORM * FROM dblink(src_dsn, remotesql) AS t(result text);
-            RAISE NOTICE '    ✓ %', rpad('Waiting for sync event from ' || rec.node_name || ' on source node ' || src_node_name || '...', 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Waiting for sync event from ' || rec.node_name || ' on source node ' || src_node_name || '...', 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
                 RAISE NOTICE '    ✗ %', rpad('Waiting for sync event from ' || rec.node_name || ' on source node ' || src_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
@@ -1583,7 +1922,7 @@ BEGIN
             SELECT * FROM dblink(new_node_dsn, remotesql) AS t(ts timestamp) INTO commit_ts;
             
             IF commit_ts IS NOT NULL THEN
-                RAISE NOTICE '    ✓ %', rpad('Found commit timestamp for ' || rec.node_name || '->' || new_node_name || ': ' || commit_ts, 120, ' ');
+                RAISE NOTICE '    OK: %', rpad('Found commit timestamp for ' || rec.node_name || '->' || new_node_name || ': ' || commit_ts, 120, ' ');
             ELSE
                 RAISE NOTICE '    - %', rpad('No commit timestamp found for ' || rec.node_name || '->' || new_node_name, 120, ' ');
                 CONTINUE;
@@ -1637,7 +1976,7 @@ BEGIN
                 END IF;
                 
                 PERFORM * FROM dblink(rec.dsn, remotesql) AS t(result text);
-                RAISE NOTICE '    ✓ %', rpad('Advanced slot ' || slot_name || ' from ' || current_lsn || ' to ' || target_lsn, 120, ' ');
+                RAISE NOTICE '    OK: %', rpad('Advanced slot ' || slot_name || ' from ' || current_lsn || ' to ' || target_lsn, 120, ' ');
             END;
         EXCEPTION
             WHEN OTHERS THEN
@@ -1679,7 +2018,7 @@ END;
 $$;
 
 -- ============================================================================
--- Procedure to wait for sync on source and new node
+-- Procedure to wait for sync on source and new node using sync_event and wait_for_sync_event
 -- ============================================================================
 CREATE OR REPLACE PROCEDURE spock.wait_for_source_node_sync(
     src_node_name text,
@@ -1691,52 +2030,38 @@ CREATE OR REPLACE PROCEDURE spock.wait_for_source_node_sync(
 ) LANGUAGE plpgsql AS $$
 DECLARE
     remotesql text;
-    sub_name text;
-    sub_slot_name text;
+    sync_lsn pg_lsn;
+    timeout_ms integer := 1200;  -- 20 minutes timeout
 BEGIN
     RAISE NOTICE 'Phase 6: Waiting for sync on source and new node';
-    
-	-- First, get subscription information
+
+    -- Trigger sync event on new node and wait for it on source node
     BEGIN
-        remotesql := format('SELECT s.sub_name, s.sub_slot_name FROM spock.subscription s JOIN spock.node o ON s.sub_origin = o.node_id JOIN spock.node t ON s.sub_target = t.node_id WHERE o.node_name = %L AND t.node_name = %L;',
-                           src_node_name, new_node_name);
-        SELECT t.sub_name, t.sub_slot_name FROM dblink(new_node_dsn, remotesql) AS t(sub_name text, sub_slot_name text) INTO STRICT sub_name, sub_slot_name;
+        remotesql := 'SELECT spock.sync_event();';
+        IF verb THEN
+            RAISE NOTICE '    Remote SQL for sync_event on new node %: %', new_node_name, remotesql;
+        END IF;
+        SELECT * FROM dblink(new_node_dsn, remotesql) AS t(lsn pg_lsn) INTO sync_lsn;
+        RAISE NOTICE '    OK: %', rpad('Triggered sync_event on new node ' || new_node_name || ' (LSN: ' || sync_lsn || ')...', 120, ' ');
     EXCEPTION
         WHEN OTHERS THEN
-            RAISE NOTICE '    ✗ %', rpad('Unable to get subscription information on new node ' || new_node_name  || ' (error: ' || SQLERRM || ')', 120, ' ');
+            RAISE NOTICE '    ✗ %', rpad('Triggering sync_event on new node ' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
             RAISE;
     END;
 
-    -- wait for sync on source node using dblink
+    -- Wait for sync event on source node
     BEGIN
-        remotesql := format('SELECT spock.wait_slot_confirm_lsn(%L, NULL)', sub_slot_name);
+        remotesql := format('CALL spock.wait_for_sync_event(true, %L, %L::pg_lsn, %s);', new_node_name, sync_lsn, timeout_ms);
         IF verb THEN
-			RAISE NOTICE '    Remote SQL for waiting for sync on source node % : %', src_node_name, remotesql;
+            RAISE NOTICE '    Remote SQL for wait_for_sync_event on source node %: %', src_node_name, remotesql;
         END IF;
         PERFORM * FROM dblink(src_dsn, remotesql) AS t(result text);
-		RAISE NOTICE '    ✓ %', rpad('Waiting for sync on source node ' || src_node_name || '...', 120, ' ');
+        RAISE NOTICE '    OK: %', rpad('Waiting for sync event from ' || new_node_name || ' on source node ' || src_node_name || '...', 120, ' ');
     EXCEPTION
         WHEN OTHERS THEN
-            RAISE NOTICE '    ✗ %', rpad('Unable to wait for sync on source node ' || src_node_name || '...', 120, ' ');
+            RAISE NOTICE '    ✗ %', rpad('Unable to wait for sync event from ' || new_node_name || ' on source node ' || src_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
             RAISE;
     END;
-
-	-- for best results enable sync check on new node
-	IF sync_check_on_new_node THEN
-	    -- wait for sync on new node using dblink
-		BEGIN
-			remotesql := format('SELECT spock.sub_wait_for_sync(%L)', sub_name);
-			IF verb THEN
-				RAISE NOTICE '    Remote SQL for waiting for sync on new node % : %', new_node_name, remotesql;
-			END IF;
-			PERFORM * FROM dblink(new_node_dsn, remotesql) AS t(result text);
-			RAISE NOTICE '    ✓ %', rpad('Waiting for sync on new node ' || new_node_name || '...', 120, ' ');
-		EXCEPTION
-		WHEN OTHERS THEN
-			RAISE NOTICE '    ✗ %', rpad('Unable to wait for sync on new node ' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
-			RAISE;
-		END;
-	END IF;
 END;
 $$;
 
@@ -1768,10 +2093,10 @@ BEGIN
         SELECT status INTO sub_status FROM spock.sub_show_status() LIMIT 1;
         
         IF sub_status = 'replicating' THEN
-            RAISE NOTICE '    ✓ Replication is active (status: %)', sub_status;
+            RAISE NOTICE '    OK: Replication is active (status: %)', sub_status;
             EXIT;
         ELSIF wait_count >= max_wait_count THEN
-            RAISE NOTICE '    ⚠ Timeout waiting for replication to be active (current status: %)', sub_status;
+            RAISE NOTICE '    WARNING: Timeout waiting for replication to be active (current status: %)', sub_status;
             EXIT;
         ELSE
             RAISE NOTICE '    Waiting for replication... (status: %, attempt %/%)', sub_status, wait_count, max_wait_count;
@@ -1871,39 +2196,57 @@ $$
 DECLARE
     initial_node_count integer;
 BEGIN
-
-    -- Phase 1: Verify prerequisites (source and new node validation)
+    -- Phase 1: Verify prerequisites for source and new node.
+    -- Example: Ensure n1 (source) and n4 (new) are ready before adding n4 to cluster n1,n2,n3.
     CALL spock.verify_node_prerequisites(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
 
-    -- Phase 2: Create nodes
+    -- Phase 2: Create node objects in the cluster.
+    -- Example: Register n4 as a new node alongside n1, n2, n3.
     CALL spock.create_nodes_only(src_node_name, src_dsn, new_node_name, new_node_dsn, verb, new_node_location, new_node_country, new_node_info, initial_node_count);
 
-    -- Phase 3: Create disabled subscriptions and slots
+    -- Phase 3: Create disabled subscriptions and replication slots.
+    -- Example: Prepare n4 for replication but keep subscriptions disabled initially.
     CALL spock.create_disable_subscriptions_and_slots(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
 
-    -- Phase 4: Create source to new node subscription
-    CALL spock.create_source_to_new_subscription(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
-
-    -- Phase 5: Trigger sync events on other nodes and wait on source
+    -- Phase 4: Trigger sync events on other nodes and wait on source.
+    -- Example: Sync n2 and n3, then wait for n1 to acknowledge before proceeding with n4.
     CALL spock.trigger_sync_on_other_nodes_and_wait_on_source(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
 
-    -- Phase 6: Waiting for sync on source and new node
+    -- Phase 5: Create subscription from source to new node.
+    -- Example: Set up n1 to replicate to n4.
+    CALL spock.create_source_to_new_subscription(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
+
+    -- Phase 6: Wait for sync on source and new node.
+    -- Example: Ensure n1 and n4 are fully synchronized before continuing.
     CALL spock.wait_for_source_node_sync(src_node_name, src_dsn, new_node_name, new_node_dsn, verb, true);
 
-    -- Phase 7: Check commit timestamp and advance replication slot
+    -- Phase 7: Check commit timestamp and advance replication slot.
+    -- Example: Confirm n4 is caught up to n1's latest changes.
     CALL spock.check_commit_timestamp_and_advance_slot(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
 
-    -- Phase 8: Enable disabled subscriptions
+    -- Phase 8: Enable previously disabled subscriptions.
+    -- Example: Activate replication paths for n4.
     CALL spock.enable_disabled_subscriptions(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
 
-    -- Phase 9: Create subscription from new node to source node
+    -- Phase 9: Create subscription from new node to source node.
+    -- Example: Set up n4 to replicate back to n1 for bidirectional sync.
     CALL spock.create_sub_on_new_node_to_src_node(src_node_name, src_dsn, new_node_name, new_node_dsn, verb);
 
-    -- Phase 10: Present final cluster state
+    -- Phase 10: Present final cluster state.
+    -- Example: Show n1, n2, n3, n4 as fully connected and synchronized.
     CALL spock.present_final_cluster_state(initial_node_count, verb);
 
-    -- Phase 11: Monitor replication lag
+    -- Phase 11: Monitor replication lag.
+    -- Example: Check that n4 is keeping up with n1, n2, n3 after joining.
     CALL spock.monitor_replication_lag(src_node_name, new_node_name, new_node_dsn, verb);
+
+    -- Phase 12: Show comprehensive node status across all nodes.
+    -- Example: Display all nodes in n1, n2, n3, n4, n5 cluster.
+    CALL spock.show_all_nodes(src_dsn, verb);
+
+    -- Phase 13: Show comprehensive subscription status across all nodes.
+    -- Example: Display status of all subscriptions in n1, n2, n3, n4, n5 cluster.
+    CALL spock.show_all_subscription_status(src_dsn, verb);
 END;
 $$;
 

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -1425,7 +1425,17 @@ BEGIN
             IF rec.node_name = src_node_name THEN
                 CONTINUE;
             END IF;
-            dbname := substring(rec.dsn from 'dbname=([^\s]+)');
+            -- Extract dbname and handle both quoted and unquoted values
+            -- Extract dbname and handle both quoted and unquoted values
+        dbname := substring(rec.dsn from 'dbname=([^\s]+)');
+        -- Remove single quotes if present
+        IF dbname IS NOT NULL THEN
+            dbname := TRIM(BOTH '''' FROM dbname);
+        END IF;
+            -- Remove single quotes if present
+            IF dbname IS NOT NULL THEN
+                dbname := TRIM(BOTH '''' FROM dbname);
+            END IF;
             IF dbname IS NULL THEN
                 dbname := 'pgedge';
             END IF;
@@ -1518,7 +1528,17 @@ BEGIN
 
         -- Create replication slot on the "other" node
         BEGIN
-            dbname := substring(rec.dsn from 'dbname=([^\s]+)');
+            -- Extract dbname and handle both quoted and unquoted values
+            -- Extract dbname and handle both quoted and unquoted values
+        dbname := substring(rec.dsn from 'dbname=([^\s]+)');
+        -- Remove single quotes if present
+        IF dbname IS NOT NULL THEN
+            dbname := TRIM(BOTH '''' FROM dbname);
+        END IF;
+            -- Remove single quotes if present
+            IF dbname IS NOT NULL THEN
+                dbname := TRIM(BOTH '''' FROM dbname);
+            END IF;
             IF dbname IS NULL THEN dbname := 'pgedge'; END IF;
             slot_name := left('spk_' || dbname || '_' || rec.node_name || '_sub_' || rec.node_name || '_' || new_node_name, 64);
 
@@ -1950,7 +1970,17 @@ BEGIN
         
         -- Advance replication slot based on commit timestamp
         BEGIN
-            dbname := substring(rec.dsn from 'dbname=([^\s]+)');
+            -- Extract dbname and handle both quoted and unquoted values
+            -- Extract dbname and handle both quoted and unquoted values
+        dbname := substring(rec.dsn from 'dbname=([^\s]+)');
+        -- Remove single quotes if present
+        IF dbname IS NOT NULL THEN
+            dbname := TRIM(BOTH '''' FROM dbname);
+        END IF;
+            -- Remove single quotes if present
+            IF dbname IS NOT NULL THEN
+                dbname := TRIM(BOTH '''' FROM dbname);
+            END IF;
             IF dbname IS NULL THEN dbname := 'pgedge'; END IF;
             slot_name := left('spk_' || dbname || '_' || rec.node_name || '_sub_' || rec.node_name || '_' || new_node_name, 64);
             

--- a/samples/Z0DAN/zodrn.py
+++ b/samples/Z0DAN/zodrn.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+ZODRN - Spock Node Removal Tool (Python Version)
+100% matches zodrn.sql functionality but uses direct psql connections instead of dblink.
+
+This script provides all the same procedures and functionality as zodrn.sql:
+- remove_node: Complete node removal with all 7 phases
+- Schema detection and skipping functionality
+- All validation, removal, and monitoring procedures
+- Error handling and verbose logging
+
+Usage:
+    python zodrn.py remove_node --target-node-name n4 --target-node-dsn "host=127.0.0.1 dbname=pgedge port=5434 user=pgedge password=pgedge" --verbose
+"""
+
+import subprocess
+import json
+import time
+import sys
+from typing import List, Dict, Any, Optional, Tuple
+import argparse
+import re
+
+class SpockClusterManager:
+    def __init__(self, verbose: bool = False):
+        self.verbose = verbose
+
+    def log(self, msg: str):
+        """Log a message with timestamp"""
+        print(f"[LOG] {msg}")
+
+    def info(self, msg: str):
+        """Log an info message"""
+        print(f"[INFO] {msg}")
+
+    def notice(self, msg: str):
+        """Log a notice message (matches PostgreSQL NOTICE)"""
+        print(f"NOTICE: {msg}")
+
+    def format_notice(self, status: str, message: str, node: str = None):
+        """Format notice message like zodrn.sql: ✓/✗ datetime [node] : message"""
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        if node:
+            formatted_msg = f"{status} {timestamp} [{node}] : {message}"
+        else:
+            formatted_msg = f"{status} {timestamp} : {message}"
+        self.notice(formatted_msg)
+
+    def run_psql(self, dsn: str, sql: str, fetch: bool = False, return_single: bool = False) -> Optional[Any]:
+        """
+        Runs a SQL command using psql and returns results.
+
+        Args:
+            dsn: Database connection string
+            sql: SQL command to execute
+            fetch: Whether to return results as list of dicts
+            return_single: If fetch=True, return single value instead of list
+        """
+        cmd = [
+            "psql",
+            dsn,
+            "-X",
+            "-A",
+            "-t",
+            "-c",
+            sql
+        ]
+
+        if self.verbose:
+            self.info(f"Running SQL on DSN: {dsn}")
+            self.info(f"SQL: {sql}")
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            self.log(f"SQL failed: {result.stderr.strip()}")
+            return None
+
+        if fetch:
+            lines = [line.strip() for line in result.stdout.strip().split('\n') if line.strip()]
+            if not lines:
+                return [] if not return_single else None
+
+            if return_single:
+                return lines[0] if lines else None
+
+            # Parse results as list of dicts
+            # This is a simplified parser - in practice you'd need to know column names
+            return lines
+
+        return None
+
+    def get_spock_nodes(self, dsn: str) -> List[Dict[str, Any]]:
+        """Retrieve all Spock nodes and their DSNs from a remote cluster"""
+        sql = """
+        SELECT n.node_id, n.node_name, n.location, n.country, n.info, i.if_dsn
+        FROM spock.node n
+        JOIN spock.node_interface i ON n.node_id = i.if_nodeid
+        ORDER BY n.node_id;
+        """
+
+        if self.verbose:
+            self.info("[STEP] get_spock_nodes: Retrieved nodes from remote DSN: " + dsn)
+            self.info("[QUERY] SELECT n.node_id, n.node_name, n.location, n.country, n.info, i.if_dsn FROM spock.node n JOIN spock.node_interface i ON n.node_id = i.if_nodeid")
+
+        cmd = [
+            "psql",
+            dsn,
+            "-X",
+            "-A",
+            "-F", "|",
+            "-t",
+            "-c",
+            sql
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            self.log("[STEP] Failed to fetch nodes.")
+            return []
+
+        lines = [line.strip() for line in result.stdout.strip().split('\n') if line.strip()]
+        columns = ["node_id", "node_name", "location", "country", "info", "dsn"]
+        rows = []
+
+        for line in lines:
+            values = line.split("|")
+            if len(values) == len(columns):
+                row = dict(zip(columns, values))
+                rows.append(row)
+
+        if self.verbose:
+            self.info(f"Retrieved {len(rows)} nodes from remote cluster")
+
+        return rows
+
+    def check_component_exists(self, dsn: str, component_type: str, component_name: str) -> bool:
+        """Check if a component exists on a node"""
+        queries = {
+            'node': f"SELECT EXISTS (SELECT 1 FROM spock.node WHERE node_name = '{component_name}')",
+            'subscription': f"SELECT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = '{component_name}')",
+            'repset': f"SELECT EXISTS (SELECT 1 FROM spock.replication_set WHERE set_name = '{component_name}')",
+            'slot': f"SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{component_name}')"
+        }
+
+        if component_type not in queries:
+            return False
+
+        sql = queries[component_type]
+        result = self.run_psql(dsn, sql, fetch=True, return_single=True)
+
+        if result and result.strip() == 't':
+            return True
+        return False
+
+    def get_node_repsets(self, target_node_name: str, dsn: str) -> List[str]:
+        """Get all replication sets for a node"""
+        sql = f"""
+        SELECT DISTINCT rs.set_name::text
+        FROM spock.node n
+        JOIN spock.subscription sub ON sub.sub_provider = n.node_id
+        JOIN spock.subscription_replication_set sub_rs ON sub_rs.srs_s_id = sub.sub_id
+        JOIN spock.replication_set rs ON rs.set_id = sub_rs.srs_set_id
+        WHERE n.node_name = '{target_node_name}';
+        """
+
+        result = self.run_psql(dsn, sql, fetch=True)
+        return [line.strip() for line in result] if result else []
+
+    def get_node_subscriptions(self, target_node_name: str, dsn: str) -> List[str]:
+        """Get all subscriptions for a node"""
+        sql = f"""
+        SELECT sub.sub_name::text
+        FROM spock.node n
+        JOIN spock.subscription sub ON sub.sub_provider = n.node_id
+        WHERE n.node_name = '{target_node_name}';
+        """
+
+        result = self.run_psql(dsn, sql, fetch=True)
+        return [line.strip() for line in result] if result else []
+
+    def get_node_slots(self, target_node_name: str, dsn: str) -> List[str]:
+        """Get all replication slots for a node"""
+        sql = f"""
+        SELECT slot_name::text
+        FROM spock.node n
+        JOIN spock.subscription sub ON sub.sub_provider = n.node_id
+        WHERE n.node_name = '{target_node_name}';
+        """
+
+        result = self.run_psql(dsn, sql, fetch=True)
+        return [line.strip() for line in result] if result else []
+
+    def validate_node_removal_prerequisites(self, target_node_name: str, target_node_dsn: str):
+        """Phase 1: Validate node removal prerequisites"""
+        self.notice("Phase 1: Validating node removal prerequisites")
+
+        # Check if node exists
+        if not self.check_component_exists(target_node_dsn, 'node', target_node_name):
+            self.format_notice("✗", f"Node '{target_node_name}' does not exist")
+            raise Exception(f"Node {target_node_name} does not exist")
+
+        # Get total node count
+        sql = "SELECT count(*) FROM spock.node;"
+        node_count = self.run_psql(target_node_dsn, sql, fetch=True, return_single=True)
+
+        if node_count:
+            count = int(node_count.strip())
+            self.format_notice("✓", f"Node '{target_node_name}' exists in cluster")
+            self.format_notice("✓", f"Total nodes in cluster: {count}")
+
+            if count <= 1:
+                self.format_notice("✗", "Cannot remove the last node from cluster")
+                raise Exception("Cannot remove the last node from cluster")
+        else:
+            self.format_notice("✗", "Failed to get node count")
+            raise Exception("Failed to validate cluster state")
+
+        self.format_notice("✓", "Node removal validation passed")
+
+    def gather_cluster_info_for_removal(self, target_node_name: str, target_node_dsn: str):
+        """Phase 2: Gather cluster information for removal"""
+        self.notice("Phase 2: Gathering cluster information")
+
+        # Get all nodes except the target
+        nodes = self.get_spock_nodes(target_node_dsn)
+        other_nodes = [node for node in nodes if node['node_name'] != target_node_name]
+
+        self.format_notice("✓", f"Gathered information for {len(other_nodes)} nodes")
+        self.format_notice("✓", "Cluster information ready for node removal")
+
+        return other_nodes
+
+    def remove_node_replication_sets(self, target_node_name: str, target_node_dsn: str):
+        """Phase 3: Remove replication sets"""
+        self.notice("Phase 3: Removing replication sets")
+
+        repsets = self.get_node_repsets(target_node_name, target_node_dsn)
+
+        for repset_name in repsets:
+            try:
+                if self.verbose:
+                    self.info(f"Checking replication set: {repset_name}")
+
+                # Check if repset exists
+                if self.check_component_exists(target_node_dsn, 'repset', repset_name):
+                    # Remove repset
+                    sql = f"SELECT spock.repset_drop('{repset_name}', true);"
+                    self.run_psql(target_node_dsn, sql)
+                    self.format_notice("✓", f"Removed replication set '{repset_name}'")
+                else:
+                    self.format_notice("-", f"Replication set '{repset_name}' not found")
+            except Exception as e:
+                self.format_notice("✗", f"Error removing replication set '{repset_name}': {str(e)}")
+
+        self.format_notice("✓", "Replication set removal phase completed")
+
+    def remove_node_subscriptions(self, target_node_name: str, target_node_dsn: str):
+        """Phase 4: Remove subscriptions"""
+        self.notice("Phase 4: Removing subscriptions")
+
+        subscriptions = self.get_node_subscriptions(target_node_name, target_node_dsn)
+
+        for sub_name in subscriptions:
+            try:
+                if self.verbose:
+                    self.info(f"Checking subscription: {sub_name}")
+
+                # Check if subscription exists
+                if self.check_component_exists(target_node_dsn, 'subscription', sub_name):
+                    # Remove subscription
+                    sql = f"SELECT spock.sub_drop('{sub_name}', true);"
+                    self.run_psql(target_node_dsn, sql)
+                    self.format_notice("✓", f"Removed subscription '{sub_name}'")
+                else:
+                    self.format_notice("-", f"Subscription '{sub_name}' not found")
+            except Exception as e:
+                self.format_notice("✗", f"Error removing subscription '{sub_name}': {str(e)}")
+
+        self.format_notice("✓", "Subscription removal phase completed")
+
+    def remove_node_replication_slots(self, target_node_name: str, target_node_dsn: str):
+        """Phase 5: Remove replication slots"""
+        self.notice("Phase 5: Removing replication slots")
+
+        slots = self.get_node_slots(target_node_name, target_node_dsn)
+
+        for slot_name in slots:
+            try:
+                if self.verbose:
+                    self.info(f"Checking replication slot: {slot_name}")
+
+                # Check if slot exists
+                if self.check_component_exists(target_node_dsn, 'slot', slot_name):
+                    # Remove slot
+                    sql = f"SELECT pg_drop_replication_slot('{slot_name}');"
+                    self.run_psql(target_node_dsn, sql)
+                    self.format_notice("✓", f"Removed replication slot '{slot_name}'")
+                else:
+                    self.format_notice("-", f"Replication slot '{slot_name}' not found")
+            except Exception as e:
+                self.format_notice("✗", f"Error removing replication slot '{slot_name}': {str(e)}")
+
+        self.format_notice("✓", "Replication slot removal phase completed")
+
+    def remove_node_from_cluster_registry(self, target_node_name: str, target_node_dsn: str):
+        """Phase 6: Remove node from cluster registry"""
+        self.notice("Phase 6: Removing node from cluster registry")
+
+        try:
+            # Check if node exists before removal
+            if self.check_component_exists(target_node_dsn, 'node', target_node_name):
+                # Remove node from cluster
+                sql = f"SELECT spock.node_drop('{target_node_name}', true);"
+                self.run_psql(target_node_dsn, sql)
+                self.format_notice("✓", f"Removed node '{target_node_name}' from cluster")
+            else:
+                self.format_notice("-", f"Node '{target_node_name}' not found in cluster")
+        except Exception as e:
+            self.format_notice("✗", f"Error removing node '{target_node_name}': {str(e)}")
+
+        self.format_notice("✓", "Node removal phase completed")
+
+    def finalize_node_removal(self, target_node_name: str, target_node_dsn: str):
+        """Phase 7: Final cleanup and status report"""
+        self.notice("Phase 7: Final cleanup and status report")
+
+        # Get final cluster state
+        nodes = self.get_spock_nodes(target_node_dsn)
+        remaining_nodes = [node for node in nodes if node['node_name'] != target_node_name]
+
+        self.notice("NODE REMOVAL SUMMARY")
+        self.format_notice("✓", f"Node removed: {target_node_name}")
+        self.format_notice("✓", f"Remaining nodes in cluster: {len(remaining_nodes)}")
+
+        for node in remaining_nodes:
+            self.format_notice("✓", f"Active node: {node['node_name']}")
+
+        self.format_notice("✓", "Node removal process completed")
+
+    def remove_node(self, target_node_name: str, target_node_dsn: str):
+        """Main remove_node procedure - matches zodrn.sql exactly"""
+        self.notice(f"STARTING NODE REMOVAL PROCESS")
+        self.notice(f"Node: {target_node_name}")
+
+        try:
+            # Phase 1: Validate prerequisites
+            self.validate_node_removal_prerequisites(target_node_name, target_node_dsn)
+
+            # Phase 2: Gather cluster information
+            cluster_info = self.gather_cluster_info_for_removal(target_node_name, target_node_dsn)
+
+            # Phase 3: Remove replication sets
+            self.remove_node_replication_sets(target_node_name, target_node_dsn)
+
+            # Phase 4: Remove subscriptions
+            self.remove_node_subscriptions(target_node_name, target_node_dsn)
+
+            # Phase 5: Remove replication slots
+            self.remove_node_replication_slots(target_node_name, target_node_dsn)
+
+            # Phase 6: Remove node from cluster registry
+            self.remove_node_from_cluster_registry(target_node_name, target_node_dsn)
+
+            # Phase 7: Final cleanup and status report
+            self.finalize_node_removal(target_node_name, target_node_dsn)
+
+            self.notice("")
+            self.notice("✅ Node removal completed successfully!")
+
+        except Exception as e:
+            self.format_notice("✗", f"Node removal failed: {str(e)}")
+            raise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ZODRN - Spock Node Removal Tool (Python Version)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python zodrn.py remove_node --target-node-name n4 --target-node-dsn "host=127.0.0.1 dbname=pgedge port=5434 user=pgedge password=pgedge" --verbose
+
+Arguments:
+  --target-node-name    Name of the node to remove (e.g., n4)
+  --target-node-dsn     DSN of the node to remove
+  --verbose            Enable verbose logging
+        """
+    )
+
+    parser.add_argument("command", choices=["remove_node"], help="Command to execute")
+    parser.add_argument("--target-node-name", required=True, help="Name of the node to remove")
+    parser.add_argument("--target-node-dsn", required=True, help="DSN of the node to remove")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+
+    args = parser.parse_args()
+
+    # Create cluster manager
+    manager = SpockClusterManager(verbose=args.verbose)
+
+    try:
+        if args.command == "remove_node":
+            manager.remove_node(args.target_node_name, args.target_node_dsn)
+        else:
+            parser.print_help()
+
+    except Exception as e:
+        manager.log(f"Command failed: {str(e)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/Z0DAN/zodrn.sql
+++ b/samples/Z0DAN/zodrn.sql
@@ -1,0 +1,538 @@
+-- ============================================================================
+-- ZODAN - Node Removal Script (zodrn.sql)
+-- Purpose: Systematically remove a node from Spock cluster
+-- Order: repset -> subscription -> slots -> node
+-- ============================================================================
+
+-- Enable dblink extension if not already enabled
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+-- ============================================================================
+-- Temporary table for tracking removal status
+-- ============================================================================
+CREATE TEMP TABLE IF NOT EXISTS temp_removal_status (
+    component_type text,
+    component_name text,
+    status text,
+    message text,
+    removed_at timestamp DEFAULT now()
+);
+
+-- ============================================================================
+-- Temporary table to store spock nodes information
+-- ============================================================================
+CREATE TEMP TABLE IF NOT EXISTS temp_spock_nodes (
+    node_id integer,
+    node_name text,
+    location text,
+    country text,
+    info text,
+    dsn text
+);
+
+-- ============================================================================
+-- Temporary table to store sync events information
+-- ============================================================================
+CREATE TEMP TABLE IF NOT EXISTS temp_sync_events (
+    node_name text,
+    sync_lsn pg_lsn
+);
+
+-- ============================================================================
+-- Function to check if replication set exists on a node
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.check_repset_exists_on_node(
+    node_dsn text,
+    repset_name text
+) RETURNS boolean AS $$
+DECLARE
+    result boolean := false;
+    remotesql text;
+BEGIN
+    remotesql := format('SELECT EXISTS (SELECT 1 FROM spock.replication_set WHERE set_name = %L)', repset_name);
+    SELECT * FROM dblink(node_dsn, remotesql) AS t(exists boolean) INTO result;
+    RETURN result;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN false;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Function to check if subscription exists on a node
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.check_subscription_exists_on_node(
+    node_dsn text,
+    subscription_name text
+) RETURNS boolean AS $$
+DECLARE
+    result boolean := false;
+    remotesql text;
+BEGIN
+    remotesql := format('SELECT EXISTS (SELECT 1 FROM spock.subscription WHERE sub_name = %L)', subscription_name);
+    SELECT * FROM dblink(node_dsn, remotesql) AS t(exists boolean) INTO result;
+    RETURN result;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN false;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Function to check if replication slot exists on a node
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.check_slot_exists_on_node(
+    node_dsn text,
+    slot_name text
+) RETURNS boolean AS $$
+DECLARE
+    result boolean := false;
+    remotesql text;
+BEGIN
+    remotesql := format('SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = %L)', slot_name);
+    SELECT * FROM dblink(node_dsn, remotesql) AS t(exists boolean) INTO result;
+    RETURN result;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN false;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Function to check if node exists in cluster
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.check_node_exists(
+    node_name text
+) RETURNS boolean AS $$
+BEGIN
+    RETURN EXISTS (SELECT 1 FROM spock.node WHERE node_name = check_node_exists.node_name);
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN false;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Function to get all replication sets for a node
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.get_node_repsets(
+    node_name text
+) RETURNS TABLE(repset_name text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT rs.set_name::text
+    FROM spock.node n
+    JOIN spock.subscription sub ON sub.sub_provider = n.node_id
+    JOIN spock.subscription_replication_set sub_rs ON sub_rs.srs_s_id = sub.sub_id
+    JOIN spock.replication_set rs ON rs.set_id = sub_rs.srs_set_id
+    WHERE n.node_name = get_node_repsets.node_name;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Function to get all subscriptions for a node
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.get_node_subscriptions(
+    node_name text
+) RETURNS TABLE(subscription_name text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT sub.sub_name::text
+    FROM spock.node n
+    JOIN spock.subscription sub ON sub.sub_provider = n.node_id
+    WHERE n.node_name = get_node_subscriptions.node_name;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Function to get all replication slots for a node
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.get_node_slots(
+    node_name text
+) RETURNS TABLE(slot_name text) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT slot_name::text
+    FROM spock.node n
+    JOIN spock.subscription sub ON sub.sub_provider = n.node_id
+    WHERE n.node_name = get_node_slots.node_name;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 1: Validate node removal prerequisites
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.validate_node_removal_prerequisites(
+    target_node_name text,    -- Name of the node to remove
+    target_node_dsn text,     -- DSN of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    node_count integer;
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 1: Validating node removal prerequisites';
+    END IF;
+
+    -- Check if node exists in cluster
+    IF NOT spock.check_node_exists(target_node_name) THEN
+        RAISE EXCEPTION 'Node % does not exist in cluster', target_node_name;
+    END IF;
+
+    -- Get total node count in cluster
+    SELECT count(*) INTO node_count FROM spock.node;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Node % exists in cluster', target_node_name;
+        RAISE NOTICE '    ✓ Total nodes in cluster: %', node_count;
+    END IF;
+
+    -- Validate that we're not trying to remove the last node
+    IF node_count <= 1 THEN
+        RAISE EXCEPTION 'Cannot remove the last node from cluster';
+    END IF;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Node removal validation passed';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 2: Gather cluster information
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.gather_cluster_info_for_removal(
+    target_node_name text,    -- Name of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 2: Gathering cluster information';
+    END IF;
+
+    -- Clear existing temp tables
+    TRUNCATE temp_spock_nodes, temp_removal_status, temp_sync_events;
+
+    -- Gather all nodes in cluster except the target node
+    INSERT INTO temp_spock_nodes (node_id, node_name, location, country, info, dsn)
+    SELECT n.node_id, n.node_name, n.location, n.country, n.info, ni.dsn
+    FROM spock.node n
+    JOIN spock.node_interface ni ON ni.if_nodeid = n.node_id
+    WHERE n.node_name != target_node_name;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Gathered information for % nodes', (SELECT count(*) FROM temp_spock_nodes);
+        RAISE NOTICE '    ✓ Cluster information ready for node removal';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 3: Remove replication sets
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.remove_node_replication_sets(
+    target_node_name text,    -- Name of the node to remove
+    target_node_dsn text,     -- DSN of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    repset_rec RECORD;
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 3: Removing replication sets';
+    END IF;
+
+    FOR repset_rec IN SELECT * FROM spock.get_node_repsets(target_node_name) LOOP
+        BEGIN
+            IF verbose THEN
+                RAISE NOTICE '  Checking replication set: %', repset_rec.repset_name;
+            END IF;
+
+            -- Check if repset exists on target node
+            IF spock.check_repset_exists_on_node(target_node_dsn, repset_rec.repset_name) THEN
+                -- Remove repset from target node
+                PERFORM spock.repset_drop(repset_rec.repset_name, true);
+
+                INSERT INTO temp_removal_status (component_type, component_name, status, message)
+                VALUES ('repset', repset_rec.repset_name, 'REMOVED', 'Successfully removed from target node');
+
+                IF verbose THEN
+                    RAISE NOTICE '    ✓ Removed replication set: %', repset_rec.repset_name;
+                END IF;
+            ELSE
+                INSERT INTO temp_removal_status (component_type, component_name, status, message)
+                VALUES ('repset', repset_rec.repset_name, 'NOT_FOUND', 'Replication set not found on target node');
+
+                IF verbose THEN
+                    RAISE NOTICE '    - Replication set % not found on target node', repset_rec.repset_name;
+                END IF;
+            END IF;
+
+        EXCEPTION WHEN OTHERS THEN
+            INSERT INTO temp_removal_status (component_type, component_name, status, message)
+            VALUES ('repset', repset_rec.repset_name, 'ERROR', SQLERRM);
+
+            IF verbose THEN
+                RAISE NOTICE '    ✗ Error removing replication set %: %', repset_rec.repset_name, SQLERRM;
+            END IF;
+        END;
+    END LOOP;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Replication set removal phase completed';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 4: Remove subscriptions
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.remove_node_subscriptions(
+    target_node_name text,    -- Name of the node to remove
+    target_node_dsn text,     -- DSN of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    sub_rec RECORD;
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 4: Removing subscriptions';
+    END IF;
+
+    FOR sub_rec IN SELECT * FROM spock.get_node_subscriptions(target_node_name) LOOP
+        BEGIN
+            IF verbose THEN
+                RAISE NOTICE '  Checking subscription: %', sub_rec.subscription_name;
+            END IF;
+
+            -- Check if subscription exists on target node
+            IF spock.check_subscription_exists_on_node(target_node_dsn, sub_rec.subscription_name) THEN
+                -- Remove subscription from target node
+                PERFORM spock.sub_drop(sub_rec.subscription_name, true);
+
+                INSERT INTO temp_removal_status (component_type, component_name, status, message)
+                VALUES ('subscription', sub_rec.subscription_name, 'REMOVED', 'Successfully removed from target node');
+
+                IF verbose THEN
+                    RAISE NOTICE '    ✓ Removed subscription: %', sub_rec.subscription_name;
+                END IF;
+            ELSE
+                INSERT INTO temp_removal_status (component_type, component_name, status, message)
+                VALUES ('subscription', sub_rec.subscription_name, 'NOT_FOUND', 'Subscription not found on target node');
+
+                IF verbose THEN
+                    RAISE NOTICE '    - Subscription % not found on target node', sub_rec.subscription_name;
+                END IF;
+            END IF;
+
+        EXCEPTION WHEN OTHERS THEN
+            INSERT INTO temp_removal_status (component_type, component_name, status, message)
+            VALUES ('subscription', sub_rec.subscription_name, 'ERROR', SQLERRM);
+
+            IF verbose THEN
+                RAISE NOTICE '    ✗ Error removing subscription %: %', sub_rec.subscription_name, SQLERRM;
+            END IF;
+        END;
+    END LOOP;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Subscription removal phase completed';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 5: Remove replication slots
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.remove_node_replication_slots(
+    target_node_name text,    -- Name of the node to remove
+    target_node_dsn text,     -- DSN of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    slot_rec RECORD;
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 5: Removing replication slots';
+    END IF;
+
+    FOR slot_rec IN SELECT * FROM spock.get_node_slots(target_node_name) LOOP
+        BEGIN
+            IF verbose THEN
+                RAISE NOTICE '  Checking replication slot: %', slot_rec.slot_name;
+            END IF;
+
+            -- Check if slot exists on target node
+            IF spock.check_slot_exists_on_node(target_node_dsn, slot_rec.slot_name) THEN
+                -- Remove slot from target node via dblink
+                PERFORM dblink_exec(target_node_dsn,
+                    format('SELECT pg_drop_replication_slot(%L)', slot_rec.slot_name));
+
+                INSERT INTO temp_removal_status (component_type, component_name, status, message)
+                VALUES ('slot', slot_rec.slot_name, 'REMOVED', 'Successfully removed from target node');
+
+                IF verbose THEN
+                    RAISE NOTICE '    ✓ Removed replication slot: %', slot_rec.slot_name;
+                END IF;
+            ELSE
+                INSERT INTO temp_removal_status (component_type, component_name, status, message)
+                VALUES ('slot', slot_rec.slot_name, 'NOT_FOUND', 'Replication slot not found on target node');
+
+                IF verbose THEN
+                    RAISE NOTICE '    - Replication slot % not found on target node', slot_rec.slot_name;
+                END IF;
+            END IF;
+
+        EXCEPTION WHEN OTHERS THEN
+            INSERT INTO temp_removal_status (component_type, component_name, status, message)
+            VALUES ('slot', slot_rec.slot_name, 'ERROR', SQLERRM);
+
+            IF verbose THEN
+                RAISE NOTICE '    ✗ Error removing replication slot %: %', slot_rec.slot_name, SQLERRM;
+            END IF;
+        END;
+    END LOOP;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Replication slot removal phase completed';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 6: Remove node from cluster
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.remove_node_from_cluster_registry(
+    target_node_name text,    -- Name of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 6: Removing node from cluster registry';
+    END IF;
+
+    BEGIN
+        IF spock.check_node_exists(target_node_name) THEN
+            -- Remove node from cluster
+            PERFORM spock.node_drop(target_node_name, true);
+
+            INSERT INTO temp_removal_status (component_type, component_name, status, message)
+            VALUES ('node', target_node_name, 'REMOVED', 'Successfully removed from cluster');
+
+            IF verbose THEN
+                RAISE NOTICE '    ✓ Removed node: %', target_node_name;
+            END IF;
+        ELSE
+            INSERT INTO temp_removal_status (component_type, component_name, status, message)
+            VALUES ('node', target_node_name, 'NOT_FOUND', 'Node not found in cluster');
+
+            IF verbose THEN
+                RAISE NOTICE '    - Node % not found in cluster', target_node_name;
+            END IF;
+        END IF;
+
+    EXCEPTION WHEN OTHERS THEN
+        INSERT INTO temp_removal_status (component_type, component_name, status, message)
+        VALUES ('node', target_node_name, 'ERROR', SQLERRM);
+
+        IF verbose THEN
+            RAISE NOTICE '    ✗ Error removing node %: %', target_node_name, SQLERRM;
+        END IF;
+    END;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Node removal phase completed';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Phase 7: Final cleanup and status report
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.finalize_node_removal(
+    target_node_name text,    -- Name of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+DECLARE
+    total_processed integer;
+    successfully_removed integer;
+    errors_encountered integer;
+    status_rec RECORD;
+BEGIN
+    IF verbose THEN
+        RAISE NOTICE 'Phase 7: Final cleanup and status report';
+    END IF;
+
+    -- Calculate summary statistics
+    SELECT count(*), count(*) FILTER (WHERE status = 'REMOVED'), count(*) FILTER (WHERE status = 'ERROR')
+    INTO total_processed, successfully_removed, errors_encountered
+    FROM temp_removal_status;
+
+    -- Display summary
+    IF verbose THEN
+        RAISE NOTICE 'NODE REMOVAL SUMMARY';
+        RAISE NOTICE 'Node removed: %', target_node_name;
+        RAISE NOTICE 'Total components processed: %', total_processed;
+        RAISE NOTICE 'Successfully removed: %', successfully_removed;
+        RAISE NOTICE 'Errors encountered: %', errors_encountered;
+
+        -- Show detailed status
+        RAISE NOTICE 'Detailed Status:';
+        FOR status_rec IN SELECT * FROM temp_removal_status ORDER BY removed_at LOOP
+            RAISE NOTICE '  %: % - % - %', status_rec.component_type, status_rec.component_name, status_rec.status, status_rec.message;
+        END LOOP;
+    END IF;
+
+    IF verbose THEN
+        RAISE NOTICE '    ✓ Node removal process completed';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- Main procedure: Remove node from Spock cluster (Phase-based approach)
+-- Each phase includes a 2-line description and an example for n1,n2,n3,n4 removing n4
+-- ============================================================================
+CREATE OR REPLACE PROCEDURE spock.remove_node(
+    target_node_name text,    -- Name of the node to remove
+    target_node_dsn text,     -- DSN of the node to remove
+    verbose boolean DEFAULT true
+) LANGUAGE plpgsql AS $$
+BEGIN
+    -- Phase 1: Validate prerequisites.
+    -- Ensure node n4 is eligible for removal (e.g., not a provider for others).
+    -- Example: Check n4 is safe to remove from cluster n1,n2,n3,n4.
+    CALL spock.validate_node_removal_prerequisites(target_node_name, target_node_dsn, verbose);
+
+    -- Phase 2: Gather cluster information.
+    -- Collect all relevant cluster metadata and dependencies for n4.
+    -- Example: Gather info about n4's subscriptions, slots, and sets in n1,n2,n3,n4.
+    CALL spock.gather_cluster_info_for_removal(target_node_name, verbose);
+
+    -- Phase 3: Remove replication sets.
+    -- Drop replication sets associated with n4 to prevent further data flow.
+    -- Example: Remove n4's replication sets from cluster n1,n2,n3,n4.
+    CALL spock.remove_node_replication_sets(target_node_name, target_node_dsn, verbose);
+
+    -- Phase 4: Remove subscriptions.
+    -- Unsubscribe n4 from all providers and remove its own subscriptions.
+    -- Example: Remove all subscriptions to and from n4 in n1,n2,n3,n4.
+    CALL spock.remove_node_subscriptions(target_node_name, target_node_dsn, verbose);
+
+    -- Phase 5: Remove replication slots.
+    -- Drop replication slots for n4 to clean up WAL sender resources.
+    -- Example: Remove n4's replication slots from all nodes in n1,n2,n3,n4.
+    CALL spock.remove_node_replication_slots(target_node_name, target_node_dsn, verbose);
+
+    -- Phase 6: Remove node from cluster registry.
+    -- Delete n4 from the Spock node registry so it is no longer part of the cluster.
+    -- Example: Remove n4 from the node list in n1,n2,n3,n4.
+    CALL spock.remove_node_from_cluster_registry(target_node_name, verbose);
+
+    -- Phase 7: Final cleanup and status report.
+    -- Summarize the removal process and report any errors or issues.
+    -- Example: Show summary of n4 removal from cluster n1,n2,n3,n4.
+    CALL spock.finalize_node_removal(target_node_name, verbose);
+
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
SPOC-218: Add health-check command to ZODAN for pre and post validation

- Implement health-check command similar to pg_upgrade -c option
- Add --check-type flag with 'pre' (before add_node) and 'post' (after add_node) options
- Pre-check validates: version compatibility, connectivity, extensions, database emptiness
- Post-check validates: replication status, active subscriptions, new node integration
- Output shows clear PASS/FAIL for each check with summary
- Exit code 0 if all checks pass, 1 if any fail
- Prevents runtime errors by validating cluster readiness before node addition
- Fix run_query to run_psql method calls for compatibility