### PR TITLE
Increase stability of regression tests (spoc-197).

### DIFF
--- a/tests/regress/expected/att_list.out
+++ b/tests/regress/expected/att_list.out
@@ -275,6 +275,13 @@ SELECT nspname, relname, att_list, has_row_filter FROM spock.repset_show_table('
  public  | basic_dml | {something} | f
 (1 row)
 
+-- Need to wait confirmation of flushing to the slot everything changed
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 -- verify that columns are not automatically added for filtering unless told so.
 SELECT * FROM spock.sub_show_table('test_subscription', 'basic_dml');

--- a/tests/regress/expected/functions.out
+++ b/tests/regress/expected/functions.out
@@ -279,6 +279,13 @@ SELECT spock.sub_disable('test_subscription', true);
  t
 (1 row)
 
+-- Wait for the end of this operation
+DO $$
+BEGIN
+    WHILE EXISTS (SELECT 1 FROM pg_replication_slots WHERE active = 'true')
+	LOOP
+    END LOOP;
+END;$$;
 \c :provider_dsn
 SELECT quote_literal(pg_current_xlog_location()) as curr_lsn
 \gset

--- a/tests/regress/expected/interfaces.out
+++ b/tests/regress/expected/interfaces.out
@@ -50,26 +50,25 @@ SELECT * FROM spock.sub_alter_interface('test_subscription', 'super2');
 
 DO $$
 BEGIN
-    FOR i IN 1..100 LOOP
-        IF EXISTS (SELECT 1 FROM spock.sub_show_status() WHERE status != 'down') THEN
-            EXIT;
-        END IF;
-        PERFORM pg_sleep(0.1);
+    WHILE EXISTS (SELECT 1 FROM spock.sub_show_status() WHERE status = 'down')
+	LOOP
     END LOOP;
 END;$$;
-SELECT pg_sleep(0.1);
- pg_sleep 
-----------
- 
-(1 row)
-
-SELECT subscription_name, status, provider_node, replication_sets, forward_origins FROM spock.sub_show_status();
+SELECT
+  subscription_name, status, provider_node, replication_sets, forward_origins
+FROM spock.sub_show_status();
  subscription_name |   status    | provider_node |           replication_sets            | forward_origins 
 -------------------+-------------+---------------+---------------------------------------+-----------------
  test_subscription | replicating | test_provider | {default,default_insert_only,ddl_sql} | 
 (1 row)
 
 \c :provider_dsn
+DO $$
+BEGIN
+    WHILE EXISTS (SELECT 1 FROM pg_replication_slots WHERE active = 'false')
+	LOOP
+    END LOOP;
+END;$$;
 SELECT plugin, slot_type, active FROM pg_replication_slots;
     plugin    | slot_type | active 
 --------------+-----------+--------
@@ -90,20 +89,16 @@ SELECT * FROM spock.sub_alter_interface('test_subscription', 'test_provider');
 
 DO $$
 BEGIN
-    FOR i IN 1..100 LOOP
-        IF EXISTS (SELECT 1 FROM spock.sub_show_status() WHERE status != 'down') THEN
-            EXIT;
-        END IF;
-        PERFORM pg_sleep(0.1);
+    WHILE EXISTS (SELECT 1 FROM spock.sub_show_status() WHERE status = 'down')
+	LOOP
+	-- TODO: The multimaster testing buildfarm should have a general parameter
+	-- like 'wait_change_timeout' that may be used to take control over infinite
+	-- waiting cycles.
     END LOOP;
 END;$$;
-SELECT pg_sleep(0.1);
- pg_sleep 
-----------
- 
-(1 row)
-
-SELECT subscription_name, status, provider_node, replication_sets, forward_origins FROM spock.sub_show_status();
+SELECT
+  subscription_name, status, provider_node, replication_sets, forward_origins
+FROM spock.sub_show_status();
  subscription_name |   status    | provider_node |           replication_sets            | forward_origins 
 -------------------+-------------+---------------+---------------------------------------+-----------------
  test_subscription | replicating | test_provider | {default,default_insert_only,ddl_sql} | 
@@ -111,6 +106,13 @@ SELECT subscription_name, status, provider_node, replication_sets, forward_origi
 
 \c :provider_dsn
 DROP USER super2;
+-- Creation of a slot needs some time. Just wait.
+DO $$
+BEGIN
+    WHILE EXISTS (SELECT 1 FROM pg_replication_slots WHERE active = 'false')
+	LOOP
+    END LOOP;
+END;$$;
 SELECT plugin, slot_type, active FROM pg_replication_slots;
     plugin    | slot_type | active 
 --------------+-----------+--------

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -284,6 +284,12 @@ INSERT INTO spoc_102l VALUES (3);
 INSERT INTO spoc_102g VALUES (-4); -- NOT replicated
 END;
 INSERT INTO spoc_102g VALUES (-5);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 -- Check replication state before the problem fixation
 SELECT * FROM spoc_102g ORDER BY x;
@@ -314,6 +320,12 @@ SELECT * FROM spoc_102l ORDER BY x;
 
 -- Return to provider and check that it doesn't see value (4).
 -- Afterwards, add value 5 that must be replicated
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :provider_dsn
 SELECT * FROM spoc_102l ORDER BY x;
  x 
@@ -325,6 +337,12 @@ SELECT * FROM spoc_102l ORDER BY x;
 
 INSERT INTO spoc_102l VALUES (5);
 -- Re-check that subscription works properly
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 SELECT * FROM spoc_102l ORDER BY x;
  x 
@@ -369,6 +387,12 @@ INSERT INTO spoc_102l VALUES (3);
 INSERT INTO spoc_102g VALUES (-4);
 END;
 INSERT INTO spoc_102g VALUES (-5);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 -- Check replication state before the problem fixation
 SELECT * FROM spoc_102g ORDER BY x;
@@ -395,6 +419,12 @@ NOTICE:  relation "spoc_102l" already exists, skipping
 
 INSERT INTO spoc_102l VALUES (4);
 INSERT INTO spoc_102g VALUES (-6);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required after changes
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 SELECT * FROM spoc_102g ORDER BY x;
  x  
@@ -469,14 +499,14 @@ UPDATE spoc_102l_u SET x = 3 WHERE x = 2;
 UPDATE spoc_102g_u SET x = -3 WHERE x = -2;
 END;
 UPDATE spoc_102g_u SET x = 1 WHERE x = 0;
-\c :subscriber_dsn
--- Check replication state before the problem fixation
 SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
  wait_slot_confirm_lsn 
 -----------------------
  
 (1 row)
 
+\c :subscriber_dsn
+-- Check replication state before the problem fixation
 SELECT * FROM spoc_102g_u ORDER BY x;
  x  
 ----
@@ -499,6 +529,12 @@ UPDATE spoc_102l_u SET x = -3 WHERE x = 3;
 INSERT INTO spoc_102l_u VALUES (4);
 UPDATE spoc_102l_u SET x = 5 WHERE x = 4;
 -- Check that replication works
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
  wait_slot_confirm_lsn 
@@ -575,13 +611,13 @@ DELETE FROM spoc_102g_d WHERE x = -1;
 DELETE FROM spoc_102l_d WHERE x = 1;
 DELETE FROM spoc_102g_d WHERE x = -2;
 -- Check the state of replication on the subscriber node
-\c :subscriber_dsn
-SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required
  wait_slot_confirm_lsn 
 -----------------------
  
 (1 row)
 
+\c :subscriber_dsn
 SELECT * FROM spoc_102l_d ORDER BY x; -- ERROR, not existed yet.
 ERROR:  relation "spoc_102l_d" does not exist at character 15
 SELECT * FROM spoc_102g_d ORDER BY x; -- See one record (-3).
@@ -607,13 +643,13 @@ UPDATE spoc_102l_d SET x = 5 WHERE x = 3;
 DELETE FROM spoc_102g_d WHERE x = -3 OR x = -6;
 DELETE FROM spoc_102l_d WHERE x = 1 OR x = 5;
 -- Check the state of replication on the subscriber node
-\c :subscriber_dsn
-SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required
  wait_slot_confirm_lsn 
 -----------------------
  
 (1 row)
 
+\c :subscriber_dsn
 SELECT * FROM spoc_102l_d ORDER BY x; -- See (4)
  x 
 ---

--- a/tests/regress/expected/tuple_origin.out
+++ b/tests/regress/expected/tuple_origin.out
@@ -28,9 +28,16 @@ SELECT * FROM spock.repset_add_table('default', 'users');
 
 BEGIN;
 INSERT INTO USERS SELECT 1, 5;
-UPDATE USERS SET id = id + 1 WHERE mgr_id < 10; 
+UPDATE USERS SET id = id + 1 WHERE mgr_id < 10;
 UPDATE USERS SET id = id + 1 WHERE mgr_id < 10;
 END;
+-- Ensure that DDL and updates is confirmed as flushed to the subscriber
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
 \c :subscriber_dsn
 SELECT * FROM users ORDER BY id;
  id | mgr_id 

--- a/tests/regress/sql/att_list.sql
+++ b/tests/regress/sql/att_list.sql
@@ -124,6 +124,8 @@ DELETE FROM basic_dml WHERE other = 2;
 SELECT * FROM basic_dml ORDER BY other;
 SELECT nspname, relname, att_list, has_row_filter FROM spock.repset_show_table('basic_dml', ARRAY['default']);
 
+-- Need to wait confirmation of flushing to the slot everything changed
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :subscriber_dsn
 -- verify that columns are not automatically added for filtering unless told so.
 SELECT * FROM spock.sub_show_table('test_subscription', 'basic_dml');

--- a/tests/regress/sql/functions.sql
+++ b/tests/regress/sql/functions.sql
@@ -163,6 +163,14 @@ ALTER TABLE public.not_nullcheck_tbl ADD COLUMN id2 integer not null;
 
 -- disable now to use pg_logical_slot_get_changes() later
 SELECT spock.sub_disable('test_subscription', true);
+-- Wait for the end of this operation
+DO $$
+BEGIN
+    WHILE EXISTS (SELECT 1 FROM pg_replication_slots WHERE active = 'true')
+	LOOP
+    END LOOP;
+END;$$;
+
 \c :provider_dsn
 
 SELECT quote_literal(pg_current_xlog_location()) as curr_lsn

--- a/tests/regress/sql/replication_set.sql
+++ b/tests/regress/sql/replication_set.sql
@@ -129,6 +129,7 @@ INSERT INTO spoc_102g VALUES (-4); -- NOT replicated
 END;
 INSERT INTO spoc_102g VALUES (-5);
 
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :subscriber_dsn
 -- Check replication state before the problem fixation
 SELECT * FROM spoc_102g ORDER BY x;
@@ -148,11 +149,13 @@ SELECT * FROM spoc_102l ORDER BY x;
 
 -- Return to provider and check that it doesn't see value (4).
 -- Afterwards, add value 5 that must be replicated
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :provider_dsn
 SELECT * FROM spoc_102l ORDER BY x;
 INSERT INTO spoc_102l VALUES (5);
 
 -- Re-check that subscription works properly
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :subscriber_dsn
 SELECT * FROM spoc_102l ORDER BY x;
 
@@ -180,6 +183,7 @@ INSERT INTO spoc_102g VALUES (-4);
 END;
 INSERT INTO spoc_102g VALUES (-5);
 
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :subscriber_dsn
 -- Check replication state before the problem fixation
 SELECT * FROM spoc_102g ORDER BY x;
@@ -192,6 +196,7 @@ SELECT spock.replicate_ddl('CREATE TABLE IF NOT EXISTS spoc_102l (x integer PRIM
 INSERT INTO spoc_102l VALUES (4);
 INSERT INTO spoc_102g VALUES (-6);
 
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required after changes
 \c :subscriber_dsn
 SELECT * FROM spoc_102g ORDER BY x;
 SELECT * FROM spoc_102l ORDER BY x;
@@ -225,9 +230,9 @@ UPDATE spoc_102g_u SET x = -3 WHERE x = -2;
 END;
 UPDATE spoc_102g_u SET x = 1 WHERE x = 0;
 
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :subscriber_dsn
 -- Check replication state before the problem fixation
-SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 SELECT * FROM spoc_102g_u ORDER BY x;
 SELECT * FROM spoc_102l_u ORDER BY x; -- ERROR, does not exist yet
 
@@ -239,6 +244,7 @@ INSERT INTO spoc_102l_u VALUES (4);
 UPDATE spoc_102l_u SET x = 5 WHERE x = 4;
 
 -- Check that replication works
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required
 \c :subscriber_dsn
 SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 SELECT * FROM spoc_102l_u ORDER BY x;
@@ -269,8 +275,8 @@ DELETE FROM spoc_102l_d WHERE x = 1;
 DELETE FROM spoc_102g_d WHERE x = -2;
 
 -- Check the state of replication on the subscriber node
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required
 \c :subscriber_dsn
-SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 SELECT * FROM spoc_102l_d ORDER BY x; -- ERROR, not existed yet.
 SELECT * FROM spoc_102g_d ORDER BY x; -- See one record (-3).
 
@@ -287,8 +293,8 @@ DELETE FROM spoc_102g_d WHERE x = -3 OR x = -6;
 DELETE FROM spoc_102l_d WHERE x = 1 OR x = 5;
 
 -- Check the state of replication on the subscriber node
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- required
 \c :subscriber_dsn
-SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 SELECT * FROM spoc_102l_d ORDER BY x; -- See (4)
 SELECT * FROM spoc_102g_d ORDER BY x; -- See (-5).
 

--- a/tests/regress/sql/tuple_origin.sql
+++ b/tests/regress/sql/tuple_origin.sql
@@ -17,10 +17,12 @@ SELECT * FROM spock.repset_add_table('default', 'users');
 
 BEGIN;
 INSERT INTO USERS SELECT 1, 5;
-UPDATE USERS SET id = id + 1 WHERE mgr_id < 10; 
+UPDATE USERS SET id = id + 1 WHERE mgr_id < 10;
 UPDATE USERS SET id = id + 1 WHERE mgr_id < 10;
 END;
 
+-- Ensure that DDL and updates is confirmed as flushed to the subscriber
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 \c :subscriber_dsn
 SELECT * FROM users ORDER BY id;
 


### PR DESCRIPTION
There are a few tests that rely on the time period required to synchronise a subscription or deliver replicated data to a subscriber. Such time dependency causes tests' instability, which can be easily checked by inserting something like 'pg_usleep(10000);' into any part of the Postgres code where the confirmed_flush parameter is advanced.

With this commit, we utilise standard Spock machinery to wait for the WAL flushing event, as well as to perform infinite cycles waiting for a change in subscription state.

It seems an infinite wait is not the best choice. In the future, we could introduce a 'wait_change_timeout' environment parameter that can be configured according to the characteristics of the test platform.

One more race we have detected here is that, altering the subscription, Spock just sends a signal to the apply worker. So, switching to the publisher quickly enough, we may find that the replication slot is still not ready to send data. Just wait until the plugin is ready - yeah, still in an infinite loop.