### PR TITLE
Arrange the spock pg_dump/pg_restore code according to Postgres 18.

### DIFF
--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -157,6 +157,8 @@ get_pg_executable(char *cmdname, char *cmdbuf)
 			 PG_VERSION_NUM / 100 / 100, PG_VERSION_NUM / 100 % 100);
 }
 
+#define ARGV_MAX_NUM	(22)
+
 static void
 dump_structure(SpockSubscription *sub, const char *destfile,
 			   const char *snapshot)
@@ -164,7 +166,7 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 	char	   *dsn;
 	char	   *err_msg;
 	char		pg_dump[MAXPGPATH];
-	char	   *cmdargv[20];
+	char	   *cmdargv[ARGV_MAX_NUM];
 	int			cmdargc = 0;
 	bool		has_snowflake;
 	StringInfoData	s;
@@ -194,8 +196,12 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 	appendStringInfo(&s, "--exclude-schema=%s", EXTENSION_NAME);
 	cmdargv[cmdargc++] = pstrdup(s.data);
 	resetStringInfo(&s);
-
-	/* Skip the snowflake if it exists locally. */
+#if PG_VERSION_NUM >= 180000
+	appendStringInfo(&s, "--exclude-extension=%s", EXTENSION_NAME);
+	cmdargv[cmdargc++] = pstrdup(s.data);
+	resetStringInfo(&s);
+#endif
+	/* Skip snowflake if it exists locally. */
 	StartTransactionCommand();
 	has_snowflake = OidIsValid(LookupExplicitNamespace("snowflake", true));
 	CommitTransactionCommand();
@@ -205,6 +211,11 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 		appendStringInfo(&s, "--exclude-schema=%s", "snowflake");
 		cmdargv[cmdargc++] = pstrdup(s.data);
 		resetStringInfo(&s);
+#if PG_VERSION_NUM >= 180000
+		appendStringInfo(&s, "--exclude-extension=%s", "snowflake");
+		cmdargv[cmdargc++] = pstrdup(s.data);
+		resetStringInfo(&s);
+#endif
 	}
 
 	/* Skip schemas specified in skip_schema list */
@@ -232,6 +243,8 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 	free(dsn);
 
 	cmdargv[cmdargc++] = NULL;
+
+	Assert(cmdargc < ARGV_MAX_NUM);
 
 	if (exec_cmd(pg_dump, cmdargv) != 0)
 		ereport(ERROR,


### PR DESCRIPTION
Commit 522ed12 introduced a new dump parameter '--exclude-extension'. Use it to avoid unnecessary commands related to the Spock and snowflake extensions.