### PR TITLE
Multiple minor fixes in the Z0DAN SQL script (SPOC-239).

### DIFF
--- a/samples/Z0DAN/README.md
+++ b/samples/Z0DAN/README.md
@@ -63,9 +63,10 @@ Execute the following command in your PostgreSQL session:
 ```sql
 CALL spock.add_node(
   'source_node_name',
-  'source_node_dsn',
+  'src_dsn',
   'new_node_name',
   'new_node_dsn',
+  'verb',			    -- optional
   'new_node_location',  -- optional
   'new_node_country',   -- optional
   '{}'::jsonb           -- optional info

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -51,7 +51,7 @@ BEGIN
         RAISE NOTICE 'Checking Spock version on source node';
     END IF;
     SELECT * FROM dblink(src_dsn, remotesql) AS t(version text) INTO src_version;
-    
+
     IF src_version IS NULL THEN
         RAISE EXCEPTION 'Spock extension not found on source node';
     END IF;
@@ -61,13 +61,13 @@ BEGIN
         RAISE EXCEPTION 'Spock version mismatch: source node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
             src_version, min_required_version, min_required_version;
     END IF;
-    
+
     -- Get new node Spock version
     IF verb THEN
         RAISE NOTICE 'Checking Spock version on new node';
     END IF;
     SELECT * FROM dblink(new_node_dsn, remotesql) AS t(version text) INTO new_version;
-    
+
     IF new_version IS NULL THEN
         RAISE EXCEPTION 'Spock extension not found on new node';
     END IF;
@@ -82,16 +82,16 @@ BEGIN
         RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Please ensure that they match.',
             new_version, src_version;
     END IF;
-    
+
     -- Check all existing nodes in cluster
-    FOR node_rec IN 
-        SELECT node_name, if_dsn 
-        FROM dblink(src_dsn, 
+    FOR node_rec IN
+        SELECT node_name, if_dsn
+        FROM dblink(src_dsn,
             'SELECT n.node_name, i.if_dsn FROM spock.node n JOIN spock.node_interface i ON n.node_id = i.if_nodeid'
         ) AS t(node_name text, if_dsn text)
     LOOP
         SELECT * FROM dblink(node_rec.if_dsn, remotesql) AS t(version text) INTO node_version;
-        
+
         IF node_version IS NULL THEN
             RAISE EXCEPTION 'Spock extension not found on node %', node_rec.node_name;
         END IF;
@@ -107,7 +107,7 @@ BEGIN
                 new_version, node_version;
         END IF;
     END LOOP;
-    
+
     IF verb THEN
         RAISE NOTICE 'Version check passed: All nodes running Spock version % or later. Source version is %, new node version is %', min_required_version, src_version, new_version;
     END IF;
@@ -132,11 +132,11 @@ BEGIN
     -- Build and execute remote SQL to fetch node details and DSNs
     -- Note: Procedures cannot return tables directly, so we'll use RAISE NOTICE
     -- to display the results or store them in a temporary table
-    
+
     IF verb THEN
         RAISE NOTICE E'[STEP] get_spock_nodes: Retrieved nodes from remote DSN: %', src_dsn;
     END IF;
-    
+
     -- Create a temporary table to store results
     CREATE TEMP TABLE IF NOT EXISTS temp_spock_nodes (
         node_id    integer,
@@ -146,10 +146,10 @@ BEGIN
         info       text,
         dsn        text
     );
-    
+
     -- Clear previous results
     DELETE FROM temp_spock_nodes;
-    
+
     -- Insert results into temp table
     IF verb THEN
         RAISE NOTICE '[QUERY] SELECT n.node_id, n.node_name, n.location, n.country, n.info, i.if_dsn FROM spock.node n JOIN spock.node_interface i ON n.node_id = i.if_nodeid';
@@ -169,7 +169,7 @@ BEGIN
         info text,
         dsn text
     );
-    
+
     IF verb THEN
         RAISE NOTICE 'Retrieved % nodes from remote cluster', (SELECT count(*) FROM temp_spock_nodes);
     END IF;
@@ -296,7 +296,7 @@ BEGIN
     IF verb THEN
         RAISE NOTICE '[QUERY] SQL: %', remotesql;
     END IF;
-    
+
     BEGIN
         SELECT * FROM dblink(node_dsn, remotesql) AS t(sid oid) INTO sid;
 
@@ -422,7 +422,7 @@ $$;
 -- ============================================================================
 
 CREATE OR REPLACE PROCEDURE spock.sync_event(
-    node_dsn text, 
+    node_dsn text,
     verb boolean,
     INOUT sync_lsn pg_lsn DEFAULT NULL
 )
@@ -1006,10 +1006,10 @@ BEGIN
     IF verb THEN
         RAISE NOTICE '[STEP] Getting nodes from remote cluster: %', node_dsn;
     END IF;
-    
+
     -- Get all nodes except the newest one (assuming it's the receiver)
-    FOR node_rec IN 
-        SELECT * FROM dblink(node_dsn, 'SELECT node_name FROM spock.node ORDER BY node_id') 
+    FOR node_rec IN
+        SELECT * FROM dblink(node_dsn, 'SELECT node_name FROM spock.node ORDER BY node_id')
         AS t(node_name text)
     LOOP
         node_count := node_count + 1;
@@ -1017,14 +1017,14 @@ BEGIN
             node_list := node_list || ', ';
         END IF;
         node_list := node_list || '''' || node_rec.node_name || '''';
-        
+
         -- Build lag variable declarations
         IF node_count > 1 THEN
             lag_vars := lag_vars || E'\n            ';
         END IF;
         lag_vars := lag_vars || 'lag_' || node_rec.node_name || ' interval;';
         lag_vars := lag_vars || E'\n            lag_' || node_rec.node_name || '_bytes bigint;';
-        
+
         -- Build lag assignments
         IF node_count > 1 THEN
             lag_assignments := lag_assignments || E'\n\n                ';
@@ -1033,13 +1033,13 @@ BEGIN
         lag_assignments := lag_assignments || E'\n                SELECT now() - commit_timestamp, replication_lag_bytes INTO lag_' || node_rec.node_name || ', lag_' || node_rec.node_name || '_bytes';
         lag_assignments := lag_assignments || E'\n                FROM spock.lag_tracker';
         lag_assignments := lag_assignments || E'\n                WHERE origin_name = ''''' || node_rec.node_name || ''''' AND receiver_name = (SELECT node_name FROM spock.node ORDER BY node_id DESC LIMIT 1);';
-        
+
         -- Build lag log message
         IF node_count > 1 THEN
             lag_log := lag_log || ', ';
         END IF;
         lag_log := lag_log || node_rec.node_name || ' → newest lag: % (bytes: %)';
-        
+
         -- Build lag conditions
         IF node_count > 1 THEN
             lag_conditions := lag_conditions || E'\n                          AND ';
@@ -1047,12 +1047,12 @@ BEGIN
         lag_conditions := lag_conditions || 'lag_' || node_rec.node_name || ' IS NOT NULL';
         lag_conditions := lag_conditions || E'\n                          AND (extract(epoch FROM lag_' || node_rec.node_name || ') < 59 OR lag_' || node_rec.node_name || '_bytes = 0)';
     END LOOP;
-    
+
     IF node_count <= 1 THEN
         RAISE NOTICE '[STEP] Only one node found, skipping lag monitoring';
         RETURN;
     END IF;
-    
+
     -- ============================================================================
     -- Step 2: Build dynamic remote SQL for monitoring replication lag
     -- ============================================================================
@@ -1061,8 +1061,8 @@ BEGIN
         coalesce_params text := '';
         node_rec2 record;
     BEGIN
-        FOR node_rec2 IN 
-            SELECT * FROM dblink(node_dsn, 'SELECT node_name FROM spock.node ORDER BY node_id') 
+        FOR node_rec2 IN
+            SELECT * FROM dblink(node_dsn, 'SELECT node_name FROM spock.node ORDER BY node_id')
             AS t(node_name text)
         LOOP
             IF coalesce_params != '' THEN
@@ -1070,7 +1070,7 @@ BEGIN
             END IF;
             coalesce_params := coalesce_params || 'COALESCE(lag_' || node_rec2.node_name || '::text, ''NULL''), COALESCE(lag_' || node_rec2.node_name || '_bytes::text, ''NULL'')';
         END LOOP;
-        
+
         remotesql := format($sql$
             DO '
             DECLARE%s
@@ -1089,7 +1089,7 @@ BEGIN
                 END LOOP;
             END
             ';
-        $sql$, 
+        $sql$,
             lag_vars,
             lag_assignments,
             lag_log,
@@ -1140,13 +1140,13 @@ DECLARE
     elapsed_interval interval;
 BEGIN
     IF verb THEN
-        RAISE NOTICE 'Monitoring replication lag from % to % (max lag: % seconds)', 
+        RAISE NOTICE 'Monitoring replication lag from % to % (max lag: % seconds)',
                      origin_node, receiver_node, max_lag_seconds;
     END IF;
 
     LOOP
         -- Get current lag time and bytes
-        SELECT now() - commit_timestamp, replication_lag_bytes 
+        SELECT now() - commit_timestamp, replication_lag_bytes
         INTO lag_interval, lag_bytes
         FROM spock.lag_tracker
         WHERE origin_name = origin_node AND receiver_name = receiver_node;
@@ -1163,7 +1163,7 @@ BEGIN
         END IF;
 
         -- Exit when lag is within acceptable limits OR when lag_bytes is zero
-        EXIT WHEN lag_interval IS NOT NULL 
+        EXIT WHEN lag_interval IS NOT NULL
                   AND (extract(epoch FROM lag_interval) < max_lag_seconds OR lag_bytes = 0);
 
         -- Sleep before next check
@@ -1172,10 +1172,10 @@ BEGIN
 
     IF verb THEN
         IF lag_bytes = 0 THEN
-            RAISE NOTICE 'Replication lag from % to % completed (lag_bytes = 0)', 
+            RAISE NOTICE 'Replication lag from % to % completed (lag_bytes = 0)',
                          origin_node, receiver_node;
         ELSE
-            RAISE NOTICE 'Replication lag from % to % is now within acceptable limits (% seconds)', 
+            RAISE NOTICE 'Replication lag from % to % is now within acceptable limits (% seconds)',
                          origin_node, receiver_node, max_lag_seconds;
         END IF;
     END IF;
@@ -1206,7 +1206,7 @@ DECLARE
     lag_data record;
 BEGIN
     IF verb THEN
-        RAISE NOTICE 'Monitoring multiple replication lags (max lag: % seconds, timeout: % seconds)', 
+        RAISE NOTICE 'Monitoring multiple replication lags (max lag: % seconds, timeout: % seconds)',
                      max_lag_seconds, max_wait_seconds;
         RAISE NOTICE 'Monitoring % paths', jsonb_array_length(lag_configs);
     END IF;
@@ -1227,21 +1227,21 @@ BEGIN
 
     LOOP
         all_within_limits := true;
-        
+
         IF verb THEN
             RAISE NOTICE 'Checking lag for % paths...', jsonb_array_length(lag_configs);
         END IF;
-        
+
         -- Check each replication path
         FOR config IN SELECT * FROM jsonb_array_elements(lag_configs)
         LOOP
             IF verb THEN
                 RAISE NOTICE 'Checking path: % → %', config->>'origin', config->>'receiver';
             END IF;
-            
+
             SELECT now() - commit_timestamp INTO lag_interval
             FROM spock.lag_tracker
-            WHERE origin_name = config->>'origin' 
+            WHERE origin_name = config->>'origin'
               AND receiver_name = config->>'receiver';
 
             IF verb THEN
@@ -1255,13 +1255,13 @@ BEGIN
                 all_within_limits := false;
             END IF;
         END LOOP;
-        
+
         -- Also show all available lag data for debugging
         IF verb THEN
             RAISE NOTICE 'All available lag data:';
             FOR lag_data IN SELECT origin_name, receiver_name, commit_timestamp, replication_lag FROM spock.lag_tracker LOOP
-                RAISE NOTICE '  % → %: commit_ts=%s, lag=%s', 
-                    lag_data.origin_name, lag_data.receiver_name, 
+                RAISE NOTICE '  % → %: commit_ts=%s, lag=%s',
+                    lag_data.origin_name, lag_data.receiver_name,
                     lag_data.commit_timestamp, lag_data.replication_lag;
             END LOOP;
         END IF;
@@ -1270,13 +1270,13 @@ BEGIN
         elapsed_interval := now() - start_time;
 
         IF verb THEN
-            RAISE NOTICE 'All paths within limits: % (elapsed: %)', 
+            RAISE NOTICE 'All paths within limits: % (elapsed: %)',
                          all_within_limits, elapsed_interval::text;
         END IF;
 
         -- Exit when all paths are within acceptable limits
         EXIT WHEN all_within_limits;
-        
+
         -- Exit if we've been waiting too long
         IF extract(epoch FROM elapsed_interval) > max_wait_seconds THEN
             IF verb THEN
@@ -1321,9 +1321,9 @@ BEGIN
 
     -- Monitor both paths
     CALL spock.monitor_multiple_replication_lags(
-        lag_configs, 
-        max_lag_seconds, 
-        check_interval_seconds, 
+        lag_configs,
+        max_lag_seconds,
+        check_interval_seconds,
         verb
     );
 END;
@@ -1427,7 +1427,7 @@ DECLARE
     new_db_exists boolean;
 BEGIN
     RAISE NOTICE 'Phase 1: Validating source and new node prerequisites';
-    
+
     -- Check if database specified in new_node_dsn exists on new node
     new_db_name := substring(new_node_dsn from 'dbname=([^\s]+)');
     IF new_db_name IS NOT NULL THEN
@@ -1436,7 +1436,7 @@ BEGIN
     IF new_db_name IS NULL THEN
         new_db_name := 'pgedge';
     END IF;
-    
+
     BEGIN
         SELECT EXISTS(SELECT 1 FROM dblink(new_node_dsn, 'SELECT 1') AS t(dummy int)) INTO new_db_exists;
         RAISE NOTICE '    OK: %', rpad('Checking database ' || new_db_name || ' exists on new node', 120, ' ');
@@ -1445,7 +1445,7 @@ BEGIN
             RAISE NOTICE '    [FAILED] %', rpad('Database ' || new_db_name || ' does not exist on new node', 60, ' ');
             RAISE EXCEPTION 'Exiting add_node: Database % does not exist on new node. Please create it first.', new_db_name;
     END;
-    
+
     -- Check if database has user-created tables in user-created schemas
     DECLARE
         user_table_count integer;
@@ -1453,7 +1453,7 @@ BEGIN
     BEGIN
         remotesql := 'SELECT count(*) FROM pg_tables WHERE schemaname NOT IN (''information_schema'', ''pg_catalog'', ''pg_toast'', ''spock'') AND schemaname NOT LIKE ''pg_temp_%'' AND schemaname NOT LIKE ''pg_toast_temp_%''';
         SELECT * FROM dblink(new_node_dsn, remotesql) AS t(count integer) INTO user_table_count;
-        
+
         IF user_table_count > 0 THEN
             RAISE NOTICE '    [FAILED] %', rpad('Database ' || new_db_name || ' has ' || user_table_count || ' user-created tables', 60, ' ');
             RAISE EXCEPTION 'Exiting add_node: Database % on new node has user-created tables. It must be a freshly created database with no user tables (only system and extension tables allowed).', new_db_name;
@@ -1461,7 +1461,7 @@ BEGIN
             RAISE NOTICE '    OK: %', rpad('Checking database ' || new_db_name || ' has no user-created tables', 120, ' ');
         END IF;
     END;
-    
+
     -- Check that new node has all users that source node has
     DECLARE
         missing_users text := '';
@@ -1471,14 +1471,14 @@ BEGIN
         check_user_sql text;
     BEGIN
         src_users_sql := 'SELECT rolname FROM pg_roles WHERE rolcanlogin = true AND rolname NOT IN (''postgres'', ''rdsadmin'', ''rdsrepladmin'', ''rds_superuser'') ORDER BY rolname';
-        
-        FOR user_rec IN 
+
+        FOR user_rec IN
             SELECT * FROM dblink(src_dsn, src_users_sql) AS t(rolname text)
         LOOP
             -- Build the SQL with the rolname embedded (properly escaped)
             check_user_sql := format('SELECT EXISTS(SELECT 1 FROM pg_roles WHERE rolname = %L AND rolcanlogin = true)', user_rec.rolname);
             SELECT * FROM dblink(new_node_dsn, check_user_sql) AS t(exists boolean) INTO user_exists;
-            
+
             IF NOT user_exists THEN
                 IF missing_users = '' THEN
                     missing_users := user_rec.rolname;
@@ -1487,7 +1487,7 @@ BEGIN
                 END IF;
             END IF;
         END LOOP;
-        
+
         IF missing_users != '' THEN
             RAISE NOTICE '    [FAILED] %', rpad('New node missing users: ' || missing_users, 60, ' ');
             RAISE EXCEPTION 'Exiting add_node: New node is missing the following users that exist on source node: %. Please create these users on the new node before adding it to the cluster.', missing_users;
@@ -1495,7 +1495,7 @@ BEGIN
             RAISE NOTICE '    OK: %', rpad('Checking new node has all source node users', 120, ' ');
         END IF;
     END;
-    
+
     -- Validating new node prerequisites
     SELECT count(*) INTO new_exists FROM spock.node WHERE node_name = new_node_name;
     IF new_exists > 0 THEN
@@ -1582,25 +1582,30 @@ BEGIN
     RAISE NOTICE 'Phase 4: Configuring cross-node replication';
     BEGIN
         FOR rec IN SELECT * FROM temp_spock_nodes LOOP
-            
             IF rec.node_name = src_node_name THEN
                 CONTINUE;
             END IF;
-            -- Extract dbname and handle both quoted and unquoted values
-            -- Extract dbname and handle both quoted and unquoted values
-        dbname := substring(rec.dsn from 'dbname=([^\s]+)');
-        -- Remove single quotes if present
-        IF dbname IS NOT NULL THEN
-            dbname := TRIM(BOTH '''' FROM dbname);
-        END IF;
-            -- Remove single quotes if present
+
+		    -- Extract dbname and handle both quoted and unquoted values
+            dbname := TRIM(BOTH '''' FROM substring(rec.dsn from 'dbname=([^\s]+)'));
+
+		    -- Remove single quotes if present
+            IF dbname IS NOT NULL THEN
+                dbname := TRIM(BOTH '''' FROM dbname);
+            END IF;
+
+		    -- Remove single quotes if present
             IF dbname IS NOT NULL THEN
                 dbname := TRIM(BOTH '''' FROM dbname);
             END IF;
             IF dbname IS NULL THEN
                 dbname := 'pgedge';
             END IF;
-            slot_name := left('spk_' || dbname || '_' || rec.node_name || '_sub_' || rec.node_name || '_' || new_node_name, 64);
+
+            slot_name := spock.spock_gen_slot_name(
+							dbname, rec.node_name,
+							'sub_' || rec.node_name || '_' || new_node_name);
+
             CALL spock.create_replication_slot(
                 rec.dsn,
                 slot_name,
@@ -1629,17 +1634,18 @@ CREATE OR REPLACE PROCEDURE spock.create_disable_subscriptions_and_slots(
     verb boolean         -- Verbose flag
 ) LANGUAGE plpgsql AS $$
 DECLARE
-    rec RECORD;
+    rec                RECORD;
     subscription_count integer := 0;
-    remotesql text;
-    dbname text;
-    slot_name text;
+    remotesql          text;
+    dbname             text;
+    slot_name          text;
+	sub_name           text;
 BEGIN
     RAISE NOTICE 'Phase 3: Creating disabled subscriptions and slots';
-    
+
     -- Get all existing nodes (excluding source and new)
     CALL spock.get_spock_nodes(src_dsn, verb);
-    
+
     -- Create temporary table to store sync LSNs
     CREATE TEMP TABLE IF NOT EXISTS temp_sync_lsns (
         origin_node text PRIMARY KEY,
@@ -1668,9 +1674,13 @@ BEGIN
         RAISE NOTICE '    - 2-node scenario: sync event stored, skipping disabled subscriptions';
         RETURN;
     END IF;
-    
+
     -- For each "other" node (not source, not new), create disabled subscription and slot
-    FOR rec IN SELECT * FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name LOOP
+    FOR rec IN SELECT * FROM temp_spock_nodes
+	           WHERE node_name != src_node_name AND node_name != new_node_name
+	LOOP
+		sub_name := 'sub_' || rec.node_name || '_' || new_node_name;
+
         -- Trigger sync event on origin node and store LSN
         BEGIN
             RAISE NOTICE '    - 3+ node scenario: sync event stored, skipping disabled subscriptions';
@@ -1692,12 +1702,13 @@ BEGIN
         -- Create replication slot on the "other" node
         BEGIN
             -- Extract dbname and handle both quoted and unquoted values
-            -- Extract dbname and handle both quoted and unquoted values
-        dbname := substring(rec.dsn from 'dbname=([^\s]+)');
-        -- Remove single quotes if present
-        IF dbname IS NOT NULL THEN
-            dbname := TRIM(BOTH '''' FROM dbname);
-        END IF;
+            dbname := TRIM(BOTH '''' FROM substring(rec.dsn from 'dbname=([^\s]+)'));
+
+            -- Remove single quotes if present
+            IF dbname IS NOT NULL THEN
+                dbname := TRIM(BOTH '''' FROM dbname);
+            END IF;
+
             -- Remove single quotes if present
             IF dbname IS NOT NULL THEN
                 dbname := TRIM(BOTH '''' FROM dbname);
@@ -1722,7 +1733,7 @@ BEGIN
         BEGIN
             CALL spock.create_sub(
                 new_node_dsn,                                 -- Create on new node
-                'sub_' || rec.node_name || '_' || new_node_name, -- sub_<other_node>_<new_node>
+                sub_name, 									  -- sub_<new_node>_<other_node>
                 rec.dsn,                                      -- Provider is other node
                 'ARRAY[''default'', ''default_insert_only'', ''ddl_sql'']', -- Replication sets
                 false,                                        -- synchronize_structure
@@ -1733,15 +1744,15 @@ BEGIN
                 false,                                        -- force_text_transfer
                 verb                                          -- verbose
             );
-            RAISE NOTICE '    OK: %', rpad('Creating initial subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name, 120, ' ');
+            RAISE NOTICE '    ✓ %', rpad('Creating initial subscription ' || sub_name || ' on node ' || rec.node_name, 120, ' ');
             PERFORM pg_sleep(5);
             subscription_count := subscription_count + 1;
         EXCEPTION
             WHEN OTHERS THEN
-                RAISE NOTICE '    ✗ %', rpad('Creating initial subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+                RAISE NOTICE '    ✗ %', rpad('Creating initial subscription ' || sub_name || ' on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
         END;
     END LOOP;
-    
+
     IF subscription_count = 0 THEN
         RAISE NOTICE '    - No disabled subscriptions created';
     END IF;
@@ -1759,20 +1770,19 @@ CREATE OR REPLACE PROCEDURE spock.enable_disabled_subscriptions(
     verb boolean
 ) LANGUAGE plpgsql AS $$
 DECLARE
-    rec RECORD;
+    rec      RECORD;
+	sub_name text;
 BEGIN
     RAISE NOTICE 'Phase 8: Enabling disabled subscriptions';
-    
+
     -- Check if this is a 2-node scenario (only source and new node)
     IF (SELECT count(*) FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name) = 0 THEN
         -- 2-node scenario: enable the disabled subscription from source to new node
+
+		sub_name := 'sub_' || src_node_name || '_' || new_node_name;
+
         BEGIN
-                    CALL spock.enable_sub(
-            new_node_dsn,
-            'sub_' || src_node_name || '_' || new_node_name,
-            verb,  -- verb
-            true   -- immediate
-        );
+            CALL spock.enable_sub( new_node_dsn, sub_name, verb, true);
 
             -- Wait for the sync event that was captured when subscription was created
             -- This ensures the subscription starts replicating from the correct sync point
@@ -1783,8 +1793,8 @@ BEGIN
             BEGIN
                 -- Check if temp_sync_lsns table exists
                 SELECT EXISTS (
-                    SELECT 1 FROM pg_tables 
-                    WHERE tablename = 'temp_sync_lsns' 
+                    SELECT 1 FROM pg_tables
+                    WHERE tablename = 'temp_sync_lsns'
                     AND schemaname = 'pg_temp'
                 ) INTO temp_table_exists;
 
@@ -1825,15 +1835,15 @@ BEGIN
                 verb
             );
 
-            RAISE NOTICE '    OK: %', rpad('Enabling subscription sub_' || src_node_name || '_' || new_node_name || '...', 120, ' ');
+            RAISE NOTICE '    ✓ %', rpad('Enabling subscription ' || sub_name || '...', 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
-                RAISE NOTICE '    ✗ %', rpad('Enabling subscription sub_' || src_node_name || '_' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+                RAISE NOTICE '    ✗ %', rpad('Enabling subscription ' || sub_name || ' (error: ' || SQLERRM || ')', 120, ' ');
                 RAISE;
         END;
         RETURN;
     END IF;
-    
+
     -- Multi-node scenario: original logic for other nodes
     -- Enable the initially disabled subscriptions
     BEGIN
@@ -1841,19 +1851,16 @@ BEGIN
             subscription_count integer := 0;
         BEGIN
             FOR rec IN SELECT * FROM temp_spock_nodes LOOP
-                IF rec.node_name = src_node_name THEN   
+                IF rec.node_name = src_node_name THEN
                     CONTINUE;  -- Skip source node as it's handled separately
                 END IF;
                 IF rec.node_name = new_node_name THEN
                     CONTINUE;  -- Skip new node to avoid self-subscription
                 END IF;
-                
-                CALL spock.enable_sub(
-                    new_node_dsn,
-                    'sub_'|| rec.node_name || '_' || new_node_name,
-                    verb,  -- verb
-                    true   -- immediate
-                );
+
+				sub_name := 'sub_'|| rec.node_name || '_' || new_node_name;
+
+                CALL spock.enable_sub(new_node_dsn, sub_name, verb, true);
 
                 -- Wait for the sync event that was captured when subscription was created
                 -- This ensures the subscription starts replicating from the correct sync point
@@ -1891,10 +1898,10 @@ BEGIN
                     verb
                 );
 
-                RAISE NOTICE '    OK: %', rpad('Enabling subscription sub_' || rec.node_name || '_' || new_node_name || '...', 120, ' ');
+                RAISE NOTICE '    ✓ %', rpad('Enabling subscription ' || sub_name || '...', 120, ' ');
                 subscription_count := subscription_count + 1;
             END LOOP;
-            
+
             IF subscription_count = 0 THEN
                 RAISE NOTICE '    - %', rpad('No subscriptions to enable', 120, ' ');
             END IF;
@@ -1918,20 +1925,22 @@ CREATE OR REPLACE PROCEDURE spock.create_sub_on_new_node_to_src_node(
     verb            boolean  -- Verbose flag
 ) LANGUAGE plpgsql AS $$
 DECLARE
-    rec RECORD;
+    rec                RECORD;
     subscription_count integer := 0;
+	sub_name           text;
 BEGIN
     RAISE NOTICE 'Phase 9: Creating subscriptions from all other nodes to new node';
-    
+
     -- Get all existing nodes (excluding new node)
     CALL spock.get_spock_nodes(src_dsn, verb);
-    
+
     -- For each existing node (excluding new node), create subscription TO the new node
     FOR rec IN SELECT * FROM temp_spock_nodes WHERE node_name != new_node_name LOOP
+	    sub_name := 'sub_' || rec.node_name || '_' || new_node_name;
         BEGIN
             CALL spock.create_sub(
                 rec.dsn,                                      -- Create on existing node
-                'sub_' || new_node_name || '_' || rec.node_name, -- sub_<existing_node>_<new_node>
+                sub_name, 									  -- sub_<new_node>_<existing_node>
                 new_node_dsn,                                 -- Provider is new node
                 'ARRAY[''default'', ''default_insert_only'', ''ddl_sql'']', -- Replication sets
                 false,                                        -- synchronize_structure
@@ -1942,15 +1951,15 @@ BEGIN
                 false,                                        -- force_text_transfer
                 verb                                          -- verbose
             );
-            RAISE NOTICE '    OK: %', rpad('Creating subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name || '...', 120, ' ');
+            RAISE NOTICE '    ✓ %', rpad('Creating subscription ' || sub_name || ' on node ' || rec.node_name || '...', 120, ' ');
             PERFORM pg_sleep(5);
             subscription_count := subscription_count + 1;
         EXCEPTION
             WHEN OTHERS THEN
-                RAISE NOTICE '    ✗ %', rpad('Creating subscription sub_' || rec.node_name || '_' || new_node_name || ' on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+                RAISE NOTICE '    ✗ %', rpad('Creating subscription ' || sub_name || ' on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
         END;
     END LOOP;
-    
+
     IF subscription_count = 0 THEN
         RAISE NOTICE '    - No subscriptions created (no other nodes found)';
     ELSE
@@ -1969,13 +1978,15 @@ CREATE OR REPLACE PROCEDURE spock.create_new_to_source_subscription(
     new_node_dsn text,
     verb boolean
 ) LANGUAGE plpgsql AS $$
+DECLARE
+    sub_name text := 'sub_' || new_node_name || '_' || src_node_name;
 BEGIN
     RAISE NOTICE 'Phase 10: Creating new to source node subscription';
-    
+
     -- Create subscription from new node to source node (enabled with sync)
     CALL spock.create_sub(
         src_dsn,
-        'sub_' || new_node_name || '_' || src_node_name,
+        sub_name,
         new_node_dsn,
         'ARRAY[''default'', ''default_insert_only'', ''ddl_sql'']',
         false,   -- synchronize_structure
@@ -1986,7 +1997,7 @@ BEGIN
         false,   -- force_text_transfer
         verb
     );
-    RAISE NOTICE '    OK: %', rpad('Creating subscription sub_' || new_node_name || '_' || src_node_name || ' on node ' || new_node_name || '...', 120, ' ');
+    RAISE NOTICE '    ✓ %', rpad('Creating subscription ' || sub_name || ' on node ' || new_node_name || '...', 120, ' ');
     PERFORM pg_sleep(5);
 END;
 $$;
@@ -2001,13 +2012,15 @@ CREATE OR REPLACE PROCEDURE spock.create_source_to_new_subscription(
     new_node_dsn    text,  -- New node DSN
     verb            boolean  -- Verbose flag
 ) LANGUAGE plpgsql AS $$
+DECLARE
+    sub_name text := 'sub_' || src_node_name || '_' || new_node_name;
 BEGIN
     RAISE NOTICE 'Phase 4: Creating source to new node subscription';
-    
+
     -- Create subscription from source to new node (enabled with sync)
     CALL spock.create_sub(
         new_node_dsn,                                 -- Create on new node
-        'sub_' || src_node_name || '_' || new_node_name, -- sub_<src_node>_<new_node>
+        sub_name, 									  -- sub_<new_node>_<src_node>
         src_dsn,                                      -- Provider is source node
         'ARRAY[''default'', ''default_insert_only'', ''ddl_sql'']', -- Replication sets
         true,                                         -- synchronize_structure
@@ -2018,7 +2031,7 @@ BEGIN
         false,                                        -- force_text_transfer
         verb                                          -- verbose
     );
-    RAISE NOTICE '    OK: %', rpad('Creating subscription sub_' || src_node_name || '_' || new_node_name || ' on node ' || new_node_name || '...', 120, ' ');
+    RAISE NOTICE '    ✓ %', rpad('Creating subscription ' || sub_name || ' on node ' || new_node_name || '...', 120, ' ');
     PERFORM pg_sleep(5);
 END;
 $$;
@@ -2040,13 +2053,13 @@ DECLARE
     remotesql text;
 BEGIN
     RAISE NOTICE 'Phase 5: Triggering sync events on other nodes and waiting on source';
-    
+
     -- Check if this is a 2-node scenario (only source and new node)
     IF (SELECT count(*) FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name) = 0 THEN
         RAISE NOTICE '    - No other nodes exist, skipping sync events';
         RETURN;
     END IF;
-    
+
     -- Multi-node scenario: trigger sync on "other" nodes and wait on source
     FOR rec IN SELECT * FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name LOOP
         -- Trigger sync event on "other" node
@@ -2055,7 +2068,7 @@ BEGIN
             IF verb THEN
                 RAISE NOTICE '    Remote SQL for sync event on %: %', rec.node_name, remotesql;
             END IF;
-            
+
             SELECT * FROM dblink(rec.dsn, remotesql) AS t(lsn pg_lsn) INTO sync_lsn;
             RAISE NOTICE '    OK: %', rpad('Triggering sync event on node ' || rec.node_name || ' (LSN: ' || sync_lsn || ')...', 120, ' ');
         EXCEPTION
@@ -2063,15 +2076,15 @@ BEGIN
                 RAISE NOTICE '    ✗ %', rpad('Triggering sync event on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
                 CONTINUE;
         END;
-        
+
         -- Wait for sync event on source node
         BEGIN
-            remotesql := format('CALL spock.wait_for_sync_event(true, %L, %L::pg_lsn, %s);', 
+            remotesql := format('CALL spock.wait_for_sync_event(true, %L, %L::pg_lsn, %s);',
                                rec.node_name, sync_lsn, timeout_ms);
             IF verb THEN
                 RAISE NOTICE '    Remote SQL for waiting sync event: %', remotesql;
             END IF;
-            
+
             PERFORM * FROM dblink(src_dsn, remotesql) AS t(result text);
             RAISE NOTICE '    OK: %', rpad('Waiting for sync event from ' || rec.node_name || ' on source node ' || src_node_name || '...', 120, ' ');
         EXCEPTION
@@ -2100,25 +2113,25 @@ DECLARE
     remotesql text;
 BEGIN
     RAISE NOTICE 'Phase 7: Checking commit timestamp and advancing replication slot';
-    
+
     -- Check if this is a 2-node scenario (only source and new node)
     IF (SELECT count(*) FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name) = 0 THEN
         RAISE NOTICE '    - No other nodes exist, skipping commit timestamp check';
         RETURN;
     END IF;
-    
+
     -- Multi-node scenario: check commit timestamp for "other" nodes to new node
     FOR rec IN SELECT * FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name LOOP
         -- Check commit timestamp for lag from "other" node to new node
         BEGIN
-            remotesql := format('SELECT commit_timestamp FROM spock.lag_tracker WHERE origin_name = %L AND receiver_name = %L', 
+            remotesql := format('SELECT commit_timestamp FROM spock.lag_tracker WHERE origin_name = %L AND receiver_name = %L',
                                rec.node_name, new_node_name);
             IF verb THEN
                 RAISE NOTICE '    Remote SQL for commit timestamp check: %', remotesql;
             END IF;
-            
+
             SELECT * FROM dblink(new_node_dsn, remotesql) AS t(ts timestamp) INTO commit_ts;
-            
+
             IF commit_ts IS NOT NULL THEN
                 RAISE NOTICE '    OK: %', rpad('Found commit timestamp for ' || rec.node_name || '->' || new_node_name || ': ' || commit_ts, 120, ' ');
             ELSE
@@ -2130,59 +2143,61 @@ BEGIN
                 RAISE NOTICE '    ✗ %', rpad('Checking commit timestamp for ' || rec.node_name || '->' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
                 CONTINUE;
         END;
-        
+
         -- Advance replication slot based on commit timestamp
         BEGIN
             -- Extract dbname and handle both quoted and unquoted values
-            -- Extract dbname and handle both quoted and unquoted values
-        dbname := substring(rec.dsn from 'dbname=([^\s]+)');
-        -- Remove single quotes if present
-        IF dbname IS NOT NULL THEN
-            dbname := TRIM(BOTH '''' FROM dbname);
-        END IF;
+            dbname := TRIM(BOTH '''' FROM substring(rec.dsn from 'dbname=([^\s]+)'));
+
+            -- Remove single quotes if present
+            IF dbname IS NOT NULL THEN
+                dbname := TRIM(BOTH '''' FROM dbname);
+            END IF;
+
             -- Remove single quotes if present
             IF dbname IS NOT NULL THEN
                 dbname := TRIM(BOTH '''' FROM dbname);
             END IF;
             IF dbname IS NULL THEN dbname := 'pgedge'; END IF;
-            slot_name := left('spk_' || dbname || '_' || rec.node_name || '_sub_' || rec.node_name || '_' || new_node_name, 64);
-            
+
+			slot_name := spock.spock_gen_slot_name(dbname, rec.node_name, 'sub_' || rec.node_name || '_' || new_node_name);
+
             -- First check if slot exists and get current LSN
             remotesql := format('SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = %L', slot_name);
             IF verb THEN
                 RAISE NOTICE '    Remote SQL for slot check: %', remotesql;
             END IF;
-            
+
             DECLARE
                 current_lsn pg_lsn;
                 target_lsn pg_lsn;
             BEGIN
                 SELECT * FROM dblink(rec.dsn, remotesql) AS t(lsn pg_lsn) INTO current_lsn;
-                
+
                 IF current_lsn IS NULL THEN
                     RAISE NOTICE '    - Slot % does not exist, skipping advancement', slot_name;
                     CONTINUE;
                 END IF;
-                
+
                 -- Get target LSN from commit timestamp
                 remotesql := format('SELECT spock.get_lsn_from_commit_ts(%L, %L::timestamp)', slot_name, commit_ts);
                 IF verb THEN
                     RAISE NOTICE '    Remote SQL for LSN lookup: %', remotesql;
                 END IF;
-                
+
                 SELECT * FROM dblink(rec.dsn, remotesql) AS t(lsn pg_lsn) INTO target_lsn;
-                
+
                 IF target_lsn IS NULL OR target_lsn <= current_lsn THEN
                     RAISE NOTICE '    - Slot % already at or beyond target LSN (current: %, target: %)', slot_name, current_lsn, target_lsn;
                     CONTINUE;
                 END IF;
-                
+
                 -- Advance the slot
                 remotesql := format('SELECT pg_replication_slot_advance(%L, %L::pg_lsn)', slot_name, target_lsn);
                 IF verb THEN
                     RAISE NOTICE '    Remote SQL for slot advancement: %', remotesql;
                 END IF;
-                
+
                 PERFORM * FROM dblink(rec.dsn, remotesql) AS t(result text);
                 RAISE NOTICE '    OK: %', rpad('Advanced slot ' || slot_name || ' from ' || current_lsn || ' to ' || target_lsn, 120, ' ');
             END;
@@ -2212,7 +2227,7 @@ BEGIN
     SELECT now() - commit_timestamp INTO lag_interval
     FROM spock.lag_tracker
     WHERE origin_name = origin_node AND receiver_name = receiver_node;
-    
+
     IF lag_interval IS NOT NULL THEN
         IF verb THEN
             RAISE NOTICE '% → % lag: %', origin_node, receiver_node, lag_interval;
@@ -2288,18 +2303,18 @@ DECLARE
 BEGIN
     -- Phase 10: Presenting final cluster state
     RAISE NOTICE 'Phase 10: Presenting final cluster state';
-    
+
     -- Wait for replication to be active
     RAISE NOTICE '    Waiting for replication to be active...';
     LOOP
         wait_count := wait_count + 1;
-        
+
         -- Check subscription status
         IF verb THEN
             RAISE NOTICE '[QUERY] SELECT status FROM spock.sub_show_status() LIMIT 1';
         END IF;
         SELECT status INTO sub_status FROM spock.sub_show_status() LIMIT 1;
-        
+
         IF sub_status = 'replicating' THEN
             RAISE NOTICE '    OK: Replication is active (status: %)', sub_status;
             EXIT;
@@ -2311,26 +2326,26 @@ BEGIN
             PERFORM pg_sleep(1);
         END IF;
     END LOOP;
-    
+
     -- Print nodes in psql-style table format
     RAISE NOTICE '';
     RAISE NOTICE 'Current Spock Nodes:';
     RAISE NOTICE ' node_id | node_name | location | country | info';
     RAISE NOTICE '---------+-----------+----------+---------+------';
-    
+
     IF verb THEN
         RAISE NOTICE '[QUERY] SELECT node_id, node_name, location, country, info FROM spock.node ORDER BY node_id';
     END IF;
     FOR rec IN SELECT node_id, node_name, location, country, info FROM spock.node ORDER BY node_id LOOP
-        RAISE NOTICE ' % | % | % | % | %', 
-            rpad(rec.node_id::text, 7, ' '), 
-            rpad(rec.node_name, 9, ' '), 
-            rpad(COALESCE(rec.location, ''), 9, ' '), 
-            rpad(COALESCE(rec.country, ''), 7, ' '), 
+        RAISE NOTICE ' % | % | % | % | %',
+            rpad(rec.node_id::text, 7, ' '),
+            rpad(rec.node_name, 9, ' '),
+            rpad(COALESCE(rec.location, ''), 9, ' '),
+            rpad(COALESCE(rec.country, ''), 7, ' '),
             COALESCE(rec.info::text, '');
     END LOOP;
     RAISE NOTICE '';
-    
+
     -- Show subscription status
     RAISE NOTICE 'Subscription Status:';
     IF verb THEN
@@ -2377,6 +2392,7 @@ $$;
  *   src_dsn           - DSN of the source node
  *   new_node_name     - Name of the node to be added
  *   new_node_dsn      - DSN of the new node
+ *   verb			   - verbose, show more information during the process (default: false)
  *   new_node_location - Location (default: 'NY')
  *   new_node_country  - Country (default: 'USA')
  *   new_node_info     - JSONB object with additional metadata (default: '{}')
@@ -2393,7 +2409,7 @@ CREATE OR REPLACE PROCEDURE spock.add_node(
     src_dsn text,
     new_node_name text,
     new_node_dsn text,
-    verb boolean,
+    verb boolean DEFAULT false,
     new_node_location text DEFAULT 'NY',
     new_node_country text DEFAULT 'USA',
     new_node_info jsonb DEFAULT '{}'::jsonb


### PR DESCRIPTION
- Tune the documentation a little.
- Arrange code line shifts and trailing backspaces.
- Process the database name string, considering quoted and unquoted cases.