### PR TITLE
SPOC-307: Block zodan if lolor is installed on new node

### DIFF
--- a/samples/Z0DAN/zodan.py
+++ b/samples/Z0DAN/zodan.py
@@ -160,7 +160,21 @@ class SpockClusterManager:
         except Exception as e:
             self.format_notice("✗", f"Database {new_db_name} does not exist on new node")
             raise Exception(f"Exiting add_node: Database {new_db_name} does not exist on new node. Please create it first.")
-        
+
+        # Check if they previously installed lolor on the destination.
+        # They should not have run CREATE EXTENSION lolor yet
+        sql = """
+        SELECT count(*) FROM pg_tables
+        WHERE schemaname = 'lolor'
+        """
+        user_table_count = self.run_psql(new_node_dsn, sql, fetch=True, return_single=True)
+
+        if user_table_count and int(user_table_count.strip()) > 0:
+            self.format_notice("✗", f"Checking database {new_db_name} to ensure lolor is not installed")
+            raise Exception(f"Exiting add_node: Database {new_db_name} has the lolor extension installed or remaining lolor user data. The new node should not have the lolor extension installed")
+        else:
+            self.format_notice("OK:", f"Checking database {new_db_name} to ensure lolor is not installed")
+
         # Check if database has user-created tables
         sql = """
         SELECT count(*) FROM pg_tables 


### PR DESCRIPTION
The pgEdge lolor extension creates tables in the lolor namespace schema to contain user large object data.

If lolor is installed on the target node when zodan is run, users currently get a message about there being existing user tables, and it fails (no user tables existing is a requirement of zodan).

It can be confusing for users to understand what the issue is. To make it clearer to zodan users, add an explicit check to tell the users that they should not have lolor installed on the target node.