### PR TITLE
SPOC-288: simplify zodan version checking

### DIFF
--- a/samples/Z0DAN/zodan.py
+++ b/samples/Z0DAN/zodan.py
@@ -865,6 +865,10 @@ class SpockClusterManager:
             raise Exception(f"Spock version mismatch: new node has version {new_version}, "
                           f"but minimum required version is {min_required_version}. Please upgrade all nodes to at least {min_required_version}.")
         
+        if new_version != src_version:
+            raise Exception(f"Spock version mismatch: new node has version {new_version}, "
+                          f"but source version is {src_version}. Please ensure they are the same.")
+
         # Check all existing nodes in cluster
         nodes = self.get_spock_nodes(src_dsn)
         
@@ -880,7 +884,11 @@ class SpockClusterManager:
                 raise Exception(f"Spock version mismatch: node {node['node_name']} has version {node_version}, "
                               f"but minimum required version is {min_required_version}. "
                               f"All nodes must have version {min_required_version}.")
-        
+
+            if node_version != new_version:
+                raise Exception(f"Spock version mismatch: new node has version {new_version}, "
+                              f"but node version is {node_version}. Please ensure they are the same.")
+
         self.notice(f"Version check passed: All nodes running at least Spock version {min_required_version}. Source node {src_version}, new node {new_version}")
 
     def add_node(self, src_node_name: str, src_dsn: str, new_node_name: str, new_node_dsn: str,

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -77,6 +77,11 @@ BEGIN
         RAISE EXCEPTION 'Spock version mismatch: new node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
             new_version, min_required_version, min_required_version;
     END IF;
+
+    IF new_version != src_version THEN
+        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Please ensure that they match.',
+            new_version, src_version;
+    END IF;
     
     -- Check all existing nodes in cluster
     FOR node_rec IN 
@@ -95,6 +100,11 @@ BEGIN
             version_mismatch := true;
             RAISE EXCEPTION 'Spock version mismatch: node % has version %, but required version is at least %. All nodes must have version % or later.'
                 node_rec.node_name, node_version, min_required_version, min_required_version;
+        END IF;
+
+        IF node_version != new_version THEN
+            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Please ensure that they match.',
+                new_version, node_version;
         END IF;
     END LOOP;
     


### PR DESCRIPTION
Change the version checking to simply make sure that the version is at least 5.0.4, and that the version matches on all of the nodes. This will simplify maintenance in the short term, especially between branches.

Yes, once we get to version 10.* or 5.0.10, etc. we will need to revisit this.  Long term we intend to build safe-upgrade version lists for more flexibility.