### PR TITLE
SPOC-271: autoddl: centralize, simplify, and de-couple 

### DIFF
--- a/include/spock_autoddl.h
+++ b/include/spock_autoddl.h
@@ -26,6 +26,7 @@
 void		spock_autoddl_process(PlannedStmt *pstmt,
 								  const char *queryString,
 								  ProcessUtilityContext context,
-								  NodeTag *toplevel_stmt);
+								  NodeTag toplevel_stmt);
+void		add_ddl_to_repset(Node *parsetree);
 
 #endif							/* SPOCK_AUTODDL_H */


### PR DESCRIPTION
This commit moves all AutoDDL plumbing into spock_autoddl.c/.h, and the executor hook now delegates to spock_autoddl_process(), keeping spock_executor.c clean while consolidating decision logic and privilege handling in one place to reduce complexity and make future changes easier. 

It also streamlines the core logic by dropping recursive tag-matching and rewriting autoddl_can_proceed() with clear, early-exit filters for DDL-only cases; privilege handling and replication are centralized so DDL follows a single path
`clean query → replicate → repset registration`

And on subscribers, queued DDL replay registers new/altered tables directly into the appropriate replication set without relying on ProcessUtility, further reducing coupling between apply and executor.
