### PR TITLE
SPOC-482: Add replay queue spill-to-disk for large transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondar
 		  interfaces foreign_key copy sequence triggers parallel functions row_filter \
 		  row_filter_sampling att_list column_filter apply_delay \
 		  extended node_origin_cascade multiple_upstreams tuple_origin autoddl \
-		  sync_event sync_table generated_columns drop
+		  sync_event sync_table generated_columns spill_transaction drop
 
 # The following test cases are disabled while developing.
 #

--- a/include/spock.h
+++ b/include/spock.h
@@ -50,7 +50,7 @@ extern bool spock_include_ddl_repset;
 extern bool allow_ddl_from_functions;
 extern int	restart_delay_default;
 extern int	restart_delay_on_exception;
-extern int	spock_replay_queue_size;	/* Deprecated - no longer used */
+extern int	spock_replay_queue_size;
 extern bool check_all_uc_indexes;
 extern bool	spock_enable_quiet_mode;
 extern int	log_origin_change;

--- a/src/spock.c
+++ b/src/spock.c
@@ -1160,7 +1160,7 @@ _PG_init(void)
 							"Set to 0 to disable spilling (unlimited memory).",
 							&spock_replay_queue_size,
 							4,
-							-1,
+							0,
 							MAX_KILOBYTES / 1024,
 							PGC_SIGHUP,
 							GUC_UNIT_MB,

--- a/src/spock.c
+++ b/src/spock.c
@@ -143,7 +143,7 @@ bool		spock_include_ddl_repset = false;
 bool		allow_ddl_from_functions = false;
 int			restart_delay_default;
 int			restart_delay_on_exception;
-int			spock_replay_queue_size;	/* Deprecated - no longer used */
+int			spock_replay_queue_size;
 bool		check_all_uc_indexes = false;
 bool		spock_enable_quiet_mode = false;
 int			log_origin_change = SPOCK_ORIGIN_NONE;
@@ -1154,12 +1154,13 @@ _PG_init(void)
 							NULL);
 
 	DefineCustomIntVariable("spock.exception_replay_queue_size",
-							"DEPRECATED: apply-worker replay queue size (no longer used)",
-							"This setting is deprecated and has no effect. "
-							"The replay queue now dynamically allocates memory as needed.",
+							"Maximum in-memory size for the apply replay queue",
+							"When the replay queue exceeds this size, subsequent "
+							"entries are spilled to a temporary file on disk. "
+							"Set to 0 to disable spilling (unlimited memory).",
 							&spock_replay_queue_size,
 							4,
-							0,
+							-1,
 							MAX_KILOBYTES / 1024,
 							PGC_SIGHUP,
 							GUC_UNIT_MB,

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -3181,9 +3181,11 @@ stream_replay:
 					 * In-memory entries (both first-pass and replay) live in
 					 * ApplyReplayContext and are freed by
 					 * MemoryContextReset inside apply_replay_queue_reset,
-					 * called from handle_commit.
+					 * called on applying a COMMIT.
+					 *
+					 * !from_pq catches spill-read entries during replay.
 					 */
-					if (entry_spilled)
+					if (entry_spilled || !entry->from_pq)
 						apply_replay_entry_free(entry);
 				}
 				else if (c == 'k')
@@ -4124,9 +4126,16 @@ apply_replay_spill_write_entry(int len, char *data)
 	Assert(len > 0);
 	Assert(data != NULL);
 
+	/*
+	 * Increment the count before writing so that a partial or failed write
+	 * (ERROR from BufFileWrite) leaves the count higher than the number of
+	 * complete records on disk.  During replay, apply_replay_spill_read_entry()
+	 * will attempt to read this record, hit EOF or a short read, and raise
+	 * ERROR — which triggers a clean worker restart via the outer PG_CATCH.
+	 */
+	apply_replay_spill_count++;
 	BufFileWrite(apply_replay_spill_file, &len, sizeof(int));
 	BufFileWrite(apply_replay_spill_file, data, len);
-	apply_replay_spill_count++;
 }
 
 /*
@@ -4328,11 +4337,6 @@ apply_replay_queue_append_entry(ApplyReplayEntry *entry, StringInfo msg)
 
 		apply_replay_spill_write_entry(msg->len, msg->data);
 
-		/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
-		if (xact_action_counter % 100 == 0)
-			elog(DEBUG1, "SPOCK %s: replay queue spill entry %u: ",
-				 MySubscription->name, xact_action_counter);
-
 		/*
 		 * Move the entry struct from ApplyReplayContext to TopMemoryContext.
 		 * handle_commit calls apply_replay_queue_reset which does
@@ -4342,9 +4346,8 @@ apply_replay_queue_append_entry(ApplyReplayEntry *entry, StringInfo msg)
 		 */
 		oldctx = MemoryContextSwitchTo(TopMemoryContext);
 		mc_entry = (ApplyReplayEntry *) palloc(sizeof(ApplyReplayEntry));
-		/* nosemgrep: palloc above allocates exactly sizeof(ApplyReplayEntry)
-		 * bytes — the same size memcpy copies — so no overflow is possible. */
-		memcpy(mc_entry, entry, sizeof(ApplyReplayEntry));
+		/* palloc and memcpy use the same sizeof — no overflow possible. */
+		memcpy(mc_entry, entry, sizeof(ApplyReplayEntry)); /* nosemgrep */
 		MemoryContextSwitchTo(oldctx);
 
 		pfree(entry);

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -44,6 +44,7 @@
 
 #include "rewrite/rewriteHandler.h"
 
+#include "storage/buffile.h"
 #include "storage/ipc.h"
 #include "storage/lmgr.h"
 #include "storage/proc.h"
@@ -117,13 +118,29 @@ typedef struct ApplyReplayEntryData ApplyReplayEntry;
 struct ApplyReplayEntryData
 {
 	StringInfoData copydata;
+	bool		from_pq;	/* true if data was allocated by libpq (PQgetCopyData) */
 	ApplyReplayEntry *next;
 };
 static MemoryContext ApplyReplayContext = NULL;
 static ApplyReplayEntry * apply_replay_head = NULL;
 static ApplyReplayEntry * apply_replay_tail = NULL;
+
+/*
+ * NULL if apply worker is in normal mode.  Points to the current element of
+ * the replay queue (to be replayed in DISCARD mode or logged during dry-run
+ * in TRANSDISCARD or SUB_DISABLE modes).  Must be NULL when a spilled record
+ * is read from disk.
+ */
 static ApplyReplayEntry * apply_replay_next = NULL;
+
+/* Total bytes of libpq-allocated data held by in-memory queue entries */
 static int	apply_replay_bytes = 0;
+
+static bool apply_replay_mode = false;		/* true when replaying */
+static BufFile *apply_replay_spill_file = NULL;
+static bool apply_replay_spilling = false;
+static int	apply_replay_spill_count = 0;
+static int	apply_replay_spill_read = 0;
 
 /* Number of tuples inserted after which we switch to multi-insert. */
 #define MIN_MULTI_INSERT_TUPLES 5
@@ -234,6 +251,12 @@ static void get_feedback_position(XLogRecPtr *recvpos, XLogRecPtr *writepos,
 								  XLogRecPtr *flushpos, XLogRecPtr *max_recvpos);
 static void UpdateWorkerStats(XLogRecPtr last_received, XLogRecPtr last_inserted);
 static void maybe_advance_forwarded_origin(XLogRecPtr end_lsn, bool xact_had_exception);
+static ApplyReplayEntry *apply_replay_queue_next_entry(void);
+static ApplyReplayEntry *apply_replay_queue_append_entry(ApplyReplayEntry *entry,
+							StringInfo msg);
+static void apply_replay_queue_start_replay(void);
+static void apply_replay_spill_write_entry(int len, char *data);
+static ApplyReplayEntry *apply_replay_spill_read_entry(void);
 
 /* Wrapper for latch for waiting for previous transaction to commit */
 void
@@ -1026,14 +1049,14 @@ handle_commit(StringInfo s)
 	xact_action_counter = 0;
 	remote_xid = InvalidTransactionId;
 
+	/* Reset the ApplyReplayContext and pointers */
+	apply_replay_queue_reset();
+
 	/*
 	 * This is the only place we can reset the use_try_block = false without
 	 * any risk of going into the error deathloop
 	 */
 	MyApplyWorker->use_try_block = false;
-
-	/* Reset the ApplyReplayContext and poiners */
-	apply_replay_queue_reset();
 
 	process_syncing_tables(end_lsn);
 
@@ -2920,7 +2943,6 @@ stream_replay:
 		while (!got_SIGTERM)
 		{
 			int			rc;
-			int			r;
 
 			MySpockWorker->worker_status = SPOCK_WORKER_STATUS_RUNNING;
 
@@ -2992,6 +3014,7 @@ stream_replay:
 			{
 				ApplyReplayEntry *entry;
 				bool		queue_append;
+				bool		entry_spilled = false;
 				StringInfo	msg;
 				int			c;
 
@@ -3000,7 +3023,7 @@ stream_replay:
 				if (got_SIGTERM)
 					break;
 
-				if (ConfigReloadPending)
+			if (ConfigReloadPending)
 				{
 					ConfigReloadPending = false;
 					ProcessConfigFile(PGC_SIGHUP);
@@ -3032,9 +3055,12 @@ stream_replay:
 					break;
 				}
 
-				if (apply_replay_next == NULL)
+				if (!apply_replay_mode)
 				{
 					char	   *buf;
+					int			r;
+
+					Assert(apply_replay_next == NULL);
 
 					/* We are not in replay mode so receive from the stream */
 					r = PQgetCopyData(applyconn, &buf, 1);
@@ -3087,9 +3113,9 @@ stream_replay:
 				}
 				else
 				{
-					/* We are in replay mode so present the next queue entry */
-					entry = apply_replay_next;
-					apply_replay_next = apply_replay_next->next;
+					entry = apply_replay_queue_next_entry();
+					if (entry == NULL)
+						continue;
 					queue_append = false;
 				}
 
@@ -3113,26 +3139,21 @@ stream_replay:
 					if (last_received < end_lsn)
 						last_received = end_lsn;
 
-					/*
-					 * Append the entry to the end of the replay queue if we
-					 * read it from the stream. Dynamic allocation means no
-					 * fixed size limit - queue grows as needed. Note:
-					 * spock_replay_queue_size is deprecated and no longer
-					 * checked.
-					 */
+					/* Append the entry to the replay queue if from stream */
 					if (queue_append)
 					{
-						apply_replay_bytes += msg->len;
+						ApplyReplayEntry *orig = entry;
 
-						if (apply_replay_head == NULL)
-						{
-							apply_replay_head = apply_replay_tail = entry;
-						}
-						else
-						{
-							apply_replay_tail->next = entry;
-							apply_replay_tail = entry;
-						}
+						entry = apply_replay_queue_append_entry(entry, msg);
+						entry_spilled = (entry != orig);
+
+						/*
+						 * Spilling relocates the entry from ApplyReplayContext
+						 * to TopMemoryContext, freeing the original.  Update msg
+						 * to point to the new copy's copydata.
+						 */
+						if (entry_spilled)
+							msg = &entry->copydata;
 					}
 
 					/*
@@ -3153,9 +3174,17 @@ stream_replay:
 					replication_handler(msg);
 
 					/*
-					 * Note: No overflow handling needed - dynamic allocation
-					 * used
+					 * Free spilled entries explicitly: their structs live in
+					 * TopMemoryContext (not ApplyReplayContext), so they are
+					 * not cleaned up by apply_replay_queue_reset.
+					 *
+					 * In-memory entries (both first-pass and replay) live in
+					 * ApplyReplayContext and are freed by
+					 * MemoryContextReset inside apply_replay_queue_reset,
+					 * called from handle_commit.
 					 */
+					if (entry_spilled)
+						apply_replay_entry_free(entry);
 				}
 				else if (c == 'k')
 				{
@@ -3380,7 +3409,8 @@ stream_replay:
 		MemoryContextReset(ApplyOperationContext);
 		spock_relation_cache_reset();
 
-		apply_replay_next = apply_replay_head;
+		apply_replay_queue_start_replay();
+
 		in_remote_transaction = false;
 		first_begin_at_startup = true;
 		remote_origin_lsn = InvalidXLogRecPtr;
@@ -4041,23 +4071,24 @@ spock_apply_main(Datum main_arg)
 }
 
 
-/* Create a new apply reply queue entry in the ApplyReplayContext */
+/* Create a new apply replay queue entry in ApplyReplayContext */
 static ApplyReplayEntry *
-apply_replay_entry_create(int r, char *buf)
+apply_replay_entry_create(int bufsize, char *buf)
 {
 	MemoryContext oldcontext;
 	ApplyReplayEntry *entry;
 
-	Assert(r > 0);
+	Assert(bufsize > 0);
 	Assert(buf != NULL);
 
 	oldcontext = MemoryContextSwitchTo(ApplyReplayContext);
 
 	entry = (ApplyReplayEntry *) palloc(sizeof(ApplyReplayEntry));
-	entry->copydata.len = r;
-	entry->copydata.maxlen = -1;
+	entry->copydata.len = bufsize;
+	entry->copydata.maxlen = bufsize;
 	entry->copydata.cursor = 0;
 	entry->copydata.data = buf;
+	entry->from_pq = true;
 	entry->next = NULL;
 
 	MemoryContextSwitchTo(oldcontext);
@@ -4065,31 +4096,314 @@ apply_replay_entry_create(int r, char *buf)
 	return entry;
 }
 
-/* Free on replay entry (unqueued message type or queue is overflowing) */
+/*
+ * Free one replay entry and its data buffer.
+ *
+ * Used for spilled entries whose structs live outside ApplyReplayContext
+ * and therefore are not cleaned up by MemoryContextReset.  The data buffer
+ * is freed with PQfreemem (libpq-allocated) or pfree (read from spill file).
+ */
 static void
-apply_replay_entry_free(ApplyReplayEntry * entry)
+apply_replay_entry_free(ApplyReplayEntry *entry)
 {
-	PQfreemem(entry->copydata.data);
+	if (entry->from_pq)
+		PQfreemem(entry->copydata.data);	/* libpq-allocated */
+	else
+		pfree(entry->copydata.data);		/* palloc'd from spill read */
 	pfree(entry);
 }
 
-/* Free all queued messages and reset the apply replay queue */
+/*
+ * Write one replay entry to the spill file.
+ * Format: [int32 length][data bytes]
+ */
+static void
+apply_replay_spill_write_entry(int len, char *data)
+{
+	Assert(apply_replay_spill_file != NULL);
+	Assert(len > 0);
+	Assert(data != NULL);
+
+	BufFileWrite(apply_replay_spill_file, &len, sizeof(int));
+	BufFileWrite(apply_replay_spill_file, data, len);
+	apply_replay_spill_count++;
+}
+
+/*
+ * Read one replay entry from the spill file.
+ *
+ * Returns a newly palloc'd ApplyReplayEntry.  Allocated in TopMemoryContext
+ * so it survives MemoryContextReset(ApplyReplayContext); on error during
+ * replay the apply worker restarts and cleans up all memory.
+ */
+static ApplyReplayEntry *
+apply_replay_spill_read_entry(void)
+{
+	int				len;
+	size_t			nread;
+	char		   *data;
+	ApplyReplayEntry *entry;
+	MemoryContext	oldcontext;
+
+	Assert(MyApplyWorker->use_try_block && apply_replay_spill_file != NULL);
+
+	nread = BufFileRead(apply_replay_spill_file, &len, sizeof(int));
+	if (nread != sizeof(int) || len <= 0 || len > (int) MaxAllocSize)
+	{
+		/*
+		 * Corrupt data on disk.  Raise ERROR to force worker restart or
+		 * subscription disablement.  The spill file is no longer a trusted
+		 * source of data.
+		 */
+		elog(ERROR, "SPOCK %s: corrupt replay spill file: "
+			 "read %zu bytes, record length %d",
+			 MySubscription->name, nread, len);
+	}
+
+	/*
+	 * Allocate in long-living memory context so the entry survives cleanup of
+	 * the in-memory replay queue.
+	 */
+	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+
+	data = palloc(len);
+	nread = BufFileRead(apply_replay_spill_file, data, len);
+	if (nread != len)
+		elog(ERROR, "SPOCK %s: corrupt replay spill file: "
+			 "read %zu bytes, record length %d",
+			 MySubscription->name, nread, len);
+
+	entry = (ApplyReplayEntry *) palloc(sizeof(ApplyReplayEntry));
+	entry->copydata.len = len;
+	entry->copydata.maxlen = len;
+	entry->copydata.cursor = 0;
+	entry->copydata.data = data;
+	entry->from_pq = false;
+	entry->next = NULL;
+
+	MemoryContextSwitchTo(oldcontext);
+
+	apply_replay_spill_read++;
+	return entry;
+}
+
+/*
+ * Free all messages queued in memory and reset replay context.
+ *
+ * In-memory entries may hold data buffers allocated by libpq (indicated by
+ * from_pq = true).  Those must be freed with PQfreemem before the
+ * ApplyReplayContext is reset, because MemoryContextReset only releases
+ * palloc'd memory.
+ */
 static void
 apply_replay_queue_reset(void)
 {
 	ApplyReplayEntry *entry;
 
+	/* Free libpq-allocated data buffers and in-memory queue itself */
 	for (entry = apply_replay_head; entry != NULL; entry = entry->next)
 	{
+		Assert(entry->from_pq);
 		PQfreemem(entry->copydata.data);
 	}
-
 	apply_replay_head = NULL;
 	apply_replay_tail = NULL;
 	apply_replay_next = NULL;
 	apply_replay_bytes = 0;
+	apply_replay_mode = false;
+
+	/* Close and delete the spill file if it exists */
+	if (apply_replay_spill_file != NULL)
+	{
+		BufFileClose(apply_replay_spill_file);
+		apply_replay_spill_file = NULL;
+	}
+	apply_replay_spilling = false;
+	apply_replay_spill_count = 0;
+	apply_replay_spill_read = 0;
 
 	MemoryContextReset(ApplyReplayContext);
+}
+
+/*
+ * Return the next entry from the replay queue.
+ *
+ * Drains the in-memory linked list first, then reads from the spill file.
+ * When all entries are exhausted, replay mode is turned off and NULL is
+ * returned.  The caller is responsible for freeing spilled entries; in-memory
+ * entries are freed by apply_replay_queue_reset via MemoryContextReset.
+ */
+static ApplyReplayEntry *
+apply_replay_queue_next_entry(void)
+{
+	Assert(apply_replay_mode);
+	Assert(MyApplyWorker->use_try_block);
+
+	if (apply_replay_next != NULL)
+	{
+		ApplyReplayEntry *entry = apply_replay_next;
+
+		apply_replay_next = apply_replay_next->next;
+
+		/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
+		elog(DEBUG1, "SPOCK: replay queue next entry from memory: len=%d",
+			 entry->copydata.len);
+		return entry;
+	}
+	else if (apply_replay_spilling &&
+			 apply_replay_spill_read < apply_replay_spill_count)
+	{
+		ApplyReplayEntry *entry = apply_replay_spill_read_entry();
+
+		/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
+		if (xact_action_counter % 100 == 0)
+			elog(DEBUG1, "SPOCK: replay queue next entry from disk: "
+				 "len=%d, read=%d of %d",
+				 entry->copydata.len, apply_replay_spill_read,
+				 apply_replay_spill_count);
+		Assert(entry != NULL);
+		return entry;
+	}
+	else
+	{
+		/*
+		 * Replay queue exhausted — switch back to stream reading.
+		 * The remaining cleanup (spill file, PQfreemem of in-memory
+		 * entries, MemoryContextReset) is deferred to
+		 * apply_replay_queue_reset called from handle_commit.
+		 */
+		apply_replay_mode = false;
+		return NULL;
+	}
+}
+
+/*
+ * Append an entry to the replay queue.
+ *
+ * If spock_replay_queue_size is configured and the in-memory limit is
+ * exceeded, spill subsequent entries to a temporary file on disk.
+ *
+ * Returns the entry to use after the call.  When spilled, the original
+ * entry (in ApplyReplayContext) is freed and replaced by a copy in
+ * TopMemoryContext that survives MemoryContextReset(ApplyReplayContext)
+ * in handle_commit.  The caller can detect spilling by comparing the
+ * returned pointer to the original.
+ */
+static ApplyReplayEntry *
+apply_replay_queue_append_entry(ApplyReplayEntry *entry, StringInfo msg)
+{
+	MemoryContext	oldctx;
+
+	Assert(entry != NULL);
+	Assert(msg != NULL);
+
+	/* Activate spilling once the in-memory limit is exceeded */
+	if (!apply_replay_spilling && spock_replay_queue_size > 0 &&
+		apply_replay_bytes + msg->len > spock_replay_queue_size * 1024L * 1024L)
+	{
+		/*
+		 * Allocate the BufFile in TopMemoryContext so it survives
+		 * across transaction boundaries, as required by
+		 * BufFileCreateTemp(interXact=true).
+		 */
+		oldctx = MemoryContextSwitchTo(TopMemoryContext);
+		apply_replay_spill_file = BufFileCreateTemp(true);
+		MemoryContextSwitchTo(oldctx);
+		apply_replay_spilling = true;
+
+		/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
+		elog(DEBUG1,
+			 "SPOCK %s: replay queue spill activated: "
+			 "in-memory %d bytes exceeds %d MB limit",
+			 MySubscription->name, apply_replay_bytes,
+			 spock_replay_queue_size);
+
+		/* Don't need it anymore */
+		apply_replay_bytes = 0;
+	}
+
+	if (apply_replay_spilling)
+	{
+		ApplyReplayEntry *mc_entry;
+
+		apply_replay_spill_write_entry(msg->len, msg->data);
+
+		/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
+		if (xact_action_counter % 100 == 0)
+			elog(DEBUG1, "SPOCK %s: replay queue spill entry %u: ",
+				 MySubscription->name, xact_action_counter);
+
+		/*
+		 * Move the entry struct from ApplyReplayContext to TopMemoryContext.
+		 * handle_commit calls apply_replay_queue_reset which does
+		 * MemoryContextReset(ApplyReplayContext).  Spilled entries are not
+		 * in the in-memory linked list and must survive until the caller
+		 * frees them explicitly after replication_handler returns.
+		 */
+		oldctx = MemoryContextSwitchTo(TopMemoryContext);
+		mc_entry = (ApplyReplayEntry *) palloc(sizeof(ApplyReplayEntry));
+		/* nosemgrep: palloc above allocates exactly sizeof(ApplyReplayEntry)
+		 * bytes — the same size memcpy copies — so no overflow is possible. */
+		memcpy(mc_entry, entry, sizeof(ApplyReplayEntry));
+		MemoryContextSwitchTo(oldctx);
+
+		pfree(entry);
+		return mc_entry;
+	}
+	else
+	{
+		Assert(apply_replay_spill_file == NULL &&
+			   apply_replay_spill_count == 0 &&
+			   apply_replay_spill_read == 0);
+
+		/* Keep in memory */
+		apply_replay_bytes += msg->len;
+
+		if (apply_replay_head == NULL)
+			apply_replay_head = apply_replay_tail = entry;
+		else
+		{
+			apply_replay_tail->next = entry;
+			apply_replay_tail = entry;
+		}
+
+		/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
+		if (xact_action_counter % 100 == 0)
+			elog(DEBUG1, "SPOCK %s: replay queue keep in-memory entry %u: ",
+				 MySubscription->name, xact_action_counter);
+
+		return entry;
+	}
+}
+
+/*
+ * Begin replay of the queued entries after an exception.
+ *
+ * Positions the replay cursor at the head of the in-memory list and, if
+ * entries were spilled to disk, seeks the spill file back to the start.
+ */
+static void
+apply_replay_queue_start_replay(void)
+{
+	Assert(apply_replay_next == NULL && !apply_replay_mode);
+
+	apply_replay_next = apply_replay_head;
+	apply_replay_mode = true;
+
+	/* Seek spill file to the beginning for re-read */
+	if (apply_replay_spilling)
+	{
+		Assert(apply_replay_spill_file != NULL);
+		BufFileSeek(apply_replay_spill_file, 0, 0, SEEK_SET);
+		apply_replay_spill_read = 0;
+	}
+
+	/* XXX: keep DEBUG1 logging until spill-to-disk code is proven stable */
+	elog(DEBUG1, "SPOCK: replay queue start: in-memory entries=%s, "
+		 "spill file=%s (spill_count=%d)",
+		 apply_replay_next != NULL ? "yes" : "none",
+		 apply_replay_spilling ? "active" : "none",
+		 apply_replay_spill_count);
 }
 
 /*

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -252,8 +252,8 @@ static void get_feedback_position(XLogRecPtr *recvpos, XLogRecPtr *writepos,
 static void UpdateWorkerStats(XLogRecPtr last_received, XLogRecPtr last_inserted);
 static void maybe_advance_forwarded_origin(XLogRecPtr end_lsn, bool xact_had_exception);
 static ApplyReplayEntry *apply_replay_queue_next_entry(void);
-static ApplyReplayEntry *apply_replay_queue_append_entry(ApplyReplayEntry *entry,
-							StringInfo msg);
+static bool apply_replay_queue_append_entry(ApplyReplayEntry **entry_p,
+							StringInfo *msg_p);
 static void apply_replay_queue_start_replay(void);
 static void apply_replay_spill_write_entry(int len, char *data);
 static ApplyReplayEntry *apply_replay_spill_read_entry(void);
@@ -3014,7 +3014,7 @@ stream_replay:
 			{
 				ApplyReplayEntry *entry;
 				bool		queue_append;
-				bool		entry_spilled = false;
+				bool		need_free = false;
 				StringInfo	msg;
 				int			c;
 
@@ -3141,19 +3141,17 @@ stream_replay:
 
 					/* Append the entry to the replay queue if from stream */
 					if (queue_append)
+						need_free = apply_replay_queue_append_entry(&entry,
+																	&msg);
+					else
 					{
-						ApplyReplayEntry *orig = entry;
-
-						entry = apply_replay_queue_append_entry(entry, msg);
-						entry_spilled = (entry != orig);
-
 						/*
-						 * Spilling relocates the entry from ApplyReplayContext
-						 * to TopMemoryContext, freeing the original.  Update msg
-						 * to point to the new copy's copydata.
+						 * Replay path: spill-read entries live in
+						 * TopMemoryContext and must be freed explicitly.
+						 * Capture this before replication_handler, which
+						 * may reset ApplyReplayContext and free the entry.
 						 */
-						if (entry_spilled)
-							msg = &entry->copydata;
+						need_free = !entry->from_pq;
 					}
 
 					/*
@@ -3173,19 +3171,7 @@ stream_replay:
 
 					replication_handler(msg);
 
-					/*
-					 * Free spilled entries explicitly: their structs live in
-					 * TopMemoryContext (not ApplyReplayContext), so they are
-					 * not cleaned up by apply_replay_queue_reset.
-					 *
-					 * In-memory entries (both first-pass and replay) live in
-					 * ApplyReplayContext and are freed by
-					 * MemoryContextReset inside apply_replay_queue_reset,
-					 * called on applying a COMMIT.
-					 *
-					 * !from_pq catches spill-read entries during replay.
-					 */
-					if (entry_spilled || !entry->from_pq)
+					if (need_free)
 						apply_replay_entry_free(entry);
 				}
 				else if (c == 'k')
@@ -4292,15 +4278,20 @@ apply_replay_queue_next_entry(void)
  * If spock_replay_queue_size is configured and the in-memory limit is
  * exceeded, spill subsequent entries to a temporary file on disk.
  *
- * Returns the entry to use after the call.  When spilled, the original
- * entry (in ApplyReplayContext) is freed and replaced by a copy in
- * TopMemoryContext that survives MemoryContextReset(ApplyReplayContext)
- * in handle_commit.  The caller can detect spilling by comparing the
- * returned pointer to the original.
+ * When spilled, the original entry (in ApplyReplayContext) is freed and
+ * replaced by a copy in TopMemoryContext that survives
+ * MemoryContextReset(ApplyReplayContext) in handle_commit.  The updated
+ * entry and msg pointers are written back through entry_p and msg_p.
+ *
+ * Returns true if the caller must free the entry after processing
+ * (i.e. it lives in TopMemoryContext), false if it will be cleaned up
+ * automatically by MemoryContextReset(ApplyReplayContext).
  */
-static ApplyReplayEntry *
-apply_replay_queue_append_entry(ApplyReplayEntry *entry, StringInfo msg)
+static bool
+apply_replay_queue_append_entry(ApplyReplayEntry **entry_p, StringInfo *msg_p)
 {
+	ApplyReplayEntry *entry = *entry_p;
+	StringInfo	msg = *msg_p;
 	MemoryContext	oldctx;
 
 	Assert(entry != NULL);
@@ -4351,7 +4342,9 @@ apply_replay_queue_append_entry(ApplyReplayEntry *entry, StringInfo msg)
 		MemoryContextSwitchTo(oldctx);
 
 		pfree(entry);
-		return mc_entry;
+		*entry_p = mc_entry;
+		*msg_p = &mc_entry->copydata;
+		return true;	/* caller must free */
 	}
 	else
 	{
@@ -4375,7 +4368,7 @@ apply_replay_queue_append_entry(ApplyReplayEntry *entry, StringInfo msg)
 			elog(DEBUG1, "SPOCK %s: replay queue keep in-memory entry %u: ",
 				 MySubscription->name, xact_action_counter);
 
-		return entry;
+		return false;	/* freed by MemoryContextReset */
 	}
 }
 
@@ -4397,7 +4390,9 @@ apply_replay_queue_start_replay(void)
 	if (apply_replay_spilling)
 	{
 		Assert(apply_replay_spill_file != NULL);
-		BufFileSeek(apply_replay_spill_file, 0, 0, SEEK_SET);
+		if (BufFileSeek(apply_replay_spill_file, 0, 0, SEEK_SET) != 0)
+			elog(ERROR, "SPOCK %s: could not seek replay spill file to start",
+				 MySubscription->name);
 		apply_replay_spill_read = 0;
 	}
 

--- a/tests/regress/expected/primary_key.out
+++ b/tests/regress/expected/primary_key.out
@@ -259,6 +259,15 @@ SELECT attname, attnotnull, attisdropped from pg_attribute where attrelid = 'pk_
  address    | f          | f
 (5 rows)
 
+-- Wait up to 10 seconds for the subscription to become disabled.
+DO $$
+BEGIN
+  SET LOCAL statement_timeout = '10s';
+  WHILE (SELECT status FROM spock.sub_show_status()) <> 'disabled' LOOP
+    PERFORM pg_sleep(0.1);
+  END LOOP;
+END;
+$$;
 select status from spock.sub_show_status();
   status  
 ----------

--- a/tests/regress/expected/spill_transaction.out
+++ b/tests/regress/expected/spill_transaction.out
@@ -1,0 +1,347 @@
+--
+-- Test: replay queue spill-to-disk for large transactions
+--
+-- Verifies that a bulk-loaded transaction is successfully replicated when
+-- the replay queue exceeds the in-memory limit and spills to a temp file.
+-- Tests all three exception_behaviour modes, both without and with a
+-- conflict on the last record.
+--
+SELECT * FROM spock_regress_variables()
+\gset
+\c :subscriber_dsn
+TRUNCATE spock.resolutions;
+TRUNCATE spock.exception_log;
+ALTER SYSTEM SET spock.save_resolutions = on;
+-- Force spilling by setting a very low queue size limit (1 MB)
+ALTER SYSTEM SET spock.exception_replay_queue_size = 1;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+-- Create the test table on both nodes via replicated DDL
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+  CREATE TABLE public.test_spill (
+	id integer PRIMARY KEY, payload serial);
+  CREATE UNIQUE INDEX payload_idx ON test_spill (payload);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'test_spill');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+-- ============================================================
+-- TRANSDISCARD mode — no conflict
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'transdiscard';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+SELECT count(*), sum(payload) FROM test_spill;
+ count |    sum     
+-------+------------
+ 50000 | 1250025000
+(1 row)
+
+-- ============================================================
+-- DISCARD mode — no conflict
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'discard';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+SELECT count(*), sum(payload) FROM test_spill;
+ count |    sum     
+-------+------------
+ 50000 | 1250025000
+(1 row)
+
+-- ============================================================
+-- SUB_DISABLE mode — no conflict
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+SELECT count(*), sum(payload) FROM test_spill;
+ count |    sum     
+-------+------------
+ 50000 | 1250025000
+(1 row)
+
+-- ============================================================
+-- TRANSDISCARD mode — conflict on last record
+-- The entire transaction is discarded; only the pre-inserted
+-- conflicting row remains on the subscriber.
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'transdiscard';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+INSERT INTO test_spill (id, payload) VALUES (-1, 50000);
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+-- Check: COPY transaction discarded, single record presented
+SELECT id, payload FROM test_spill;
+ id | payload 
+----+---------
+ -1 |   50000
+(1 row)
+
+SELECT command_counter AS cnt,operation AS opt,
+  remote_new_tup FROM spock.exception_log
+ORDER BY command_counter DESC LIMIT 5;
+  cnt  |  opt   |                                                  remote_new_tup                                                   
+-------+--------+-------------------------------------------------------------------------------------------------------------------
+ 50013 | INSERT | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
+ 50012 | INSERT | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
+ 50011 | INSERT | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
+ 50010 | INSERT | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
+ 50009 | INSERT | [{"value": 49996, "attname": "id", "atttype": "int4"}, {"value": 49996, "attname": "payload", "atttype": "int4"}]
+(5 rows)
+
+-- ============================================================
+-- DISCARD mode — conflict on last record
+-- The conflict is resolved per-row; all 50000 rows arrive.
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'discard';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+INSERT INTO test_spill (id, payload) VALUES (-1, 50000);
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+-- Check 49999 COPY records applied plus older one has been kept
+SELECT count(*), sum(id), sum(payload) FROM test_spill;
+ count |    sum     |    sum     
+-------+------------+------------
+ 50000 | 1249974999 | 1250025000
+(1 row)
+
+SELECT command_counter AS cnt,operation AS opt,
+  remote_new_tup FROM spock.exception_log
+ORDER BY command_counter DESC LIMIT 5;
+  cnt   |  opt   |                                                  remote_new_tup                                                   
+--------+--------+-------------------------------------------------------------------------------------------------------------------
+ 100013 | INSERT | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
+ 100012 | INSERT | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
+ 100011 | INSERT | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
+ 100010 | INSERT | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
+ 100009 | INSERT | [{"value": 49996, "attname": "id", "atttype": "int4"}, {"value": 49996, "attname": "payload", "atttype": "int4"}]
+(5 rows)
+
+-- ============================================================
+-- SUB_DISABLE mode — conflict on last record
+-- The subscription is disabled on conflict. Remove the
+-- conflicting row, re-enable, and verify the transaction
+-- is applied successfully.
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+INSERT INTO test_spill (id, payload) VALUES (-1, 50000); -- Add conflicting record
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+-- Wait for the subscription to become disabled (apply worker may still
+-- be processing the conflict asynchronously).
+\c :subscriber_dsn
+DO $$
+BEGIN
+  SET LOCAL statement_timeout = '30s';
+  WHILE (SELECT status FROM spock.sub_show_status()) <> 'disabled' LOOP
+    PERFORM pg_sleep(0.1);
+  END LOOP;
+END;
+$$;
+-- Remove the conflicting row and re-enable
+DELETE FROM test_spill WHERE id = -1;
+SELECT spock.sub_enable('test_subscription', true);
+ sub_enable 
+------------
+ t
+(1 row)
+
+\c :provider_dsn
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+-- Check: COPY passed successfully
+SELECT count(*), sum(id), sum(payload) FROM test_spill;
+ count |    sum     |    sum     
+-------+------------+------------
+ 50000 | 1250025000 | 1250025000
+(1 row)
+
+-- Check how the conflict has been processed.
+SELECT node_name,relname,idxname,conflict_type,conflict_resolution,
+  local_tuple,remote_tuple FROM spock.resolutions;
+ node_name | relname | idxname | conflict_type | conflict_resolution | local_tuple | remote_tuple 
+-----------+---------+---------+---------------+---------------------+-------------+--------------
+(0 rows)
+
+SELECT command_counter AS cnt,operation AS opt,
+  remote_new_tup FROM spock.exception_log
+ORDER BY command_counter DESC LIMIT 5;
+  cnt   |     opt     |                                                  remote_new_tup                                                   
+--------+-------------+-------------------------------------------------------------------------------------------------------------------
+ 150014 | SUB_DISABLE | 
+ 150013 | INSERT      | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
+ 150012 | INSERT      | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
+ 150011 | INSERT      | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
+ 150010 | INSERT      | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
+(5 rows)
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+ALTER SYSTEM RESET spock.exception_behaviour;
+ALTER SYSTEM RESET spock.exception_replay_queue_size;
+ALTER SYSTEM RESET spock.save_resolutions;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
+SELECT spock.replicate_ddl('DROP TABLE public.test_spill CASCADE;');
+NOTICE:  drop cascades to table test_spill membership in replication set default
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+

--- a/tests/regress/expected/spill_transaction.out
+++ b/tests/regress/expected/spill_transaction.out
@@ -267,7 +267,7 @@ COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
 DO $$
 BEGIN
   SET LOCAL statement_timeout = '30s';
-  WHILE (SELECT status FROM spock.sub_show_status()) <> 'disabled' LOOP
+  WHILE (SELECT status FROM spock.sub_show_status('test_subscription')) <> 'disabled' LOOP
     PERFORM pg_sleep(0.1);
   END LOOP;
 END;

--- a/tests/regress/expected/spill_transaction.out
+++ b/tests/regress/expected/spill_transaction.out
@@ -167,16 +167,15 @@ SELECT id, payload FROM test_spill;
  -1 |   50000
 (1 row)
 
-SELECT command_counter AS cnt,operation AS opt,
-  remote_new_tup FROM spock.exception_log
+SELECT operation AS opt, remote_new_tup FROM spock.exception_log
 ORDER BY command_counter DESC LIMIT 5;
-  cnt  |  opt   |                                                  remote_new_tup                                                   
--------+--------+-------------------------------------------------------------------------------------------------------------------
- 50013 | INSERT | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
- 50012 | INSERT | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
- 50011 | INSERT | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
- 50010 | INSERT | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
- 50009 | INSERT | [{"value": 49996, "attname": "id", "atttype": "int4"}, {"value": 49996, "attname": "payload", "atttype": "int4"}]
+  opt   |                                                  remote_new_tup                                                   
+--------+-------------------------------------------------------------------------------------------------------------------
+ INSERT | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
+ INSERT | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
+ INSERT | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
+ INSERT | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
+ INSERT | [{"value": 49996, "attname": "id", "atttype": "int4"}, {"value": 49996, "attname": "payload", "atttype": "int4"}]
 (5 rows)
 
 -- ============================================================
@@ -184,6 +183,7 @@ ORDER BY command_counter DESC LIMIT 5;
 -- The conflict is resolved per-row; all 50000 rows arrive.
 -- ============================================================
 \c :subscriber_dsn
+TRUNCATE spock.exception_log;
 ALTER SYSTEM SET spock.exception_behaviour = 'discard';
 SELECT pg_reload_conf();
  pg_reload_conf 
@@ -221,17 +221,12 @@ SELECT count(*), sum(id), sum(payload) FROM test_spill;
  50000 | 1249974999 | 1250025000
 (1 row)
 
-SELECT command_counter AS cnt,operation AS opt,
-  remote_new_tup FROM spock.exception_log
+SELECT operation AS opt,remote_new_tup FROM spock.exception_log
 ORDER BY command_counter DESC LIMIT 5;
-  cnt   |  opt   |                                                  remote_new_tup                                                   
---------+--------+-------------------------------------------------------------------------------------------------------------------
- 100013 | INSERT | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
- 100012 | INSERT | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
- 100011 | INSERT | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
- 100010 | INSERT | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
- 100009 | INSERT | [{"value": 49996, "attname": "id", "atttype": "int4"}, {"value": 49996, "attname": "payload", "atttype": "int4"}]
-(5 rows)
+  opt   |                                                  remote_new_tup                                                   
+--------+-------------------------------------------------------------------------------------------------------------------
+ INSERT | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
+(1 row)
 
 -- ============================================================
 -- SUB_DISABLE mode — conflict on last record
@@ -239,7 +234,17 @@ ORDER BY command_counter DESC LIMIT 5;
 -- conflicting row, re-enable, and verify the transaction
 -- is applied successfully.
 -- ============================================================
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+SELECT spock.sync_event() as sync_lsn \gset
 \c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+ result 
+--------
+ t
+(1 row)
+
+TRUNCATE spock.exception_log;
 ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
 SELECT pg_reload_conf();
  pg_reload_conf 
@@ -247,16 +252,17 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
-\c :provider_dsn
-TRUNCATE test_spill RESTART IDENTITY;
-SELECT spock.sync_event() as sync_lsn
-\gset
-\c :subscriber_dsn
-CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
- result 
---------
- t
+-- Check that all works and clean on subscriber
+SELECT status FROM spock.sub_show_status('test_subscription');
+   status    
+-------------
+ replicating
 (1 row)
+
+SELECT * FROM test_spill; -- empty
+ id | payload 
+----+---------
+(0 rows)
 
 INSERT INTO test_spill (id, payload) VALUES (-1, 50000); -- Add conflicting record
 \c :provider_dsn
@@ -304,16 +310,15 @@ SELECT node_name,relname,idxname,conflict_type,conflict_resolution,
 -----------+---------+---------+---------------+---------------------+-------------+--------------
 (0 rows)
 
-SELECT command_counter AS cnt,operation AS opt,
-  remote_new_tup FROM spock.exception_log
+SELECT operation AS opt, remote_new_tup FROM spock.exception_log
 ORDER BY command_counter DESC LIMIT 5;
-  cnt   |     opt     |                                                  remote_new_tup                                                   
---------+-------------+-------------------------------------------------------------------------------------------------------------------
- 150014 | SUB_DISABLE | 
- 150013 | INSERT      | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
- 150012 | INSERT      | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
- 150011 | INSERT      | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
- 150010 | INSERT      | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
+     opt     |                                                  remote_new_tup                                                   
+-------------+-------------------------------------------------------------------------------------------------------------------
+ SUB_DISABLE | 
+ INSERT      | [{"value": 50000, "attname": "id", "atttype": "int4"}, {"value": 50000, "attname": "payload", "atttype": "int4"}]
+ INSERT      | [{"value": 49999, "attname": "id", "atttype": "int4"}, {"value": 49999, "attname": "payload", "atttype": "int4"}]
+ INSERT      | [{"value": 49998, "attname": "id", "atttype": "int4"}, {"value": 49998, "attname": "payload", "atttype": "int4"}]
+ INSERT      | [{"value": 49997, "attname": "id", "atttype": "int4"}, {"value": 49997, "attname": "payload", "atttype": "int4"}]
 (5 rows)
 
 -- ============================================================

--- a/tests/regress/regress-postgresql.conf
+++ b/tests/regress/regress-postgresql.conf
@@ -11,9 +11,10 @@ hba_file = './tests/regress/regress-pg_hba.conf'
 DateStyle = 'ISO, DMY'
 log_line_prefix='[%m] [%p] [%d] '
 fsync=off
+autovacuum = off
 
 # Handy things to turn on when debugging
-#log_min_messages = debug2
+#log_min_messages = debug1
 #log_error_verbosity = verbose
 #log_statement = 'all'
 #logging_collector = on

--- a/tests/regress/sql/primary_key.sql
+++ b/tests/regress/sql/primary_key.sql
@@ -131,6 +131,16 @@ SELECT spock.wait_slot_confirm_lsn(NULL, :curr_lsn);
 \c :subscriber_dsn
 SELECT attname, attnotnull, attisdropped from pg_attribute where attrelid = 'pk_users'::regclass and attnum > 0 order by attnum;
 
+-- Wait up to 10 seconds for the subscription to become disabled.
+DO $$
+BEGIN
+  SET LOCAL statement_timeout = '10s';
+  WHILE (SELECT status FROM spock.sub_show_status()) <> 'disabled' LOOP
+    PERFORM pg_sleep(0.1);
+  END LOOP;
+END;
+$$;
+
 select status from spock.sub_show_status();
 
 \c :provider_dsn

--- a/tests/regress/sql/spill_transaction.sql
+++ b/tests/regress/sql/spill_transaction.sql
@@ -178,7 +178,7 @@ COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
 DO $$
 BEGIN
   SET LOCAL statement_timeout = '30s';
-  WHILE (SELECT status FROM spock.sub_show_status()) <> 'disabled' LOOP
+  WHILE (SELECT status FROM spock.sub_show_status('test_subscription')) <> 'disabled' LOOP
     PERFORM pg_sleep(0.1);
   END LOOP;
 END;

--- a/tests/regress/sql/spill_transaction.sql
+++ b/tests/regress/sql/spill_transaction.sql
@@ -92,7 +92,6 @@ SELECT pg_reload_conf();
 
 \c :provider_dsn
 TRUNCATE test_spill RESTART IDENTITY;
-
 SELECT spock.sync_event() as sync_lsn
 \gset
 
@@ -112,8 +111,7 @@ CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
 -- Check: COPY transaction discarded, single record presented
 SELECT id, payload FROM test_spill;
 
-SELECT command_counter AS cnt,operation AS opt,
-  remote_new_tup FROM spock.exception_log
+SELECT operation AS opt, remote_new_tup FROM spock.exception_log
 ORDER BY command_counter DESC LIMIT 5;
 
 -- ============================================================
@@ -121,12 +119,12 @@ ORDER BY command_counter DESC LIMIT 5;
 -- The conflict is resolved per-row; all 50000 rows arrive.
 -- ============================================================
 \c :subscriber_dsn
+TRUNCATE spock.exception_log;
 ALTER SYSTEM SET spock.exception_behaviour = 'discard';
 SELECT pg_reload_conf();
 
 \c :provider_dsn
 TRUNCATE test_spill RESTART IDENTITY;
-
 SELECT spock.sync_event() as sync_lsn
 \gset
 
@@ -145,8 +143,7 @@ CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
 -- Check 49999 COPY records applied plus older one has been kept
 SELECT count(*), sum(id), sum(payload) FROM test_spill;
 
-SELECT command_counter AS cnt,operation AS opt,
-  remote_new_tup FROM spock.exception_log
+SELECT operation AS opt,remote_new_tup FROM spock.exception_log
 ORDER BY command_counter DESC LIMIT 5;
 
 -- ============================================================
@@ -155,18 +152,21 @@ ORDER BY command_counter DESC LIMIT 5;
 -- conflicting row, re-enable, and verify the transaction
 -- is applied successfully.
 -- ============================================================
-\c :subscriber_dsn
-ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
-SELECT pg_reload_conf();
 
 \c :provider_dsn
 TRUNCATE test_spill RESTART IDENTITY;
-
-SELECT spock.sync_event() as sync_lsn
-\gset
+SELECT spock.sync_event() as sync_lsn \gset
 
 \c :subscriber_dsn
 CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+TRUNCATE spock.exception_log;
+ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
+SELECT pg_reload_conf();
+
+-- Check that all works and clean on subscriber
+SELECT status FROM spock.sub_show_status('test_subscription');
+SELECT * FROM test_spill; -- empty
+
 INSERT INTO test_spill (id, payload) VALUES (-1, 50000); -- Add conflicting record
 
 \c :provider_dsn
@@ -200,8 +200,7 @@ SELECT count(*), sum(id), sum(payload) FROM test_spill;
 -- Check how the conflict has been processed.
 SELECT node_name,relname,idxname,conflict_type,conflict_resolution,
   local_tuple,remote_tuple FROM spock.resolutions;
-SELECT command_counter AS cnt,operation AS opt,
-  remote_new_tup FROM spock.exception_log
+SELECT operation AS opt, remote_new_tup FROM spock.exception_log
 ORDER BY command_counter DESC LIMIT 5;
 
 -- ============================================================

--- a/tests/regress/sql/spill_transaction.sql
+++ b/tests/regress/sql/spill_transaction.sql
@@ -1,0 +1,222 @@
+--
+-- Test: replay queue spill-to-disk for large transactions
+--
+-- Verifies that a bulk-loaded transaction is successfully replicated when
+-- the replay queue exceeds the in-memory limit and spills to a temp file.
+-- Tests all three exception_behaviour modes, both without and with a
+-- conflict on the last record.
+--
+
+SELECT * FROM spock_regress_variables()
+\gset
+
+\c :subscriber_dsn
+TRUNCATE spock.resolutions;
+TRUNCATE spock.exception_log;
+ALTER SYSTEM SET spock.save_resolutions = on;
+-- Force spilling by setting a very low queue size limit (1 MB)
+ALTER SYSTEM SET spock.exception_replay_queue_size = 1;
+SELECT pg_reload_conf();
+
+-- Create the test table on both nodes via replicated DDL
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+  CREATE TABLE public.test_spill (
+	id integer PRIMARY KEY, payload serial);
+  CREATE UNIQUE INDEX payload_idx ON test_spill (payload);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'test_spill');
+
+-- ============================================================
+-- TRANSDISCARD mode — no conflict
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'transdiscard';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+SELECT count(*), sum(payload) FROM test_spill;
+
+-- ============================================================
+-- DISCARD mode — no conflict
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'discard';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+SELECT count(*), sum(payload) FROM test_spill;
+
+-- ============================================================
+-- SUB_DISABLE mode — no conflict
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+SELECT count(*), sum(payload) FROM test_spill;
+
+-- ============================================================
+-- TRANSDISCARD mode — conflict on last record
+-- The entire transaction is discarded; only the pre-inserted
+-- conflicting row remains on the subscriber.
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'transdiscard';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+INSERT INTO test_spill (id, payload) VALUES (-1, 50000);
+
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+
+-- Check: COPY transaction discarded, single record presented
+SELECT id, payload FROM test_spill;
+
+SELECT command_counter AS cnt,operation AS opt,
+  remote_new_tup FROM spock.exception_log
+ORDER BY command_counter DESC LIMIT 5;
+
+-- ============================================================
+-- DISCARD mode — conflict on last record
+-- The conflict is resolved per-row; all 50000 rows arrive.
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'discard';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+INSERT INTO test_spill (id, payload) VALUES (-1, 50000);
+
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+-- Check 49999 COPY records applied plus older one has been kept
+SELECT count(*), sum(id), sum(payload) FROM test_spill;
+
+SELECT command_counter AS cnt,operation AS opt,
+  remote_new_tup FROM spock.exception_log
+ORDER BY command_counter DESC LIMIT 5;
+
+-- ============================================================
+-- SUB_DISABLE mode — conflict on last record
+-- The subscription is disabled on conflict. Remove the
+-- conflicting row, re-enable, and verify the transaction
+-- is applied successfully.
+-- ============================================================
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.exception_behaviour = 'sub_disable';
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+TRUNCATE test_spill RESTART IDENTITY;
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+INSERT INTO test_spill (id, payload) VALUES (-1, 50000); -- Add conflicting record
+
+\c :provider_dsn
+COPY test_spill (id) FROM PROGRAM 'seq 1 50000' WITH (FORMAT text);
+
+-- Wait for the subscription to become disabled (apply worker may still
+-- be processing the conflict asynchronously).
+\c :subscriber_dsn
+DO $$
+BEGIN
+  SET LOCAL statement_timeout = '30s';
+  WHILE (SELECT status FROM spock.sub_show_status()) <> 'disabled' LOOP
+    PERFORM pg_sleep(0.1);
+  END LOOP;
+END;
+$$;
+
+-- Remove the conflicting row and re-enable
+DELETE FROM test_spill WHERE id = -1;
+SELECT spock.sub_enable('test_subscription', true);
+
+\c :provider_dsn
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
+-- Check: COPY passed successfully
+SELECT count(*), sum(id), sum(payload) FROM test_spill;
+
+-- Check how the conflict has been processed.
+SELECT node_name,relname,idxname,conflict_type,conflict_resolution,
+  local_tuple,remote_tuple FROM spock.resolutions;
+SELECT command_counter AS cnt,operation AS opt,
+  remote_new_tup FROM spock.exception_log
+ORDER BY command_counter DESC LIMIT 5;
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+ALTER SYSTEM RESET spock.exception_behaviour;
+ALTER SYSTEM RESET spock.exception_replay_queue_size;
+ALTER SYSTEM RESET spock.save_resolutions;
+SELECT pg_reload_conf();
+
+\c :provider_dsn
+SELECT spock.replicate_ddl('DROP TABLE public.test_spill CASCADE;');
+
+SELECT spock.sync_event() as sync_lsn
+\gset
+
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);


### PR DESCRIPTION
When the apply worker's replay queue exceeds `spock.exception_replay_queue_size` (in MB), subsequent entries are written to a temporary BufFile on disk instead of accumulating in memory. This prevents OOM on the subscriber when replaying large transactions with exception handling enabled.

### Design

- In-memory queue entries live in `ApplyReplayContext` and hold libpq-allocated data buffers. `apply_replay_queue_reset` (called from `handle_commit`) walks the list to `PQfreemem` them before calling `MemoryContextReset`.
- Spilled entries are relocated from `ApplyReplayContext` to `TopMemoryContext` so they survive the `MemoryContextReset` in `handle_commit`. The caller frees them explicitly after `replication_handler` returns.
- Added `from_pq` field to `ApplyReplayEntry` to distinguish libpq-allocated buffers (`PQfreemem`) from palloc'd spill-read buffers (`pfree`).
- When the replay queue is exhausted mid-transaction (exception occurred before COMMIT was received), the inner loop does `continue` instead of `break`, seamlessly transitioning to stream reading — matching the pre-spill behavior and ensuring `handle_commit` runs with a clean transaction state.

### Changes

- `apply_replay_queue_append_entry`: appends to in-memory list or spills to disk; returns a possibly-relocated entry pointer so the caller can detect spilling.
- `apply_replay_queue_next_entry`: drains in-memory list first, then reads from spill file; sets `apply_replay_mode = false` when exhausted.
- `apply_replay_spill_write_entry` / `apply_replay_spill_read_entry`: binary format `[int32 len][data]` via BufFile.
- `apply_replay_queue_start_replay`: seeks spill file back to start for re-read after exception.
- `apply_replay_queue_reset`: unified cleanup — walks list for `PQfreemem`, resets all state, closes spill file, resets context.
- Regression tests for all three `exception_behaviour` modes (transdiscard, discard, sub_disable), both without and with a primary key conflict on the last record of a 50k-row COPY.
