### PR TITLE
fix: guard NULL from spock_relation_open() and fail with clear error

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1803,6 +1803,11 @@ handle_truncate(StringInfo s)
 		Oid			relid = lfirst_oid(lc);
 
 		rel = spock_relation_open(relid, lockmode);
+		if (rel == NULL)
+			ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_TABLE),
+					 errmsg("Spock can't find relation with oid %u", relid)));
+
 		errcallback_arg.rel = rel;
 
 		/* If in list of relations which are being synchronized, skip. */

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -678,6 +678,12 @@ copy_table_data(PGconn *origin_conn, PGconn *target_conn,
 	oldctx = MemoryContextSwitchTo(curctx);
 	spock_relation_cache_updater(remoterel);
 	rel = spock_relation_open(remoterel->relid, AccessShareLock);
+	if (rel == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("relation \"%s.%s\" does not exist",
+						remoterel->nspname, remoterel->relname)));
+
 	attnamelist = make_copy_attnamelist(rel);
 
 	initStringInfo(&attlist);

--- a/tests/tap/t/004_non_default_repset.pl
+++ b/tests/tap/t/004_non_default_repset.pl
@@ -81,12 +81,12 @@ system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "
 system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "SELECT spock.repset_remove_table('default', 'basic_dml1')";
 
 # Check if table is already in delay replication set, if not add it
-my $table_in_delay = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM spock.repset_table WHERE set_name = 'delay' AND set_relname = 'basic_dml1')"`;
+my $table_in_delay = `$pg_bin/psql -p $node_ports->[0] -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM spock.tables WHERE set_name = 'delay' AND relname = 'basic_dml1')"`;
 chomp($table_in_delay);
 $table_in_delay =~ s/\s+//g;
 
 if ($table_in_delay eq 'f') {
-    system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "SELECT spock.repset_add_table('delay', 'basic_dml1')";
+    system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "SELECT spock.repset_add_table('delay', 'basic_dml1', true)";
 }
 
 # Check subscription status after DDL
@@ -94,9 +94,6 @@ my $sub_status_after_ddl = `$pg_bin/psql -p $node_ports->[1] -d $dbname -t -c "S
 chomp($sub_status_after_ddl);
 $sub_status_after_ddl =~ s/\s+//g;
 is($sub_status_after_ddl, "replicating", 'subscription still replicating after DDL');
-
-# Add table to the 'delay' replication set
-system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "SELECT * FROM spock.repset_add_table('delay', 'basic_dml1', true)";
 
 # Wait for sync to complete
 system_or_bail 'sleep', '10';


### PR DESCRIPTION
When a table is added to a repset and the subscription begins data sync, Spock monitors for the table's presence and starts copying once it appears.

Now spock_relation_open() is changed to return NULL (instead of throwing error) for not-yet-present relations. The callers in sync and truncate paths could continue using the invalid rel, leading to invalid memory access and causing segmentation fault.