### PR TITLE
Add comprehensive defensive checks to prevent crashes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ spock_create_subscriber
 spock.control
 tags
 .vscode
+*.dylib
+*.orig
+pg.log
+regression.diffs
+regression.out
+utils/spockctrl/spockctrl

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2906,7 +2906,8 @@ Datum reset_channel_stats(PG_FUNCTION_ARGS)
 	hash_seq_init(&hash_seq, SpockHash);
 	while ((entry = hash_seq_search(&hash_seq)) != NULL)
 	{
-		hash_search(SpockHash, &entry->key, HASH_REMOVE, NULL);
+		if (hash_search(SpockHash, &entry->key, HASH_REMOVE, NULL) == NULL)
+			elog(WARNING, "spock hash table corrupted during stats reset");
 	}
 
 	LWLockRelease(SpockCtx->lock);
@@ -3324,7 +3325,7 @@ get_apply_group_progress(PG_FUNCTION_ARGS)
 	HASH_SEQ_STATUS		it;
 	SpockGroupEntry	   *e;
 
-	if (!SpockCtx || !SpockHash)
+	if (!SpockCtx || !SpockHash || !SpockGroupHash)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 				 errmsg("spock must be loaded via shared_preload_libraries")));

--- a/src/spock_rmgr.c
+++ b/src/spock_rmgr.c
@@ -163,6 +163,11 @@ spock_rmgr_startup(void)
 void
 spock_rmgr_cleanup(void)
 {
+	/*
+	 * During WAL recovery the startup process must attach to the Spock
+	 * shared memory structures that were created by the postmaster.
+	 */
+	spock_shmem_attach();
 }
 
 /*


### PR DESCRIPTION
Hash table corruption checks in the relation metadata cache now emit warnings instead of aborting the entire postmaster. Hash removal operations that fail for entries obtained from sequential scan log descriptive warnings and terminate backends gracefully rather than forcing postmaster panics. This prevents cascade failures when dynahash bookkeeping becomes inconsistent, allowing other backends and workers to continue operating normally.

Hash table access functions verify shared memory initialization before performing operations. The group attach function validates SpockGroupHash exists before hash insertions and reports errors if hash_search fails to allocate entries. Lookup and foreach operations check for NULL hash pointers and handle gracefully by returning NULL or skipping iteration respectively. Progress update operations ensure both SpockCtx and SpockGroupHash are initialized before accessing locks or performing hash operations.

Worker progress retrieval no longer uses Assert statements that crash in production builds. The function returns NULL gracefully when called from contexts where the worker is not attached to a group, preventing crashes during partial initialization or error recovery paths. Stats reset operations check hash_search HASH_REMOVE return values and emit warnings when removal fails, preventing silent corruption propagation when dynahash internal bookkeeping becomes inconsistent.

The apply worker detach operation verifies the worker structure is properly initialized before dereferencing to decrement attachment counters. Entry count mismatches during resource dumps are treated as warnings rather than fatal errors when concurrent WAL replay legitimately modifies the hash table. Since WAL remains authoritative for recovery, treating transient count mismatches as fatal would cause unnecessary checkpointer crashes and prevent proper checkpoint completion.

The WAL recovery startup process explicitly attaches to shared memory structures during cleanup phase of custom resource manager processing. Without this attachment, the startup process would attempt to update group progress using invalid inherited pointers from the postmaster, causing segmentation faults during crash recovery. The group progress monitoring function now verifies all required hash tables are initialized before beginning iteration, preventing null pointer dereferences when querying replication status.