### PR TITLE
Rebase: pg{15,16,17,18}-025-logical_commit_clock core patch

### DIFF
--- a/patches/15/pg15-025-logical_commit_clock.diff
+++ b/patches/15/pg15-025-logical_commit_clock.diff
@@ -1,5 +1,5 @@
 diff --git a/src/backend/access/transam/xact.c b/src/backend/access/transam/xact.c
-index 7a3d9b4b01..b8aaecccce 100644
+index 7a3d9b4b012..b8aaeccccef 100644
 --- a/src/backend/access/transam/xact.c
 +++ b/src/backend/access/transam/xact.c
 @@ -134,6 +134,15 @@ static TransactionId *ParallelCurrentXids;
@@ -152,10 +152,10 @@ index 7a3d9b4b01..b8aaecccce 100644
 +	XLogSetLastTransactionStopTimestamp(logical_clock);
 +}
 diff --git a/src/backend/access/transam/xlog.c b/src/backend/access/transam/xlog.c
-index 32cc0ddb7f..b55a1e307f 100644
+index 0528ac38d59..22ee4fcedd5 100644
 --- a/src/backend/access/transam/xlog.c
 +++ b/src/backend/access/transam/xlog.c
-@@ -156,6 +156,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
+@@ -157,6 +157,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
   */
  int			CheckPointSegments;
  
@@ -172,7 +172,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  /* Estimated distance between checkpoints, in bytes */
  static double CheckPointDistanceEstimate = 0;
  static double PrevCheckPointDistance = 0;
-@@ -553,6 +563,14 @@ typedef struct XLogCtlData
+@@ -554,6 +564,14 @@ typedef struct XLogCtlData
  	XLogRecPtr	lastFpwDisableRecPtr;
  
  	slock_t		info_lck;		/* locks shared variables shown above */
@@ -187,7 +187,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  } XLogCtlData;
  
  static XLogCtlData *XLogCtl = NULL;
-@@ -680,6 +698,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
+@@ -682,6 +700,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
  								XLogRecData *rdata,
  								XLogRecPtr StartPos, XLogRecPtr EndPos,
  								TimeLineID tli);
@@ -195,7 +195,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  static void ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos,
  									  XLogRecPtr *EndPos, XLogRecPtr *PrevPtr);
  static bool ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos,
-@@ -830,6 +849,13 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -832,6 +851,13 @@ XLogInsertRecord(XLogRecData *rdata,
  		return InvalidXLogRecPtr;
  	}
  
@@ -209,7 +209,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  	/*
  	 * Reserve space for the record in the WAL. This also sets the xl_prev
  	 * pointer.
-@@ -845,6 +871,17 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -847,6 +873,17 @@ XLogInsertRecord(XLogRecData *rdata,
  
  	if (inserted)
  	{
@@ -227,7 +227,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  		/*
  		 * Now that xl_prev has been filled in, calculate CRC of the record
  		 * header.
-@@ -1025,6 +1062,27 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -1027,6 +1064,27 @@ XLogInsertRecord(XLogRecData *rdata,
  	return EndPos;
  }
  
@@ -255,7 +255,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  /*
   * Reserves the right amount of space for a record of given size from the WAL.
   * *StartPos is set to the beginning of the reserved section, *EndPos to
-@@ -1065,6 +1123,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
+@@ -1067,6 +1125,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
  	 */
  	SpinLockAcquire(&Insert->insertpos_lck);
  
@@ -269,7 +269,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  	startbytepos = Insert->CurrBytePos;
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
-@@ -1124,6 +1189,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
+@@ -1126,6 +1191,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
  		return false;
  	}
  
@@ -282,7 +282,7 @@ index 32cc0ddb7f..b55a1e307f 100644
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
  
-@@ -8917,3 +8988,15 @@ SetWalWriterSleeping(bool sleeping)
+@@ -8982,3 +9053,15 @@ SetWalWriterSleeping(bool sleeping)
  	XLogCtl->WalWriterSleeping = sleeping;
  	SpinLockRelease(&XLogCtl->info_lck);
  }
@@ -299,7 +299,7 @@ index 32cc0ddb7f..b55a1e307f 100644
 +	XLogCtl->lastTransactionStopTimestamp = ts;
 +}
 diff --git a/src/include/access/xact.h b/src/include/access/xact.h
-index 8d46a781bb..a665662ebf 100644
+index 8d46a781bbd..a665662ebfd 100644
 --- a/src/include/access/xact.h
 +++ b/src/include/access/xact.h
 @@ -95,6 +95,13 @@ extern PGDLLIMPORT bool bsysscan;
@@ -317,7 +317,7 @@ index 8d46a781bb..a665662ebf 100644
   * XACT_FLAGS_ACCESSEDTEMPNAMESPACE - set when a temporary object is accessed.
   * We don't allow PREPARE TRANSACTION in that case.
 diff --git a/src/include/access/xlog.h b/src/include/access/xlog.h
-index 6af943a43a..a0f94dd7b8 100644
+index e81a9d6aec9..24aece75182 100644
 --- a/src/include/access/xlog.h
 +++ b/src/include/access/xlog.h
 @@ -192,6 +192,18 @@ typedef enum WALAvailability
@@ -339,8 +339,8 @@ index 6af943a43a..a0f94dd7b8 100644
  extern XLogRecPtr XLogInsertRecord(struct XLogRecData *rdata,
  								   XLogRecPtr fpw_lsn,
  								   uint8 flags,
-@@ -260,6 +272,14 @@ extern void SetInstallXLogFileSegmentActive(void);
- extern bool IsInstallXLogFileSegmentActive(void);
+@@ -260,6 +272,14 @@ extern bool IsInstallXLogFileSegmentActive(void);
+ extern void ResetInstallXLogFileSegmentActive(void);
  extern void XLogShutdownWalRcv(void);
  
 +/*

--- a/patches/16/pg16-025-logical_commit_clock.diff
+++ b/patches/16/pg16-025-logical_commit_clock.diff
@@ -1,5 +1,5 @@
 diff --git a/src/backend/access/transam/xact.c b/src/backend/access/transam/xact.c
-index 4a2ea4adba..86d7362e1a 100644
+index 4a2ea4adbaf..86d7362e1ab 100644
 --- a/src/backend/access/transam/xact.c
 +++ b/src/backend/access/transam/xact.c
 @@ -135,6 +135,15 @@ static TransactionId *ParallelCurrentXids;
@@ -152,10 +152,10 @@ index 4a2ea4adba..86d7362e1a 100644
 +	XLogSetLastTransactionStopTimestamp(logical_clock);
 +}
 diff --git a/src/backend/access/transam/xlog.c b/src/backend/access/transam/xlog.c
-index 06235073ce..547ab2c171 100644
+index 70cb88a7fee..574230cc9ad 100644
 --- a/src/backend/access/transam/xlog.c
 +++ b/src/backend/access/transam/xlog.c
-@@ -158,6 +158,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
+@@ -159,6 +159,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
   */
  int			CheckPointSegments;
  
@@ -172,7 +172,7 @@ index 06235073ce..547ab2c171 100644
  /* Estimated distance between checkpoints, in bytes */
  static double CheckPointDistanceEstimate = 0;
  static double PrevCheckPointDistance = 0;
-@@ -557,6 +567,14 @@ typedef struct XLogCtlData
+@@ -558,6 +568,14 @@ typedef struct XLogCtlData
  	XLogRecPtr	lastFpwDisableRecPtr;
  
  	slock_t		info_lck;		/* locks shared variables shown above */
@@ -187,7 +187,7 @@ index 06235073ce..547ab2c171 100644
  } XLogCtlData;
  
  static XLogCtlData *XLogCtl = NULL;
-@@ -683,6 +701,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
+@@ -685,6 +703,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
  								XLogRecData *rdata,
  								XLogRecPtr StartPos, XLogRecPtr EndPos,
  								TimeLineID tli);
@@ -195,7 +195,7 @@ index 06235073ce..547ab2c171 100644
  static void ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos,
  									  XLogRecPtr *EndPos, XLogRecPtr *PrevPtr);
  static bool ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos,
-@@ -833,6 +852,13 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -835,6 +854,13 @@ XLogInsertRecord(XLogRecData *rdata,
  		return InvalidXLogRecPtr;
  	}
  
@@ -209,7 +209,7 @@ index 06235073ce..547ab2c171 100644
  	/*
  	 * Reserve space for the record in the WAL. This also sets the xl_prev
  	 * pointer.
-@@ -848,6 +874,17 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -850,6 +876,17 @@ XLogInsertRecord(XLogRecData *rdata,
  
  	if (inserted)
  	{
@@ -227,7 +227,7 @@ index 06235073ce..547ab2c171 100644
  		/*
  		 * Now that xl_prev has been filled in, calculate CRC of the record
  		 * header.
-@@ -1028,6 +1065,27 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -1030,6 +1067,27 @@ XLogInsertRecord(XLogRecData *rdata,
  	return EndPos;
  }
  
@@ -255,7 +255,7 @@ index 06235073ce..547ab2c171 100644
  /*
   * Reserves the right amount of space for a record of given size from the WAL.
   * *StartPos is set to the beginning of the reserved section, *EndPos to
-@@ -1068,6 +1126,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
+@@ -1070,6 +1128,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
  	 */
  	SpinLockAcquire(&Insert->insertpos_lck);
  
@@ -269,7 +269,7 @@ index 06235073ce..547ab2c171 100644
  	startbytepos = Insert->CurrBytePos;
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
-@@ -1127,6 +1192,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
+@@ -1129,6 +1194,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
  		return false;
  	}
  
@@ -282,7 +282,7 @@ index 06235073ce..547ab2c171 100644
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
  
-@@ -8979,3 +9050,15 @@ SetWalWriterSleeping(bool sleeping)
+@@ -9058,3 +9129,15 @@ SetWalWriterSleeping(bool sleeping)
  	XLogCtl->WalWriterSleeping = sleeping;
  	SpinLockRelease(&XLogCtl->info_lck);
  }
@@ -299,7 +299,7 @@ index 06235073ce..547ab2c171 100644
 +	XLogCtl->lastTransactionStopTimestamp = ts;
 +}
 diff --git a/src/include/access/xact.h b/src/include/access/xact.h
-index 7d3b9446e6..44c253734d 100644
+index 7d3b9446e62..44c253734df 100644
 --- a/src/include/access/xact.h
 +++ b/src/include/access/xact.h
 @@ -95,6 +95,13 @@ extern PGDLLIMPORT bool bsysscan;
@@ -317,7 +317,7 @@ index 7d3b9446e6..44c253734d 100644
   * XACT_FLAGS_ACCESSEDTEMPNAMESPACE - set when a temporary object is accessed.
   * We don't allow PREPARE TRANSACTION in that case.
 diff --git a/src/include/access/xlog.h b/src/include/access/xlog.h
-index 48ca852381..35583baa62 100644
+index ebb9eaade0a..9a7d2f0fa2f 100644
 --- a/src/include/access/xlog.h
 +++ b/src/include/access/xlog.h
 @@ -193,6 +193,18 @@ typedef enum WALAvailability
@@ -339,8 +339,8 @@ index 48ca852381..35583baa62 100644
  extern XLogRecPtr XLogInsertRecord(struct XLogRecData *rdata,
  								   XLogRecPtr fpw_lsn,
  								   uint8 flags,
-@@ -259,6 +271,14 @@ extern void SetInstallXLogFileSegmentActive(void);
- extern bool IsInstallXLogFileSegmentActive(void);
+@@ -260,6 +272,14 @@ extern bool IsInstallXLogFileSegmentActive(void);
+ extern void ResetInstallXLogFileSegmentActive(void);
  extern void XLogShutdownWalRcv(void);
  
 +/*

--- a/patches/17/pg17-025-logical_commit_clock.diff
+++ b/patches/17/pg17-025-logical_commit_clock.diff
@@ -152,7 +152,7 @@ index 4cecf630060..d28e4904956 100644
 +	XLogSetLastTransactionStopTimestamp(logical_clock);
 +}
 diff --git a/src/backend/access/transam/xlog.c b/src/backend/access/transam/xlog.c
-index c1dd8b54328..efd60f97fd0 100644
+index 17b88ff6453..cfe303ac156 100644
 --- a/src/backend/access/transam/xlog.c
 +++ b/src/backend/access/transam/xlog.c
 @@ -156,6 +156,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
@@ -187,7 +187,7 @@ index c1dd8b54328..efd60f97fd0 100644
  } XLogCtlData;
  
  /*
-@@ -701,6 +719,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
+@@ -702,6 +720,7 @@ static void CopyXLogRecordToWAL(int write_len, bool isLogSwitch,
  								XLogRecData *rdata,
  								XLogRecPtr StartPos, XLogRecPtr EndPos,
  								TimeLineID tli);
@@ -195,7 +195,7 @@ index c1dd8b54328..efd60f97fd0 100644
  static void ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos,
  									  XLogRecPtr *EndPos, XLogRecPtr *PrevPtr);
  static bool ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos,
-@@ -779,6 +798,13 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -780,6 +799,13 @@ XLogInsertRecord(XLogRecData *rdata,
  	if (!XLogInsertAllowed())
  		elog(ERROR, "cannot make new WAL entries during recovery");
  
@@ -209,7 +209,7 @@ index c1dd8b54328..efd60f97fd0 100644
  	/*
  	 * Given that we're not in recovery, InsertTimeLineID is set and can't
  	 * change, so we can read it without a lock.
-@@ -907,6 +933,17 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -908,6 +934,17 @@ XLogInsertRecord(XLogRecData *rdata,
  
  	if (inserted)
  	{
@@ -227,7 +227,7 @@ index c1dd8b54328..efd60f97fd0 100644
  		/*
  		 * Now that xl_prev has been filled in, calculate CRC of the record
  		 * header.
-@@ -1087,6 +1124,27 @@ XLogInsertRecord(XLogRecData *rdata,
+@@ -1088,6 +1125,27 @@ XLogInsertRecord(XLogRecData *rdata,
  	return EndPos;
  }
  
@@ -255,7 +255,7 @@ index c1dd8b54328..efd60f97fd0 100644
  /*
   * Reserves the right amount of space for a record of given size from the WAL.
   * *StartPos is set to the beginning of the reserved section, *EndPos to
-@@ -1131,6 +1189,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
+@@ -1132,6 +1190,13 @@ ReserveXLogInsertLocation(int size, XLogRecPtr *StartPos, XLogRecPtr *EndPos,
  	 */
  	SpinLockAcquire(&Insert->insertpos_lck);
  
@@ -269,7 +269,7 @@ index c1dd8b54328..efd60f97fd0 100644
  	startbytepos = Insert->CurrBytePos;
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
-@@ -1190,6 +1255,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
+@@ -1191,6 +1256,12 @@ ReserveXLogSwitch(XLogRecPtr *StartPos, XLogRecPtr *EndPos, XLogRecPtr *PrevPtr)
  		return false;
  	}
  
@@ -282,7 +282,7 @@ index c1dd8b54328..efd60f97fd0 100644
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
  
-@@ -9500,3 +9571,15 @@ SetWalWriterSleeping(bool sleeping)
+@@ -9546,3 +9617,15 @@ SetWalWriterSleeping(bool sleeping)
  	XLogCtl->WalWriterSleeping = sleeping;
  	SpinLockRelease(&XLogCtl->info_lck);
  }
@@ -317,7 +317,7 @@ index 6d4439f0524..4fc1c96a79d 100644
   * XACT_FLAGS_ACCESSEDTEMPNAMESPACE - set when a temporary object is accessed.
   * We don't allow PREPARE TRANSACTION in that case.
 diff --git a/src/include/access/xlog.h b/src/include/access/xlog.h
-index 2c507ea618c..19a6fa6d992 100644
+index 9c2d101c570..03ffc3064ec 100644
 --- a/src/include/access/xlog.h
 +++ b/src/include/access/xlog.h
 @@ -196,6 +196,18 @@ typedef enum WALAvailability
@@ -339,8 +339,8 @@ index 2c507ea618c..19a6fa6d992 100644
  extern XLogRecPtr XLogInsertRecord(struct XLogRecData *rdata,
  								   XLogRecPtr fpw_lsn,
  								   uint8 flags,
-@@ -267,6 +279,14 @@ extern void SetInstallXLogFileSegmentActive(void);
- extern bool IsInstallXLogFileSegmentActive(void);
+@@ -268,6 +280,14 @@ extern bool IsInstallXLogFileSegmentActive(void);
+ extern void ResetInstallXLogFileSegmentActive(void);
  extern void XLogShutdownWalRcv(void);
  
 +/*

--- a/patches/18/pg18-025-logical_commit_clock.diff
+++ b/patches/18/pg18-025-logical_commit_clock.diff
@@ -152,7 +152,7 @@ index b885513f765..62219cc44eb 100644
 +	XLogSetLastTransactionStopTimestamp(logical_clock);
 +}
 diff --git a/src/backend/access/transam/xlog.c b/src/backend/access/transam/xlog.c
-index c9e5daecd5e..f6cb76ded8d 100644
+index 596d2ca5836..ee52552a79f 100644
 --- a/src/backend/access/transam/xlog.c
 +++ b/src/backend/access/transam/xlog.c
 @@ -156,6 +156,16 @@ int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
@@ -282,7 +282,7 @@ index c9e5daecd5e..f6cb76ded8d 100644
  	endbytepos = startbytepos + size;
  	prevbytepos = Insert->PrevBytePos;
  
-@@ -9544,3 +9615,15 @@ SetWalWriterSleeping(bool sleeping)
+@@ -9564,3 +9635,15 @@ SetWalWriterSleeping(bool sleeping)
  	XLogCtl->WalWriterSleeping = sleeping;
  	SpinLockRelease(&XLogCtl->info_lck);
  }
@@ -317,7 +317,7 @@ index b2bc10ee041..0ab9948b4cf 100644
   * XACT_FLAGS_ACCESSEDTEMPNAMESPACE - set when a temporary object is accessed.
   * We don't allow PREPARE TRANSACTION in that case.
 diff --git a/src/include/access/xlog.h b/src/include/access/xlog.h
-index d313099c027..5d6e6831a08 100644
+index adddac6710e..99864217c5c 100644
 --- a/src/include/access/xlog.h
 +++ b/src/include/access/xlog.h
 @@ -199,6 +199,18 @@ typedef enum WALAvailability
@@ -339,8 +339,8 @@ index d313099c027..5d6e6831a08 100644
  extern XLogRecPtr XLogInsertRecord(struct XLogRecData *rdata,
  								   XLogRecPtr fpw_lsn,
  								   uint8 flags,
-@@ -271,6 +283,14 @@ extern void SetInstallXLogFileSegmentActive(void);
- extern bool IsInstallXLogFileSegmentActive(void);
+@@ -272,6 +284,14 @@ extern bool IsInstallXLogFileSegmentActive(void);
+ extern void ResetInstallXLogFileSegmentActive(void);
  extern void XLogShutdownWalRcv(void);
  
 +/*


### PR DESCRIPTION
Upstream fix a142010739 was back-patched to REL_15..REL_18, which reordered/expanded the xlog.h prototype block and added ResetInstallXLogFileSegmentActive(). That shifted nearby context in xlog.h, causing our *-025-logical_commit_clock.diff hunks to fail under git apply (while patch(1) would fuzz them in).

Refresh the series against current REL_*_STABLE so git apply succeed without fuzz. No functional changes.