### PR TITLE
Add conflict types documentation and report update_exists

### DIFF
--- a/docs/conflict_types.md
+++ b/docs/conflict_types.md
@@ -1,0 +1,256 @@
+## Conflict Types
+
+For conflict *avoidance* using delta-apply columns, see
+[Conflict Avoidance and Delta-Apply Columns](conflicts.md).
+
+In a multi-master replication environment, conflicts occur when two or
+more nodes make changes to the same row (as identified by a primary key
+or replica identity) at overlapping times. Spock detects these conflicts
+during the apply phase on the subscribing node and resolves them
+according to a configurable resolution strategy.
+
+Each conflict is classified as one of the types described below.
+Resolvable conflicts are recorded in the `spock.resolutions` table
+(when `spock.save_resolutions` is enabled); non-resolvable conflicts
+are recorded in `spock.exception_log`.
+
+### Summary Table
+
+| Conflict Type              | DML       | Resolvable                          |
+|----------------------------|-----------|-------------------------------------|
+| `insert_exists`            | INSERT    | Yes                                 |
+| `update_origin_differs`    | UPDATE    | N/A (normal flow, not recorded)     |
+| `update_exists`            | UPDATE    | No (unique constraint violated), saved in `spock.exception_log` |
+| `update_missing`           | UPDATE    | No (row not found), saved in `spock.exception_log`              |
+| `delete_origin_differs`    | DELETE    | N/A (normal flow, not recorded)     |
+| `delete_missing`           | DELETE    | Yes                                 |
+| `delete_exists`            | DELETE    | Yes                                 |
+
+A conflict is **resolvable** when Spock can automatically choose a
+winning tuple and continue replication without operator intervention.
+`update_missing` and `update_exists` are not resolvable and result in
+an ERROR that is recorded in `spock.exception_log`.
+
+---
+
+### `insert_exists`
+
+A remote INSERT arrives but a row with the same primary key (or replica
+identity) already exists on the local node. This typically happens when
+two nodes independently insert a row with the same key.
+
+Spock detects the conflict by looking up the incoming tuple against
+unique indexes (primary key, replica identity, and optionally all
+unique constraints when `spock.check_all_uc_indexes` is enabled).
+
+**Resolution:** The configurable conflict resolver (default
+`last_update_wins`) compares the commit timestamps of the local and
+remote rows. The winner's values are applied as an UPDATE to the
+existing row.
+
+---
+
+### `update_origin_differs`
+
+A remote UPDATE targets a row whose local copy was last modified by a
+different replication origin. In a multi-master topology this is the
+normal flow of replication -- two nodes each modify a row and the
+changes propagate -- so Spock does not treat it as a true conflict.
+PostgreSQL's native logical replication does classify it as a conflict,
+however, so Spock tracks the type for completeness and supports
+optional logging via the `spock.log_origin_change` GUC.
+
+Spock detects this by comparing `replorigin_session_origin` (the
+source of the incoming change) with the origin recorded on the local
+tuple. Changes from the same origin or the same local transaction are
+silently applied without any conflict reporting.
+
+**Resolution:** The configurable conflict resolver (default
+`last_update_wins`) determines the winner. Since this is normal
+replication flow, the event is not written to `spock.resolutions`
+regardless of which side wins.
+
+---
+
+### `update_exists`
+
+A remote UPDATE is applied successfully via the replica identity, but
+the new row values violate a unique constraint on a different index.
+For example, the UPDATE changes a column that is part of a secondary
+unique index and the new value collides with another existing row.
+
+This conflict type matches the definition used by PostgreSQL 18's
+native logical replication. Spock reports it to the PostgreSQL server
+log and PG18 conflict statistics when the unique constraint violation
+is detected.
+
+**Resolution:** This conflict is **not** automatically resolvable. The
+error is written to `spock.exception_log`.
+
+---
+
+### `update_missing`
+
+A remote UPDATE cannot find the target row on the local node. The row
+may have been deleted locally, or it may never have arrived due to a
+replication gap.
+
+Spock retries the lookup several times (with short waits) in case the
+row is being inserted by a concurrent transaction. If the row still
+cannot be found after retries, the conflict is raised.
+
+**Resolution:** This conflict is **not resolvable**. Spock raises an
+ERROR, which is logged to `spock.exception_log`.
+
+---
+
+### `delete_origin_differs`
+
+A remote DELETE targets a row that exists locally but was last modified
+by a different replication origin. As with `update_origin_differs`,
+this is normal replication flow rather than a true conflict -- one node
+deletes a row while another node's earlier update is still in flight.
+Spock tracks the type because PostgreSQL's native logical replication
+considers it a conflict, and supports optional logging via
+`spock.log_origin_change`.
+
+If the local tuple came from the same origin as the incoming delete,
+or from the same local transaction, the delete is applied silently
+with no conflict reporting.
+
+**Resolution:** The configurable conflict resolver (default
+`last_update_wins`) determines the winner. When the remote DELETE
+wins, the delete proceeds. When the local tuple wins (it is newer),
+the delete is skipped and the row is preserved; this case is reported
+as `delete_exists` instead.
+
+---
+
+### `delete_missing`
+
+A remote DELETE cannot find the target row on the local node. The row
+was likely already deleted by a local or other replicated transaction.
+
+As with `update_missing`, Spock retries the lookup several times
+before confirming the row is absent.
+
+**Resolution:** The conflict is automatically resolved by skipping the
+delete (`skip`). Since the row is already gone, the desired end state
+has been achieved. The event is recorded in the `spock.resolutions`
+table.
+
+---
+
+### `delete_exists`
+
+A remote DELETE arrives but the local copy of the row has a more
+recent commit timestamp than the delete. This is unique to Spock and
+does not have a counterpart in native PostgreSQL logical replication.
+
+This occurs when one node deletes a row while another node updates it
+with a later timestamp. The delete is the older operation, so the
+updated row should be preserved.
+
+**Resolution:** The delete is skipped and the local (newer) row is
+kept (`skip` / `keep_local`). The event is recorded in the
+`spock.resolutions` table.
+
+---
+
+### Conflict Resolution Strategies
+
+The `spock.conflict_resolution` GUC controls how resolvable conflicts
+(all types except `update_missing` and `update_exists`) are decided:
+
+| Strategy              | Behavior                                                  |
+|-----------------------|-----------------------------------------------------------|
+| `last_update_wins`    | The row with the most recent commit timestamp wins (default). |
+| `first_update_wins`   | The row with the earliest commit timestamp wins.          |
+| `apply_remote`        | Always apply the incoming remote change.                  |
+| `keep_local`          | Always keep the local row.                                |
+| `error`               | Raise an ERROR on any conflict.                           |
+
+The timestamp-based strategies (`last_update_wins` and
+`first_update_wins`) require `track_commit_timestamp = on` in
+`postgresql.conf`.
+
+**Tiebreaker:** When two rows have identical commit timestamps, Spock
+uses the `tiebreaker` value from the `spock.node` configuration to
+determine a winner. The node with the lower tiebreaker value wins. By
+default the tiebreaker is set to the node's unique ID.
+
+### Frozen Tuples and Missing Timestamp Data
+
+Timestamp-based conflict resolution depends on commit timestamp and
+origin information being available for the local tuple. There are two
+cases where this information is missing:
+
+**Frozen tuples.** PostgreSQL periodically "freezes" old row versions,
+replacing their transaction ID with `FrozenTransactionId`. Once
+frozen, the original commit timestamp and origin can no longer be
+retrieved. When Spock encounters a frozen local tuple during conflict
+resolution, it treats the local timestamp as zero. Since any real
+remote timestamp is greater than zero, the remote change always wins.
+No conflict is logged because the local origin could not be
+determined.
+
+**`track_commit_timestamp = off`.** If commit timestamp tracking is
+disabled, Spock cannot retrieve origin or timestamp information for
+any local tuple. In this case, Spock copies the remote origin and
+timestamp into the local values. The same-origin check then sees
+matching origins and treats the change as normal replication flow --
+no conflict is detected or logged. This effectively makes conflict
+resolution invisible: the remote change is always applied silently.
+
+For reliable conflict detection and resolution,
+`track_commit_timestamp` must be set to `on`.
+
+### Conflict Logging
+
+- **`spock.save_resolutions`** (default `off`) -- When enabled,
+  resolved conflicts are written to the `spock.resolutions` table
+  with full tuple details in JSON format.
+- **`spock.conflict_log_level`** (default `LOG`) -- Controls the
+  PostgreSQL log level at which detected conflicts are reported. Set
+  to a level below `log_min_messages` to suppress log output.
+- **`spock.log_origin_change`** (default `none`) -- Controls whether
+  `update_origin_differs` and `delete_origin_differs` events (normal
+  replication flow) are logged to the PostgreSQL server log. These
+  events are never written to `spock.resolutions`. Options: `none`,
+  `remote_only_differs`, `since_sub_creation`.
+
+### Comparison with PostgreSQL 18 Native Logical Replication
+
+PostgreSQL 18 introduced built-in conflict detection for logical
+replication. Spock's conflict types are aligned with PostgreSQL's
+definitions (same names, same enum ordering) so that the two systems
+report conflicts in a consistent way. The key differences are in how
+each system *resolves* conflicts and where it *records* them.
+
+| Conflict Type           | PostgreSQL 18                          | Spock (with last update wins)                |
+|-------------------------|----------------------------------------|----------------------------------------------|
+| `insert_exists`         | Logs and raises ERROR.                 | Resolves via `last_update_wins`; transforms INSERT into UPDATE of the winning tuple. |
+| `update_origin_differs` | Logs and always applies the remote tuple. | Resolves via `last_update_wins`; local tuple can win. Treated as normal replication flow (not a true conflict) with optional logging via `log_origin_change`. |
+| `update_exists`         | Detects unique constraint violation on updated row; logs. | Logs and records in `spock.exception_log`. |
+| `update_missing`        | Logs and skips.                        | Logs and records in `spock.exception_log`. |
+| `delete_origin_differs` | Logs and always applies the delete.    | Resolves via `last_update_wins`; local tuple can win (reported as `delete_exists`). Treated as normal replication flow (not a true conflict) with optional logging. |
+| `delete_missing`        | Logs and skips.                        | Logs and skips. Records in `spock.resolutions`. |
+| `delete_exists`         | No equivalent.                         | Unique to Spock. The local row is newer than the remote DELETE, so the delete is skipped and the row is preserved. |
+
+**Resolution.** PostgreSQL 18 does not resolve conflicts -- it either
+applies the remote change unconditionally or skips the operation, and
+logs the event. Spock adds configurable resolution strategies (default
+`last_update_wins`) with a tiebreaker mechanism, allowing the local
+tuple to win when it is more recent.
+
+**Persistence.** PostgreSQL 18 writes conflicts only to the PostgreSQL
+server log. Spock additionally persists certain conflicts in the
+`spock.resolutions` table (with full tuple details in JSON) --
+specifically `insert_exists`, `delete_missing`, and `delete_exists` --
+and non-resolvable conflicts (`update_missing`, `update_exists`) in
+`spock.exception_log`. Origin-differs events are not persisted to
+either table.
+
+**Statistics.** On PostgreSQL 18, Spock reports all conflict types to
+the native `pgstat` subscription conflict statistics, so they appear
+in the same views used by built-in logical replication.

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -1,72 +1,120 @@
 ## Conflict-Free Delta-Apply Columns (Conflict Avoidance)
 
-Conflicts can arise if a node is subscribed to multiple providers, or when local writes happen on a subscriber node.  Without Spock, logical replication can also encounter issues when resolving the value of a running sum (such as a YTD balance).
+For a complete reference on conflict types, resolution strategies, and
+comparison with PostgreSQL 18, see
+[Conflict Types and Resolution](conflict_types.md).
+
+Conflicts can arise if a node is subscribed to multiple providers, or when
+local writes happen on a subscriber node. Without Spock, logical replication
+can also encounter issues when resolving the value of a running sum (such as
+a YTD balance).
 
 !!! example
 
-    Suppose that a running bank account sum contains a balance of `$1,000`.   Two transactions "conflict" because they overlap with each from two different multi-master nodes.   Transaction A is a `$1,000` withdrawal from the account.  Transaction B is also a `$1,000` withdrawal from the account.  The correct balance is `$-1,000`.  Our Delta-Apply algorithm fixes this problem and highly conflicting workloads with this scenario (like a tpc-c like benchmark) now run correctly at lightning speeds.
+    Suppose that a running bank account sum contains a balance of
+    `$1,000`. Two transactions conflict because they overlap with each from
+    two different multi-master nodes. Transaction A is a `$1,000` withdrawal
+    from the account. Transaction B is also a `$1,000` withdrawal from the
+    account. The correct balance is `$-1,000`. The Delta-Apply algorithm
+    fixes this problem and highly conflicting workloads with this scenario
+    (for example, a tpc-c like benchmark) now run correctly at lightning
+    speeds.
 
+In the past, Postgres users have relied on special data types and numbering
+schemes to help prevent conflicts. Unlike other solutions, Spock's powerful
+and simple conflict-free delta-apply columns instead manage data update
+conflicts with the following logic:
 
- In the past, Postgres users have relied on special data types and numbering schemes to help prevent conflicts. Unlike other solutions, Spock's powerful and simple conflict-free delta-apply columns instead manage data update conflicts with logic:
-
-    - the old value is captured in WAL files.
-    - a new value comes in from a transaction.
-    - before the new value overwrites the old value, a delta value is created from the above two steps; that delta is correctly applied.
+- the old value is captured in WAL files.
+- a new value comes in from a transaction.
+- before the new value overwrites the old value, a delta value is created
+  from the above two steps; that delta is correctly applied.
 
 !!! example
 
-    To simplify: *local_value + (new_value - old_value)*
+    To simplify: local_value + (new_value - old_value)
 
-Note that on a conflicting transaction, the delta-apply column will be correctly calculated and applied.
+Note that on a conflicting transaction, the delta-apply column will be
+correctly calculated and applied.
 
-To make a column a conflict-free delta-apply column, ensuring that the value replicated is the delta of the committed changes (the old value plus or minus any new value) to a given record, you need to apply the following settings to the column:  `log_old_value=true, delta_apply_function=spock.delta_apply`.  For example:
+To make a column a conflict-free delta-apply column, ensuring that the value
+replicated is the delta of the committed changes (the old value plus or
+minus any new value) to a given record, you need to apply the following
+settings to the column: `log_old_value=true,
+delta_apply_function=spock.delta_apply`. For example:
 
 ```sql
-ALTER TABLE pgbench_accounts ALTER COLUMN abalance SET (log_old_value=true, delta_apply_function=spock.delta_apply);
-ALTER TABLE pgbench_branches ALTER COLUMN bbalance SET (log_old_value=true, delta_apply_function=spock.delta_apply);
-ALTER TABLE pgbench_tellers ALTER COLUMN tbalance SET (log_old_value=true, delta_apply_function=spock.delta_apply);
+ALTER TABLE pgbench_accounts ALTER COLUMN abalance
+  SET (log_old_value=true, delta_apply_function=spock.delta_apply);
+ALTER TABLE pgbench_branches ALTER COLUMN bbalance
+  SET (log_old_value=true, delta_apply_function=spock.delta_apply);
+ALTER TABLE pgbench_tellers ALTER COLUMN tbalance
+  SET (log_old_value=true, delta_apply_function=spock.delta_apply);
 ```
 
-As a special safety-valve feature, if you ever need to re-set a `log_old_value` column you can temporarily alter the column to `log_old_value` is `false`.
+As a special safety-valve feature, if you ever need to re-set a
+`log_old_value` column you can temporarily alter the column to
+`log_old_value` is `false`.
 
 ### Conflict Configuration Options
 
-You can configure some Spock extension behaviors with configuration options that are set in the `postgresql.conf` file or via `ALTER SYSTEM SET`:
+You can configure some Spock extension behaviors with configuration options
+that are set in the `postgresql.conf` file or via `ALTER SYSTEM SET`:
 
-- `spock.conflict_resolution = last_update_wins`
-  Sets the resolution method to `last_update_wins` for any detected conflicts between local data and incoming changes - the version of data with newest commit timestamp is kept. Note that the `track_commit_timestamp` PostgreSQL setting must also be `enabled`.
-
-- `spock.conflict_log_level`
-  Sets the log level for reporting detected conflicts. The default is `LOG`. If the parameter is set to a value lower than `log_min_messages`, resolved conflicts are not written to the server log. Accepted values are:
-
-    - The [possible values](https://www.postgresql.org/docs/15/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS) are the same as for the `log_min_messages` PostgreSQL setting.
-
-    This setting is used primarily to suppress logging of conflicts.
-
-- `spock.batch_inserts`
-  Tells Spock to use a batch insert mechanism if possible. The batch mechanism uses PostgreSQL internal batch insert mode (also used by the `COPY` command).  The default is `on`.
+- `spock.conflict_resolution = last_update_wins` sets the resolution method
+  to `last_update_wins` for any detected conflicts between local data and
+  incoming changes; the version of data with newest commit timestamp is
+  kept; note that the `track_commit_timestamp` PostgreSQL setting must also
+  be `enabled`.
+- `spock.conflict_log_level` sets the log level for reporting detected
+  conflicts; the default is `LOG`; if the parameter is set to a value lower
+  than `log_min_messages`, resolved conflicts are not written to the server
+  log; accepted values are the same as for the `log_min_messages` PostgreSQL
+  setting (see [possible
+  values](https://www.postgresql.org/docs/15/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS));
+  this setting is used primarily to suppress logging of conflicts.
+- `spock.batch_inserts` tells Spock to use a batch insert mechanism if
+  possible; the batch mechanism uses PostgreSQL internal batch insert mode
+  (also used by the `COPY` command); the default is `on`.
 
 
 ### Handling `INSERT-RowExists` or `INSERT/INSERT` Conflicts
 
-If Spock encounters a conflict caused by a constraint violation (unique constraint, primary key, or replication identity) Spock can automatically transform an `INSERT` into an `UPDATE`, updating all columns of the existing row.
+If Spock encounters a conflict caused by a constraint violation (unique
+constraint, primary key, or replication identity) Spock can automatically
+transform an `INSERT` into an `UPDATE`, updating all columns of the existing
+row.
 
-By default, when an `INSERT` statement targets a row that already exists, Spock detects the conflict and transforms the operation into an `UPDATE` statement, applying changes to all columns of the existing row. The event is recorded in the `spock.resolutions` table.
+By default, when an `INSERT` statement targets a row that already exists,
+Spock detects the conflict and transforms the operation into an `UPDATE`
+statement, applying changes to all columns of the existing row. The event is
+recorded in the `spock.resolutions` table.
 
-Extended constraint violation behavior is controlled by the `spock.check_all_uc_indexes` parameter. The default value is `off`; when set to `on`, Spock will:
+Extended constraint violation behavior is controlled by the
+`spock.check_all_uc_indexes` parameter. The default value is `off`; when set
+to `on`, Spock will perform the following actions:
 
-* Scan all valid unique constraints (as well as the primary key and replica identity).
-* Scan non-null unique constraints (including the primary key / replica identity index) in OID order.
-* Locate and resolve conflicting rows encountered during an `INSERT` statement.
-
+- scan all valid unique constraints (as well as the primary key and replica
+  identity).
+- scan non-null unique constraints (including the primary key or replica
+  identity index) in OID order.
+- locate and resolve conflicting rows encountered during an `INSERT`
+  statement.
 
 !!! warning
 
-If `spock.check_all_uc_indexes` is `enabled`, Spock will resolve only the first conflict identified, using Last-Write-Wins logic. If a second conflict occurs, an exception is recorded in the `spock.resolutions` table as either `Keep-Local` or `Apply-Remote`.
+    If `spock.check_all_uc_indexes` is `enabled`, Spock will resolve only
+    the first conflict identified, using Last-Write-Wins logic. If a second
+    conflict occurs, an exception is recorded in the `spock.resolutions`
+    table as either `Keep-Local` or `Apply-Remote`.
 
-This feature is experimental; enable this feature at your own risk.
+    This feature is experimental; enable this feature at your own risk.
 
 
 ### Handling `DELETE-RowMissing` Conflicts
 
-Given that the purpose of the DELETE statement is to remove the row anyway, we do not log these as exceptions, since the desired outcome of removing the row has obviously been achieved, one way or the other. Instead `DELETE-RowMissing` conflicts are automatically written to the `spock.resolutions` table since the desired result has been achieved.
+Given that the purpose of the DELETE statement is to remove the row anyway,
+we do not log these as exceptions, since the desired outcome of removing the
+row has obviously been achieved, one way or the other. Instead
+`DELETE-RowMissing` conflicts are automatically written to the
+`spock.resolutions` table since the desired result has been achieved.

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -105,8 +105,8 @@ to `on`, Spock will perform the following actions:
 
     If `spock.check_all_uc_indexes` is `enabled`, Spock will resolve only
     the first conflict identified, using Last-Write-Wins logic. If a second
-    conflict occurs, an exception is recorded in the `spock.resolutions`
-    table as either `Keep-Local` or `Apply-Remote`.
+    unique constraint conflict occurs, an error is raised and recorded in
+    `spock.exception_log`.
 
     This feature is experimental; enable this feature at your own risk.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,8 @@ nav:
   - Creating a Two-Node Cluster: two_node_cluster.md
   - Using Advanced Configuration Options: configuring.md
   - Upgrading a Spock Installation: upgrading_spock.md
-  - Spock's Conflict Avoidance Options: conflicts.md
+  - Conflict Types and Resolution: conflict_types.md
+  - Conflict Avoidance and Delta-Apply Columns: conflicts.md
   - Spock's Management Features:
     - Managing a Spock Installation: managing/index.md
     - Replicating Partitioned Tables: managing/partition_mgmt.md

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -819,8 +819,48 @@ spock_handle_conflict_and_apply(SpockRelation *rel, EState *estate,
 			BeginInternalSubTransaction("SpockDeltaApply");
 
 		EvalPlanQualSetSlot(epqstate, remoteslot);
-		ExecSimpleRelationUpdate(relinfo, estate, epqstate,
-								 localslot, remoteslot);
+
+		PG_TRY();
+		{
+			ExecSimpleRelationUpdate(relinfo, estate, epqstate,
+									 localslot, remoteslot);
+		}
+		PG_CATCH();
+		{
+			/*
+			 * If the UPDATE's new values violated a unique constraint,
+			 * report it as an update_exists conflict before re-throwing.
+			 * This matches PG18 native conflict detection behavior.
+			 *
+			 * We cannot safely call spock_report_conflict() here because
+			 * the executor may have invalidated tuple slot data during its
+			 * partial execution.  Use a simple elog that is similar instead
+			 */
+			if (!is_insert)
+			{
+				ErrorData  *edata;
+
+				MemoryContextSwitchTo(MessageContext);
+				edata = CopyErrorData();
+
+				if (edata->sqlerrcode == ERRCODE_UNIQUE_VIOLATION)
+				{
+					elog(spock_conflict_log_level,
+						 "CONFLICT: detected %s on %s.%s: %s",
+						 SpockConflictTypeName(SPOCK_CT_UPDATE_EXISTS),
+						 rel->nspname,
+						 RelationGetRelationName(rel->rel),
+						 edata->message);
+#if PG_VERSION_NUM >= 180000
+					spock_stat_report_subscription_conflict(
+						MyApplyWorker->subid, SPOCK_CT_UPDATE_EXISTS);
+#endif
+				}
+				FreeErrorData(edata);
+			}
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
 
 		if (is_delta_apply)
 		{

--- a/src/spock_conflict.c
+++ b/src/spock_conflict.c
@@ -386,15 +386,18 @@ spock_report_conflict(SpockConflictType conflict_type,
 		if (conflict_type == SPOCK_CT_UPDATE_EXISTS)
 			conflict_type = SPOCK_CT_UPDATE_ORIGIN_DIFFERS;
 
+		/*
+		 * Origin-differs is normal replication flow, not a true conflict.
+		 * Do not write to spock.resolutions regardless of which side wins.
+		 */
+		save_in_resolutions = false;
+
 		if (resolution == SpockResolution_ApplyRemote)
 		{
 			/*
-			 * Remote tuple wins — this is normal replication flow, not a true
-			 * conflict. Do not write to spock.resolutions, but optionally
-			 * log to the PostgreSQL log based on the GUC setting.
+			 * Remote tuple wins — optionally log to the PostgreSQL log
+			 * based on the log_origin_change GUC setting.
 			 */
-			save_in_resolutions = false;
-
 			if (!found_local_origin)
 				return;
 

--- a/tests/regress/expected/conflict_stat.out
+++ b/tests/regress/expected/conflict_stat.out
@@ -208,9 +208,119 @@ SELECT spock.reset_subscription_stats(:test_sub_id);
  
 (1 row)
 
--- Cleanup
+-- ============================================================
+-- Test UPDATE_EXISTS: an UPDATE from the provider violates a secondary
+-- unique constraint on the subscriber.  The apply worker detects the
+-- unique violation, logs update_exists to the PostgreSQL log, counts
+-- it in conflict stats, and records it in exception_log.
+-- Default exception_behaviour is TRANSDISCARD: the worker errors on
+-- the first attempt, restarts, replays read-only logging each failing
+-- row to exception_log, then advances the LSN.
+-- ============================================================
+\c :provider_dsn
+-- Create a table with a secondary unique index
+SELECT spock.replicate_ddl($$
+	CREATE TABLE public.conflict_ue_test (
+		id integer PRIMARY KEY,
+		uval integer NOT NULL,
+		data text
+	);
+	CREATE UNIQUE INDEX conflict_ue_test_uval_idx
+		ON public.conflict_ue_test (uval);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'conflict_ue_test');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+-- Seed rows on both sides via replication
+INSERT INTO conflict_ue_test VALUES (1, 100, 'row1');
+INSERT INTO conflict_ue_test VALUES (2, 200, 'row2');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+-- Insert a row only on the subscriber to set up the conflict
+INSERT INTO conflict_ue_test VALUES (3, 300, 'sub_only');
+SELECT * FROM conflict_ue_test ORDER BY id;
+ id | uval |   data   
+----+------+----------
+  1 |  100 | row1
+  2 |  200 | row2
+  3 |  300 | sub_only
+(3 rows)
+
+-- Reset stats
+SELECT spock.reset_subscription_stats(:test_sub_id);
+ reset_subscription_stats 
+--------------------------
+ 
+(1 row)
+
 TRUNCATE spock.exception_log;
 \c :provider_dsn
+-- This UPDATE sets uval=300 on row id=2.  It succeeds on the provider
+-- (no row with uval=300 here), but on the subscriber row id=3 already
+-- has uval=300, so the secondary unique index is violated.
+UPDATE conflict_ue_test SET uval = 300, data = 'should_conflict' WHERE id = 2;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+-- Row id=2 should still have its original value (update was discarded)
+SELECT * FROM conflict_ue_test ORDER BY id;
+ id | uval |   data   
+----+------+----------
+  1 |  100 | row1
+  2 |  200 | row2
+  3 |  300 | sub_only
+(3 rows)
+
+-- The conflict should be logged in exception_log
+SELECT operation, table_name FROM spock.exception_log;
+ operation |    table_name    
+-----------+------------------
+ UPDATE    | conflict_ue_test
+(1 row)
+
+-- Verify UPDATE_EXISTS counter incremented
+SELECT confl_update_exists
+FROM spock.get_subscription_stats(:test_sub_id);
+ confl_update_exists 
+---------------------
+                   1
+(1 row)
+
+SELECT spock.reset_subscription_stats(:test_sub_id);
+ reset_subscription_stats 
+--------------------------
+ 
+(1 row)
+
+TRUNCATE spock.exception_log;
+-- Cleanup
+\c :provider_dsn
+SELECT spock.replicate_ddl($$ DROP TABLE public.conflict_ue_test CASCADE; $$);
+NOTICE:  drop cascades to table conflict_ue_test membership in replication set default
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+-- Cleanup original test table
+TRUNCATE spock.exception_log;
 SELECT spock.replicate_ddl($$ DROP TABLE public.conflict_stat_test CASCADE; $$);
 NOTICE:  drop cascades to table conflict_stat_test membership in replication set default
  replicate_ddl 

--- a/tests/regress/sql/conflict_stat.sql
+++ b/tests/regress/sql/conflict_stat.sql
@@ -140,7 +140,73 @@ FROM spock.get_subscription_stats(:test_sub_id);
 
 SELECT spock.reset_subscription_stats(:test_sub_id);
 
--- Cleanup
-TRUNCATE spock.exception_log;
+-- ============================================================
+-- Test UPDATE_EXISTS: an UPDATE from the provider violates a secondary
+-- unique constraint on the subscriber.  The apply worker detects the
+-- unique violation, logs update_exists to the PostgreSQL log, counts
+-- it in conflict stats, and records it in exception_log.
+-- Default exception_behaviour is TRANSDISCARD: the worker errors on
+-- the first attempt, restarts, replays read-only logging each failing
+-- row to exception_log, then advances the LSN.
+-- ============================================================
+
 \c :provider_dsn
+
+-- Create a table with a secondary unique index
+SELECT spock.replicate_ddl($$
+	CREATE TABLE public.conflict_ue_test (
+		id integer PRIMARY KEY,
+		uval integer NOT NULL,
+		data text
+	);
+	CREATE UNIQUE INDEX conflict_ue_test_uval_idx
+		ON public.conflict_ue_test (uval);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'conflict_ue_test');
+
+-- Seed rows on both sides via replication
+INSERT INTO conflict_ue_test VALUES (1, 100, 'row1');
+INSERT INTO conflict_ue_test VALUES (2, 200, 'row2');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+
+-- Insert a row only on the subscriber to set up the conflict
+INSERT INTO conflict_ue_test VALUES (3, 300, 'sub_only');
+SELECT * FROM conflict_ue_test ORDER BY id;
+
+-- Reset stats
+SELECT spock.reset_subscription_stats(:test_sub_id);
+TRUNCATE spock.exception_log;
+
+\c :provider_dsn
+
+-- This UPDATE sets uval=300 on row id=2.  It succeeds on the provider
+-- (no row with uval=300 here), but on the subscriber row id=3 already
+-- has uval=300, so the secondary unique index is violated.
+UPDATE conflict_ue_test SET uval = 300, data = 'should_conflict' WHERE id = 2;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+
+-- Row id=2 should still have its original value (update was discarded)
+SELECT * FROM conflict_ue_test ORDER BY id;
+
+-- The conflict should be logged in exception_log
+SELECT operation, table_name FROM spock.exception_log;
+
+-- Verify UPDATE_EXISTS counter incremented
+SELECT confl_update_exists
+FROM spock.get_subscription_stats(:test_sub_id);
+
+SELECT spock.reset_subscription_stats(:test_sub_id);
+TRUNCATE spock.exception_log;
+
+-- Cleanup
+\c :provider_dsn
+SELECT spock.replicate_ddl($$ DROP TABLE public.conflict_ue_test CASCADE; $$);
+
+-- Cleanup original test table
+TRUNCATE spock.exception_log;
 SELECT spock.replicate_ddl($$ DROP TABLE public.conflict_stat_test CASCADE; $$);


### PR DESCRIPTION

- New docs/conflict_types.md covering all 7 conflict types, resolution strategies, frozen tuple handling, and comparison with PostgreSQL 18
- Detect secondary unique constraint violations during UPDATE apply and report them as update_exists to the PostgreSQL log and PG18 stats
- Origin-differs events (update_origin_differs, delete_origin_differs) are no longer written to spock.resolutions when the local tuple wins; previously only the remote-wins case was excluded
- Add conflict_types.md to mkdocs.yml nav and cross-link with conflicts.md