### PR TITLE
Improve the wait_slot_confirm_lsn routine description.

### DIFF
--- a/sql/spock--6.0.0-devel.sql
+++ b/sql/spock--6.0.0-devel.sql
@@ -371,9 +371,10 @@ CREATE FUNCTION spock.get_country() RETURNS text
 LANGUAGE sql AS
 $$ SELECT current_setting('spock.country') $$;
 
-CREATE FUNCTION
-spock.wait_slot_confirm_lsn(slotname name, target pg_lsn)
-RETURNS void LANGUAGE c AS 'spock','spock_wait_slot_confirm_lsn';
+CREATE FUNCTION spock.wait_slot_confirm_lsn(slotname name, target pg_lsn)
+RETURNS void
+AS 'spock','spock_wait_slot_confirm_lsn'
+LANGUAGE C;
 
 CREATE FUNCTION spock.sub_wait_for_sync(subscription_name name)
 RETURNS void RETURNS NULL ON NULL INPUT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_wait_for_subscription_sync_complete';

--- a/tests/regress/expected/drop.out
+++ b/tests/regress/expected/drop.out
@@ -30,6 +30,15 @@ SELECT * FROM spock.node_drop(node_name := 'test_subscriber');
 (1 row)
 
 \c :provider_dsn
+-- Check corner-case of wait function when no replication slots exist.
+SELECT slot_name FROM pg_replication_slots; -- must be empty
+ slot_name 
+-----------
+(0 rows)
+
+SET statement_timeout = '100ms';
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- trigger the statement_timeout ERROR
+ERROR:  canceling statement due to statement timeout
 SELECT * FROM spock.node_drop(node_name := 'test_provider');
  node_drop 
 -----------

--- a/tests/regress/sql/drop.sql
+++ b/tests/regress/sql/drop.sql
@@ -12,6 +12,12 @@ SELECT * FROM spock.sub_drop('test_subscription');
 SELECT * FROM spock.node_drop(node_name := 'test_subscriber');
 
 \c :provider_dsn
+
+-- Check corner-case of wait function when no replication slots exist.
+SELECT slot_name FROM pg_replication_slots; -- must be empty
+SET statement_timeout = '100ms';
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL); -- trigger the statement_timeout ERROR
+
 SELECT * FROM spock.node_drop(node_name := 'test_provider');
 
 \c :subscriber_dsn


### PR DESCRIPTION
This function has a special corner case - it waits in an infinite loop until at least one proper replication slot is found. In Spock, a subscription may be accidentally disabled due to a critical error that may cause a stall.

Describe the case in more detail and add a test to give users and developers a clue how to use this routine safely.