### PR TITLE
Fix the Spock protocol.

### DIFF
--- a/include/spock_output_plugin.h
+++ b/include/spock_output_plugin.h
@@ -66,6 +66,11 @@ typedef struct SpockOutputData
 	bool		client_binary_intdatetimes;
 	bool		client_no_txinfo;
 
+	/* Spock version related parameters. */
+	int			startup_params_format;
+	const char *spock_version;
+	int			spock_version_num;
+
 	/* List of origin names */
     List	   *forward_origins;
 	/* List of SpockRepSet */

--- a/src/spock.c
+++ b/src/spock.c
@@ -56,6 +56,7 @@
 #include "spock_node.h"
 #include "spock_conflict.h"
 #include "spock_worker.h"
+#include "spock_output_config.h"
 #include "spock_output_plugin.h"
 #include "spock_exception_handler.h"
 #include "spock_readonly.h"
@@ -560,19 +561,9 @@ spock_start_replication(PGconn *streamConn, const char *slot_name,
 #endif
 					 );
 	appendStringInfo(&command, ", \"binary.float4_byval\" '%d'",
-#ifdef USE_FLOAT4_BYVAL
-					 true
-#else
-					 false
-#endif
-					 );
+					 server_float4_byval());
 	appendStringInfo(&command, ", \"binary.float8_byval\" '%d'",
-#ifdef USE_FLOAT8_BYVAL
-					 true
-#else
-					 false
-#endif
-					 );
+					 server_float8_byval());
 	appendStringInfo(&command, ", \"binary.integer_datetimes\" '%d'",
 #ifdef USE_INTEGER_DATETIMES
 					 true
@@ -603,14 +594,10 @@ spock_start_replication(PGconn *streamConn, const char *slot_name,
 		appendStringInfoString(&command, quote_literal_cstr(replication_sets));
 	}
 
-	/* Tell the upstream that we want unbounded metadata cache size */
-	appendStringInfoString(&command, ", \"relmeta_cache_size\" '-1'");
-
 	/* general info about the downstream */
 	appendStringInfo(&command, ", pg_version '%u'", PG_VERSION_NUM);
 	appendStringInfo(&command, ", spock_version '%s'", SPOCK_VERSION);
 	appendStringInfo(&command, ", spock_version_num '%d'", SPOCK_VERSION_NUM);
-	appendStringInfo(&command, ", spock_apply_pid '%d'", MyProcPid);
 
 	appendStringInfoChar(&command, ')');
 

--- a/src/spock_output_plugin.c
+++ b/src/spock_output_plugin.c
@@ -408,6 +408,26 @@ pg_decode_startup(LogicalDecodingContext * ctx, OutputPluginOptions *opt,
 			data->field_datum_encoding = wanted_encoding;
 		}
 
+		/* Check subscriber's Spock version and complain softly if differs */
+
+		if (data->startup_params_format == 0)
+			elog(LOG, "Client doesn't set protocol parameter 'startup_params_format'");
+		else if (data->startup_params_format != 1)
+			elog(LOG, "client's startup_params_format (%d) differs from the server's one",
+				 data->startup_params_format);
+
+		if (data->spock_version == NULL)
+			elog(LOG, "Client doesn't set protocol parameter 'spock_version'");
+		else if (strcmp(data->spock_version, SPOCK_VERSION) != 0)
+			elog(LOG, "client's spock_version (%s) differs from the server's one (%s)",
+				 data->spock_version, SPOCK_VERSION);
+
+		if (data->spock_version_num == 0)
+			elog(LOG, "Client doesn't set protocol parameter 'spock_version_num'");
+		else if (data->spock_version_num != SPOCK_VERSION_NUM)
+			elog(LOG, "client's spock_version_num (%d) differs from the server's one (%d)",
+				 data->spock_version_num, SPOCK_VERSION_NUM);
+
 		/*
 		 * It's obviously not possible to send binary representation of data
 		 * unless we use the binary output.


### PR DESCRIPTION
This commit fixes the following issues:
1) protocol parameters relmeta_cache_size and spock_apply_pid that are currently not used.
2) incorrect initialisation and comparison of the floatr_byval and float8_byval parameters.
3) Receiver didn't process parameters startup_params_format, spock_version and spock_version_num.

Also, complain more loudly in case of an undefined or incorrectly installed parameter. It will help identify any protocol issues more quickly.