### PR TITLE
Fix set_repair_mode warning

### DIFF
--- a/include/spock_output_plugin.h
+++ b/include/spock_output_plugin.h
@@ -94,7 +94,6 @@ typedef struct SpockOutputSlotGroup
  * Custom WAL messages
  */
 extern bool		spock_replication_repair_mode;
-extern inline void set_repair_mode(bool is_enabled);
 
 #define SPOCK_REPAIR_MODE_ON		1	/* Suppress subsequent DML/DDL */
 #define SPOCK_REPAIR_MODE_OFF		2	/* Resume regular replication */

--- a/src/spock_output_plugin.c
+++ b/src/spock_output_plugin.c
@@ -49,6 +49,7 @@
 bool	spock_replication_repair_mode = false;
 
 /* Local functions */
+static inline void set_repair_mode(bool is_enabled);
 static void pg_decode_startup(LogicalDecodingContext * ctx,
 							  OutputPluginOptions *opt, bool is_init);
 static void pg_decode_shutdown(LogicalDecodingContext * ctx);
@@ -146,7 +147,7 @@ _PG_output_plugin_init(OutputPluginCallbacks *cb)
  * better to centralize management of this feature and LOG each time it is
  * changed.
  */
-inline void
+static inline void
 set_repair_mode(bool is_enabled)
 {
 	if (likely(spock_replication_repair_mode == is_enabled))


### PR DESCRIPTION
It is only in one file, no need to be in a header file