### PR TITLE
Fix Codacy false-positive findings and unused variable warnings

### DIFF
--- a/src/spock.c
+++ b/src/spock.c
@@ -863,7 +863,7 @@ log_message_filter(ErrorData *edata)
 	if (edata->elevel == ERROR)
 	{
 		char	   *strpos;
-		const int	len = strlen(PSWD_KEYWORD);
+		const int	len = sizeof(PSWD_KEYWORD) - 1;
 
 		/*
 		 * Password may bubble up in the error message and query string. XXX:

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -579,9 +579,7 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	List	   *progress_list = NIL;
 	int			nrows;
 	int			rno;
-	/* Column indices in the result: lsn(0), snapshot(1), then GP_* + 2 */
-	const int	COL_LSN = 0;
-	const int	COL_SNAP = 1;
+	/* Column indices in the result: lsn(0), snapshot(1) are skipped; GP_* start at 2 */
 	const int	COL_OFFSET = 2;	/* GP_* indices start at COL_OFFSET */
 
 	initStringInfo(&query);


### PR DESCRIPTION
Replace strlen(PSWD_KEYWORD) with sizeof(PSWD_KEYWORD) - 1 since PSWD_KEYWORD is a compile-time string literal; evaluated at compile time with no runtime overhead.

Remove unused COL_LSN and COL_SNAP variables in
spock_create_slot_and_read_progress(); the read_peer_progress result columns 0 and 1 are intentionally skipped in favour of the values already obtained from the replication protocol.