### PR TITLE
Fix link format for two-node cluster documentation (#230)

### DIFF
--- a/docs/install_spock.md
+++ b/docs/install_spock.md
@@ -20,7 +20,7 @@ Spock is open-source and available for review at [Github](https://github.com/pgE
     pgEdge Postgres deployments also provide a simplified upgrade path so you can take advantage of important new features quickly and easily.
 
 
-For detailed information about using Spock to create a two-node cluster, visit [here](/two_node_cluster.md)).
+For detailed information about using Spock to create a two-node cluster, visit [here](./two_node_cluster.md).
 
 
 ### Building the Extension from Source


### PR DESCRIPTION
Also, removed extra parenthesis...

(cherry picked from commit ddee8f20b1e3f58c2100891aa4accf8d12c2852b)