### PR TITLE
Bugfix on cleared memory access at the COMMIT callback (spoc-257).

### DIFF
--- a/src/spock_worker.c
+++ b/src/spock_worker.c
@@ -68,7 +68,6 @@ int			spock_stats_max_entries;
 bool		spock_stats_hash_full = false;
 
 
-static bool xacthook_signal_workers = false;
 static bool xact_cb_installed = false;
 
 static shmem_request_hook_type prev_shmem_request_hook = NULL;
@@ -626,12 +625,36 @@ spock_worker_kill(SpockWorker *worker)
 static void
 signal_worker_xact_callback(XactEvent event, void *arg)
 {
-	if (event == XACT_EVENT_COMMIT && xacthook_signal_workers)
-	{
-		SpockWorker *w;
-		ListCell   *l;
+	if (list_length(signal_workers) == 0)
+		return;
 
-		LWLockAcquire(SpockCtx->lock, LW_EXCLUSIVE);
+	if (event == XACT_EVENT_PARALLEL_COMMIT ||
+		event == XACT_EVENT_PARALLEL_ABORT ||
+		event == XACT_EVENT_PARALLEL_PRE_COMMIT)
+		/*
+		 * Subscription changing code is volatile and can't be executed inside
+		 * a parallel worker. Just ignore the case.
+		 */
+		return;
+
+	if (event == XACT_EVENT_PRE_COMMIT || event == XACT_EVENT_PRE_PREPARE ||
+		event == XACT_EVENT_PREPARE)
+		/*
+		 * It is too early for us, because worker still can't see the changes
+		 * have made. Skip until COMMIT/ABORT will come.
+		 */
+		return;
+
+	/*
+	 * Now, worker may see the Spock catalog changes that this backend has made.
+	 * COMMIT and ABORT will release resources right after this call. So, we
+	 * need to manage the signal_workers right here.
+	 */
+	LWLockAcquire(SpockCtx->lock, LW_EXCLUSIVE);
+	if (event == XACT_EVENT_COMMIT)
+	{
+		SpockWorker	   *w;
+		ListCell	   *l;
 
 		foreach(l, signal_workers)
 		{
@@ -658,17 +681,28 @@ signal_worker_xact_callback(XactEvent event, void *arg)
 		if (SpockCtx->supervisor)
 			SetLatch(&SpockCtx->supervisor->procLatch);
 
-		LWLockRelease(SpockCtx->lock);
-
 		list_free_deep(signal_workers);
 		signal_workers = NIL;
-
-		xacthook_signal_workers = false;
 	}
+	else if (event == XACT_EVENT_ABORT)
+	{
+		/*
+		 * Don't have an information about what specifically was aborted. So,
+		 * just clean whole list before this abort reset the memory context.
+		 */
+		list_free_deep(signal_workers);
+		signal_workers = NIL;
+	}
+	LWLockRelease(SpockCtx->lock);
 }
 
 /*
  * Enqueue signal for supervisor/manager at COMMIT.
+ *
+ * NOTE:
+ * Here is not fully transactional behaviour: if something will be changed (and
+ * aborted) inside a subtransaction, we still call the action on the transaction
+ * COMMIT.
  */
 void
 spock_subscription_changed(Oid subid, bool kill)
@@ -684,7 +718,12 @@ spock_subscription_changed(Oid subid, bool kill)
 		MemoryContext oldcxt;
 		signal_worker_item *item;
 
-		oldcxt = MemoryContextSwitchTo(TopTransactionContext);
+		/*
+		 * Use TopMemoryContext to simplify corner cases, like PREPARE
+		 * TRANSACTION that clears resources allocated by transaction and still
+		 * not committed.
+		 */
+		oldcxt = MemoryContextSwitchTo(TopMemoryContext);
 
 		item = palloc(sizeof(signal_worker_item));
 		item->subid = subid;
@@ -694,8 +733,6 @@ spock_subscription_changed(Oid subid, bool kill)
 
 		MemoryContextSwitchTo(oldcxt);
 	}
-
-	xacthook_signal_workers = true;
 }
 
 static Size

--- a/tests/regress/expected/interfaces.out
+++ b/tests/regress/expected/interfaces.out
@@ -9,6 +9,39 @@ SELECT * FROM spock.node_add_interface('test_provider', 'super2', (SELECT provid
          1679954453
 (1 row)
 
+-- Check that the signal_worker_xact_callback routine process subscription
+-- change in a right way, considering abortion and prepared transactions.
+BEGIN;
+SELECT * FROM spock.sub_alter_interface('test_subscription', 'super2');
+ sub_alter_interface 
+---------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+SELECT * FROM spock.sub_alter_interface('test_subscription', 'super2');
+ sub_alter_interface 
+---------------------
+ t
+(1 row)
+
+PREPARE TRANSACTION 't1';
+ABORT PREPARED 't1'; -- ERROR between preparation and abortion
+ERROR:  syntax error at or near "PREPARED"
+LINE 1: ABORT PREPARED 't1';
+              ^
+ROLLBACK PREPARED 't1';
+BEGIN;
+SAVEPOINT s1;
+SELECT * FROM spock.sub_alter_interface('test_subscription', 'super2');
+ sub_alter_interface 
+---------------------
+ t
+(1 row)
+
+ROLLBACK TO SAVEPOINT s1;
+COMMIT;
 SELECT * FROM spock.sub_alter_interface('test_subscription', 'super2');
  sub_alter_interface 
 ---------------------


### PR DESCRIPTION
There is the signal_workers list that should be processed at the end of the transaction. It existed in TopTransactionContext, and there was a case where the transaction was aborted or prepared. Upon abort, all resources are released, and signal_workers should be freed and nullified.

By this commit, we add a proper reaction to each XactEvent. Also, remove the 'xacthook_signal_workers' flag because the 'signal_workers' NULL value covers this logic.
The signal_workers list is now allocated in the TopMemoryContext. It may hide some issues, but it simplifies the code in the case of PREPARE TRANSACTION. Also, some regression tests were added.

NOTE:
It seems that the entire concept of changing the set of subscriptions may be revised: instead of modifying the Spock catalogue within the backend, we could perform all the necessary tasks within the worker manager. Just put the required data into the shared memory and send a signal to the workers manager. At the same time, we would need to wait until the manager finishes the operation and sends the 'end' signal back to the backend.