### PR TITLE
SPOC-193: autoddl: guard extension-script subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondar
 		  toasted replication_set matview bidirectional primary_key \
 		  interfaces foreign_key copy sequence triggers parallel functions row_filter \
 		  row_filter_sampling att_list column_filter apply_delay \
-		  extended node_origin_cascade multiple_upstreams tuple_origin \
+		  extended node_origin_cascade multiple_upstreams tuple_origin autoddl \
 		  drop
 
 # The following test cases are disabled while developing.

--- a/src/spock_executor.c
+++ b/src/spock_executor.c
@@ -357,6 +357,10 @@ autoddl_can_proceed(ProcessUtilityContext context, NodeTag toplevel_stmt,
 	if (context == PROCESS_UTILITY_TOPLEVEL)
 		return true;
 
+	/* Guard against CREATE EXTENSION subcommands */
+	if (creating_extension)
+		return false;
+
 	/*
 	 * Indicates a portion of a query. These statements should be handled by the
 	 * corresponding top-level query.

--- a/tests/regress/expected/autoddl.out
+++ b/tests/regress/expected/autoddl.out
@@ -1,0 +1,85 @@
+--Tuple Origin
+SELECT * FROM spock_regress_variables()
+\gset
+-- This is to ensure that the test runs with the correct configuration
+\c :provider_dsn
+ALTER SYSTEM SET spock.enable_ddl_replication = 'on';
+ALTER SYSTEM SET spock.include_ddl_repset = 'on';
+ALTER SYSTEM SET spock.allow_ddl_from_functions = 'on';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+-- Create schema with tables on provider (node 1)
+CREATE SCHEMA hollywood
+    CREATE TABLE films (title text, release date, awards text[])
+    CREATE TABLE shorts (title text, release date, awards text[]);
+INFO:  DDL statement replicated.
+-- Create a test table on provider (node 1)
+CREATE TABLE test1 (id int primary key, name text);
+INFO:  DDL statement replicated.
+-- Create a function that creates two tables when called on provider (node 1)
+CREATE FUNCTION auto_ddl_test() RETURNS void AS $func$
+BEGIN
+    EXECUTE 'CREATE TABLE test2 (id int primary key, name text)';
+    EXECUTE 'CREATE TABLE test3 (id int primary key, name text)';
+END;
+$func$ LANGUAGE plpgsql;
+INFO:  DDL statement replicated.
+-- Call function to create tables test2 and test3
+SELECT auto_ddl_test();
+INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
+ auto_ddl_test 
+---------------
+ 
+(1 row)
+
+INSERT INTO test1 VALUES (1, 'one'), (2, 'two');
+-- Generate a sync event
+SELECT spock.sync_event() as sync_event
+\gset
+\c :subscriber_dsn
+-- Wait for sync event to be processed on subscriber (node 2)
+CALL spock.wait_for_sync_event(true, 'test_provider', :'sync_event');
+ result 
+--------
+ t
+(1 row)
+
+-- Check schema, table and function appear on subscriber (node 2)
+SELECT count(*) FROM spock.tables where nspname = 'hollywood' AND set_name IS NOT NULL;
+ count 
+-------
+     2
+(1 row)
+
+SELECT count(*) FROM spock.tables where relname = 'test1' AND set_name IS NOT NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM spock.tables where (relname = 'test2' or relname = 'test3') AND set_name IS NOT NULL;
+ count 
+-------
+     2
+(1 row)
+
+-- Reset the configuration to the default value
+\c :provider_dsn
+ALTER SYSTEM SET spock.enable_ddl_replication = 'off';
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM SET spock.include_ddl_repset = 'off';
+WARNING:  This DDL statement will not be replicated.
+ALTER SYSTEM SET spock.allow_ddl_from_functions = 'off';
+WARNING:  This DDL statement will not be replicated.
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+

--- a/tests/regress/sql/autoddl.sql
+++ b/tests/regress/sql/autoddl.sql
@@ -1,0 +1,53 @@
+--Tuple Origin
+SELECT * FROM spock_regress_variables()
+\gset
+
+-- This is to ensure that the test runs with the correct configuration
+\c :provider_dsn
+ALTER SYSTEM SET spock.enable_ddl_replication = 'on';
+ALTER SYSTEM SET spock.include_ddl_repset = 'on';
+ALTER SYSTEM SET spock.allow_ddl_from_functions = 'on';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+
+-- Create schema with tables on provider (node 1)
+CREATE SCHEMA hollywood
+    CREATE TABLE films (title text, release date, awards text[])
+    CREATE TABLE shorts (title text, release date, awards text[]);
+
+-- Create a test table on provider (node 1)
+CREATE TABLE test1 (id int primary key, name text);
+
+-- Create a function that creates two tables when called on provider (node 1)
+CREATE FUNCTION auto_ddl_test() RETURNS void AS $func$
+BEGIN
+    EXECUTE 'CREATE TABLE test2 (id int primary key, name text)';
+    EXECUTE 'CREATE TABLE test3 (id int primary key, name text)';
+END;
+$func$ LANGUAGE plpgsql;
+
+-- Call function to create tables test2 and test3
+SELECT auto_ddl_test();
+INSERT INTO test1 VALUES (1, 'one'), (2, 'two');
+
+-- Generate a sync event
+SELECT spock.sync_event() as sync_event
+\gset
+
+\c :subscriber_dsn
+
+-- Wait for sync event to be processed on subscriber (node 2)
+CALL spock.wait_for_sync_event(true, 'test_provider', :'sync_event');
+
+-- Check schema, table and function appear on subscriber (node 2)
+SELECT count(*) FROM spock.tables where nspname = 'hollywood' AND set_name IS NOT NULL;
+SELECT count(*) FROM spock.tables where relname = 'test1' AND set_name IS NOT NULL;
+SELECT count(*) FROM spock.tables where (relname = 'test2' or relname = 'test3') AND set_name IS NOT NULL;
+
+-- Reset the configuration to the default value
+\c :provider_dsn
+ALTER SYSTEM SET spock.enable_ddl_replication = 'off';
+ALTER SYSTEM SET spock.include_ddl_repset = 'off';
+ALTER SYSTEM SET spock.allow_ddl_from_functions = 'off';
+SELECT pg_reload_conf();


### PR DESCRIPTION
During upgrades, the extension script runs a bunch of internal subcommands with creating_extension = true. However, Our autoddl was using ProcessUtilityContext to skip subcommands; which sometimes let these slip through, causing unintended replication.

(cherry picked from commit 00832691e6a4566933b14b90704618d8e2c9b46a)