### PR TITLE
Fix two bugs in the table re-sync routine (spoc-263).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondar
 		  interfaces foreign_key copy sequence triggers parallel functions row_filter \
 		  row_filter_sampling att_list column_filter apply_delay \
 		  extended node_origin_cascade multiple_upstreams tuple_origin autoddl \
-		  drop
+		  sync_table drop
 
 # The following test cases are disabled while developing.
 #
@@ -195,7 +195,7 @@ set -e -u -x
 # If you don't want leak checking, use --leak-check=no
 #
 # When just doing leak checking and not looking for detailed memory error reports you don't need:
-# 	--track-origins=yes --read-var-info=yes --malloc-fill=8f --free-fill=9f 
+# 	--track-origins=yes --read-var-info=yes --malloc-fill=8f --free-fill=9f
 #
 SUPP=$(POSTGRES_SRC)/src/tools/valgrind.supp
 

--- a/docs/spock_functions/functions/spock_sub_resync_table.md
+++ b/docs/spock_functions/functions/spock_sub_resync_table.md
@@ -4,18 +4,20 @@
 
 ### SYNOPSIS
 
-`spock.sub_resync_table (subscription_name name, relation regclass)`
- 
+`spock.sub_resync_table (subscription_name name, relation regclass, truncate boolean)`
+
 ### DESCRIPTION
 
-Resynchronize one existing table. 
+Resynchronize one existing table.
 
 ### EXAMPLE
 
 `spock.sub-resync-table ('sub_n2n1', 'mytable')`
- 
-### POSITIONAL ARGUMENTS
+
+### ARGUMENTS
     subscription_name
         The name of the existing subscription.
     relation
         The name of existing table, optionally schema qualified.
+    truncate
+        Truncate table before synchronisation (default value is true). If do not truncate, conflicts between existing rows and newly arriving may cause errors.

--- a/sql/spock--6.0.0-devel.sql
+++ b/sql/spock--6.0.0-devel.sql
@@ -302,9 +302,14 @@ RETURNS int CALLED ON NULL INPUT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spoc
 CREATE FUNCTION spock.sub_alter_sync(subscription_name name, truncate boolean DEFAULT false)
 RETURNS boolean STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_alter_subscription_synchronize';
 
-CREATE FUNCTION spock.sub_resync_table(subscription_name name, relation regclass,
-	truncate boolean DEFAULT true)
-RETURNS boolean STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_alter_subscription_resynchronize_table';
+CREATE FUNCTION spock.sub_resync_table(
+	subscription_name name,
+	relation          regclass,
+	truncate          boolean DEFAULT true
+)
+RETURNS boolean
+AS 'MODULE_PATHNAME', 'spock_alter_subscription_resynchronize_table'
+LANGUAGE C STRICT VOLATILE;
 
 CREATE FUNCTION spock.sync_seq(relation regclass)
 RETURNS boolean STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_synchronize_sequence';

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -3279,10 +3279,20 @@ process_syncing_tables(XLogRecPtr end_lsn)
 										 NameStr(sync->nspname),
 										 NameStr(sync->relname));
 
+				/*
+				 * TODO:
+				 * What if the SYNC worker has gone? It may be any trivial
+				 * ERROR - memory allocation, or network connection, for
+				 * example. We need to restart syncing process from the scratch.
+				 * For now, suppose that it should be always exist in testing
+				 * environment.
+				 */
+				Assert(spock_worker_running(worker));
+
 				if (spock_worker_running(worker) &&
-					end_lsn >= worker->worker.apply.replay_stop_lsn)
+					replorigin_session_origin_lsn >= worker->worker.apply.replay_stop_lsn)
 				{
-					worker->worker.apply.replay_stop_lsn = end_lsn;
+					worker->worker.apply.replay_stop_lsn = replorigin_session_origin_lsn;
 					sync->status = SYNC_STATUS_CATCHUP;
 
 					StartTransactionCommand();
@@ -3304,6 +3314,13 @@ process_syncing_tables(XLogRecPtr end_lsn)
 													SYNC_STATUS_SYNCDONE,
 													&sync->statuslsn))
 						sync->status = SYNC_STATUS_SYNCDONE;
+					else
+						/*
+						 * TODO:
+						 * Here, should be a more sophisticated logic in case if
+						 * worker exited on error or status record has lost.
+						 */
+						elog(ERROR, "a table synchronisation operation is failed");
 				}
 				else
 					LWLockRelease(SpockCtx->lock);

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -194,6 +194,7 @@ PG_FUNCTION_INFO_V1(get_apply_group_progress);
 static void gen_slot_name(Name slot_name, char *dbname,
 						  const char *provider_name,
 						  const char *subscriber_name);
+static XLogRecPtr skip_wal_records_decoding(bool enable);
 
 
 bool in_spock_replicate_ddl_command = false;
@@ -977,16 +978,25 @@ Datum spock_alter_subscription_synchronize(PG_FUNCTION_ARGS)
 /*
  * Resynchronize one existing table.
  */
-Datum spock_alter_subscription_resynchronize_table(PG_FUNCTION_ARGS)
+Datum
+spock_alter_subscription_resynchronize_table(PG_FUNCTION_ARGS)
 {
-	char *sub_name = NameStr(*PG_GETARG_NAME(0));
-	Oid reloid = PG_GETARG_OID(1);
-	bool truncate = PG_GETARG_BOOL(2);
-	SpockSubscription *sub = get_subscription_by_name(sub_name, false);
-	SpockSyncStatus *oldsync;
-	Relation rel;
-	char *nspname,
-		*relname;
+	char			   *sub_name = NameStr(*PG_GETARG_NAME(0));
+	Oid					reloid = PG_GETARG_OID(1);
+	bool				truncate = PG_GETARG_BOOL(2);
+	SpockSubscription  *sub = get_subscription_by_name(sub_name, false);
+	SpockSyncStatus	   *oldsync;
+	Relation			rel;
+	char			   *nspname;
+	char			   *relname;
+
+	/*
+	 * Don't need to replicate any WAL generated here.
+	 * If any error will happen in the middle of the process, rollback machinery
+	 * return the state of the GUC in the backend as well, as an ABORT operator
+	 * return default state in the walsender.
+	 */
+	skip_wal_records_decoding(true);
 
 	rel = table_open(reloid, AccessShareLock);
 
@@ -1027,6 +1037,7 @@ Datum spock_alter_subscription_resynchronize_table(PG_FUNCTION_ARGS)
 	/* Tell apply to re-read sync statuses. */
 	spock_subscription_changed(sub->id, false);
 
+	skip_wal_records_decoding(false);
 	PG_RETURN_BOOL(true);
 }
 
@@ -2981,23 +2992,19 @@ Datum delta_apply_money(PG_FUNCTION_ARGS)
 }
 
 /*
- * Function to control REPAIR mode
+ * Stop decoding messages till the end of the transaction.
  *
- * The Spock output plugin with suppress all DML messages after decoding
- * the SPOCK_REPAIR_MODE_ON message. Normal operation will resume after
- * receiving the SPOCK_REPAIR_MODE_OFF message or on transaction end.
- *
- * This is equivalent to session_replication_role=local.
+ * It is a general tool to perform operations, local for current spock node.
  */
-Datum
-spock_repair_mode(PG_FUNCTION_ARGS)
+static XLogRecPtr
+skip_wal_records_decoding(bool enable)
 {
 	SpockWalMessageSimple	message;
 	XLogRecPtr				lsn;
-	bool					enabled = PG_GETARG_BOOL(0);
 
-	message.mtype = (enabled) ? SPOCK_REPAIR_MODE_ON : SPOCK_REPAIR_MODE_OFF;
-	lsn = LogLogicalMessage(SPOCK_MESSAGE_PREFIX, (char *)&message, sizeof(message), true);
+	message.mtype = (enable) ? SPOCK_REPAIR_MODE_ON : SPOCK_REPAIR_MODE_OFF;
+	lsn = LogLogicalMessage(SPOCK_MESSAGE_PREFIX, (char *) &message,
+							sizeof(message), true);
 
 	/*
 	 * Set the flag of repair mode till the end of the transaction or another
@@ -3009,8 +3016,27 @@ spock_repair_mode(PG_FUNCTION_ARGS)
 	 * walsender, does it?
 	 */
 	(void) set_config_option("spock.replication_repair_mode",
-							 (enabled) ? "on" : "off", PGC_INTERNAL,
+							 (enable) ? "on" : "off", PGC_INTERNAL,
 							 PGC_S_SESSION, GUC_ACTION_LOCAL, true, 0, false);
+	return lsn;
+}
+
+/*
+ * Function to control REPAIR mode
+ *
+ * The Spock output plugin with suppress all DML messages after decoding
+ * the SPOCK_REPAIR_MODE_ON message. Normal operation will resume after
+ * receiving the SPOCK_REPAIR_MODE_OFF message or on transaction end.
+ *
+ * This is equivalent to session_replication_role=local.
+ */
+Datum
+spock_repair_mode(PG_FUNCTION_ARGS)
+{
+	XLogRecPtr	lsn;
+	bool		enabled = PG_GETARG_BOOL(0);
+
+	lsn = skip_wal_records_decoding(enabled);
 	PG_RETURN_LSN(lsn);
 }
 

--- a/tests/regress/expected/sync_table.out
+++ b/tests/regress/expected/sync_table.out
@@ -1,0 +1,206 @@
+/* First test whether a table's replication set can be properly manipulated */
+SELECT * FROM spock_regress_variables()
+\gset
+--
+-- Test resynchronization
+--
+\c :provider_dsn
+SELECT spock.replicate_ddl('CREATE TABLE test_sync(x integer primary key)');
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'test_sync');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO test_sync (x) SELECT value FROM generate_series(1,10) AS value;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+  55 |    10
+(1 row)
+
+\c :subscriber_dsn
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+  55 |    10
+(1 row)
+
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+ sync_kind | sync_nspname | sync_relname | sync_status | ?column? 
+-----------+--------------+--------------+-------------+----------
+ f         |              |              | r           | f
+(1 row)
+
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+ sub_resync_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+ table_wait_for_sync 
+---------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+  55 |    10
+(1 row)
+
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+ sync_kind | sync_nspname | sync_relname | sync_status | ?column? 
+-----------+--------------+--------------+-------------+----------
+ f         |              |              | r           | f
+ d         | public       | test_sync    | r           | t
+(2 rows)
+
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+ sub_resync_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+ table_wait_for_sync 
+---------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+  55 |    10
+(1 row)
+
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+ sync_kind | sync_nspname | sync_relname | sync_status | ?column? 
+-----------+--------------+--------------+-------------+----------
+ f         |              |              | r           | f
+ d         | public       | test_sync    | r           | t
+(2 rows)
+
+\c :provider_dsn
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+  55 |    10
+(1 row)
+
+-- Add more values and check they were added
+INSERT INTO test_sync (x) SELECT -value FROM generate_series(1,10) AS value;
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+   0 |    20
+(1 row)
+
+\c :subscriber_dsn
+-- Restart syncing this specific table, wait until the process finish and check
+-- all the data stay consistent
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+ sync_kind | sync_nspname | sync_relname | sync_status | ?column? 
+-----------+--------------+--------------+-------------+----------
+ f         |              |              | r           | f
+ d         | public       | test_sync    | r           | t
+(2 rows)
+
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+ sub_resync_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+ table_wait_for_sync 
+---------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+   0 |    20
+(1 row)
+
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+ sync_kind | sync_nspname | sync_relname | sync_status | ?column? 
+-----------+--------------+--------------+-------------+----------
+ f         |              |              | r           | f
+ d         | public       | test_sync    | r           | t
+(2 rows)
+
+-- Check all data still in place
+\c :provider_dsn
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+   0 |    20
+(1 row)
+
+-- Test that a TRUNCATE command also re-syncing correctly
+TRUNCATE test_sync;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+ sub_resync_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+ table_wait_for_sync 
+---------------------
+ 
+(1 row)
+
+SELECT sum(x), count(*) FROM test_sync;
+ sum | count 
+-----+-------
+     |     0
+(1 row)
+
+\c :provider_dsn
+-- Cleanup
+SELECT spock.repset_remove_table('default', 'test_sync', true);
+ repset_remove_table 
+---------------------
+ t
+(1 row)
+
+DROP TABLE test_sync;

--- a/tests/regress/sql/sync_table.sql
+++ b/tests/regress/sql/sync_table.sql
@@ -1,0 +1,71 @@
+/* First test whether a table's replication set can be properly manipulated */
+
+SELECT * FROM spock_regress_variables()
+\gset
+
+--
+-- Test resynchronization
+--
+
+\c :provider_dsn
+SELECT spock.replicate_ddl('CREATE TABLE test_sync(x integer primary key)');
+SELECT * FROM spock.repset_add_table('default', 'test_sync');
+INSERT INTO test_sync (x) SELECT value FROM generate_series(1,10) AS value;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+SELECT sum(x), count(*) FROM test_sync;
+
+\c :subscriber_dsn
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+SELECT sum(x), count(*) FROM test_sync;
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+SELECT sum(x), count(*) FROM test_sync;
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+
+SELECT sum(x), count(*) FROM test_sync;
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+
+\c :provider_dsn
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+SELECT sum(x), count(*) FROM test_sync;
+
+-- Add more values and check they were added
+INSERT INTO test_sync (x) SELECT -value FROM generate_series(1,10) AS value;
+SELECT sum(x), count(*) FROM test_sync;
+
+\c :subscriber_dsn
+-- Restart syncing this specific table, wait until the process finish and check
+-- all the data stay consistent
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+SELECT sum(x), count(*) FROM test_sync;
+SELECT sync_kind,sync_nspname,sync_relname,sync_status, sync_statuslsn <> '0/0'
+FROM spock.local_sync_status;
+
+-- Check all data still in place
+\c :provider_dsn
+SELECT sum(x), count(*) FROM test_sync;
+
+-- Test that a TRUNCATE command also re-syncing correctly
+TRUNCATE test_sync;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+\c :subscriber_dsn
+SELECT spock.sub_resync_table('test_subscription', 'test_sync', true);
+SELECT spock.table_wait_for_sync('test_subscription', 'test_sync');
+SELECT sum(x), count(*) FROM test_sync;
+
+\c :provider_dsn
+
+-- Cleanup
+SELECT spock.repset_remove_table('default', 'test_sync', true);
+DROP TABLE test_sync;


### PR DESCRIPTION
At first, we need to switch off WAL sending machinery when truncating and re-synchronising the table. It prevents us from losing data across the instances.

The second issue is related to the infinite waiting if no more DML is committed to the table. The SYNC apply worker report status only on commit. So, the applying worker, who has initiated this synchronisation, should provide the SYNC worker not with the last received record LSN, but with the last committed LSN.

A simple regression test set is provided.

Being in the context, revisit the documentation and visual representation of the re-sync routine in the UI script.