### PR TITLE
Pause apply workers during slot creation to fix data loss on new node.

### DIFF
--- a/.github/workflows/zodan_sync.yml
+++ b/.github/workflows/zodan_sync.yml
@@ -1,0 +1,64 @@
+# Keep its logic in sync with spockbench.yml!
+
+name: Z0DAN Sync long-lasting test
+run-name: Add new node into highly loaded multi-master configuration
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * 6'  # Saturday, 22:00 (UTC)
+
+permissions:
+  contents: read
+
+jobs:
+  pull-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        pgver: [15, 16, 17, 18]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout spock
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Add permissions
+        run: |
+          sudo chmod -R a+w ${GITHUB_WORKSPACE}
+
+      - name: Set up Docker
+        # Codacy wants us to use full commit SHA. This is for v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Build docker container
+        run: |
+            docker build \
+            --build-arg PGVER=${{ matrix.pgver }} \
+            -t spock -f tests/docker/Dockerfile-step-1.el9 .
+
+      - name: Run picked TAP tests
+        run: |
+          TAP_CT_NAME="spock-tap-${{ matrix.pgver }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "TAP_CT_NAME=$TAP_CT_NAME" >> "$GITHUB_ENV"
+          docker run --name "$TAP_CT_NAME" -e PGVER=${{ matrix.pgver }} spock /home/pgedge/run-spock-tap.sh "t/011_zodan_sync_third.pl" 10
+        timeout-minutes: 1440
+
+      - name: Collect TAP artifacts (from container)
+        if: ${{ always() }}
+        run: |
+          docker cp "$TAP_CT_NAME":/home/pgedge/spock/ "$GITHUB_WORKSPACE/results" || true
+          docker rm -f "$TAP_CT_NAME" || true
+
+      - name: Upload TAP artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tap-${{ matrix.pgver }}
+          path: |
+            ${{ github.workspace }}/results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/zodan_sync.yml
+++ b/.github/workflows/zodan_sync.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
             docker build \
             --build-arg PGVER=${{ matrix.pgver }} \
-            -t spock -f tests/docker/Dockerfile-step-1.el9 .
+            -t spock -f tests/docker/Dockerfile.el9 .
 
       - name: Run picked TAP tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ OBJS = $(filter-out src/spock_output.o, $(SRCS:.c=.o)) \
        src/compat/$(PGVER)/spock_compat.o
 
 PG_CPPFLAGS += -I$(libpq_srcdir) \
-			   -I$(realpath include) \
-			   -I$(realpath src/compat/$(PGVER)) \
+			   -I"$(realpath include)" \
+			   -I"$(realpath src/compat/$(PGVER))" \
 			   -Werror=implicit-function-declaration
 SHLIB_LINK += $(libpq) $(filter -lintl, $(LIBS))
 ifdef NO_LOG_OLD_VALUE
@@ -41,11 +41,11 @@ include $(PGXS)
 spock_output.o: src/spock_output.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
-spock_version=$(shell grep "^\#define \<SPOCK_VERSION\>" $(realpath include/spock.h) | cut -d'"' -f2)
+spock_version=$(shell grep "^\#define \<SPOCK_VERSION\>" "$(realpath include/spock.h)" | cut -d'"' -f2)
 requires =
 control_path = $(abspath $(srcdir))/spock.control
 spock.control: spock.control.in include/spock.h
-	sed 's/__SPOCK_VERSION__/$(spock_version)/;s/__REQUIRES__/$(requires)/' $(realpath $(srcdir)/spock.control.in) > $(control_path)
+	sed 's/__SPOCK_VERSION__/$(spock_version)/;s/__REQUIRES__/$(requires)/' "$(realpath $(srcdir)/spock.control.in)" > "$(control_path)"
 
 
 all: spock.control spockctrl

--- a/include/spock.h
+++ b/include/spock.h
@@ -52,6 +52,7 @@ extern bool	allow_ddl_from_functions;
 extern int	restart_delay_default;
 extern int	restart_delay_on_exception;
 extern int	spock_replay_queue_size;
+extern int	spock_pause_timeout;
 extern int	spock_feedback_frequency;
 extern bool check_all_uc_indexes;
 extern int	log_origin_change;

--- a/include/spock_worker.h
+++ b/include/spock_worker.h
@@ -64,6 +64,7 @@ typedef struct SpockApplyWorker
 	XLogRecPtr	replay_stop_lsn;	/* Replay should stop here if defined. */
 	bool		sync_pending;		/* Is there new synchronization info pending?. */
 	bool		use_try_block;		/* Should use try block for apply? */
+	bool		paused;			/* Worker is paused for slot creation. */
 	SpockApplyGroup apply_group;	/* Apply group to be used with parallel slots. */
 } SpockApplyWorker;
 
@@ -127,6 +128,13 @@ typedef struct SpockContext {
 	LWLock				   *apply_group_master_lock;
 	int						napply_groups;
 	SpockApplyGroupData	   *apply_groups;
+
+	/*
+	 * Pause mechanism for apply workers during slot creation.
+	 * Non-zero signals workers to sleep on pause_cv until cleared.
+	 */
+	pg_atomic_uint32 pause_apply;
+	ConditionVariable pause_cv;
 
 	/* Background workers. */
 	int			total_workers;

--- a/sql/spock--5.0.5--5.0.6.sql
+++ b/sql/spock--5.0.5--5.0.6.sql
@@ -5,3 +5,12 @@
 
 ALTER TABLE spock.subscription
     ADD COLUMN sub_created_at timestamptz;
+
+CREATE FUNCTION spock.pause_apply_workers()
+RETURNS void VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_pause_apply_workers';
+
+CREATE FUNCTION spock.resume_apply_workers()
+RETURNS void VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_resume_apply_workers';
+
+REVOKE EXECUTE ON FUNCTION spock.pause_apply_workers() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION spock.resume_apply_workers() FROM PUBLIC;

--- a/sql/spock--5.0.5--5.0.6.sql
+++ b/sql/spock--5.0.5--5.0.6.sql
@@ -5,12 +5,3 @@
 
 ALTER TABLE spock.subscription
     ADD COLUMN sub_created_at timestamptz;
-
-CREATE FUNCTION spock.pause_apply_workers()
-RETURNS void VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_pause_apply_workers';
-
-CREATE FUNCTION spock.resume_apply_workers()
-RETURNS void VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_resume_apply_workers';
-
-REVOKE EXECUTE ON FUNCTION spock.pause_apply_workers() FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION spock.resume_apply_workers() FROM PUBLIC;

--- a/sql/spock--5.0.6--5.0.7.sql
+++ b/sql/spock--5.0.6--5.0.7.sql
@@ -3,3 +3,12 @@
 
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION spock UPDATE TO '5.0.7'" to load this file. \quit
+
+CREATE FUNCTION spock.pause_apply_workers()
+RETURNS void VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_pause_apply_workers';
+
+CREATE FUNCTION spock.resume_apply_workers()
+RETURNS void VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_resume_apply_workers';
+
+REVOKE EXECUTE ON FUNCTION spock.pause_apply_workers() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION spock.resume_apply_workers() FROM PUBLIC;

--- a/src/spock.c
+++ b/src/spock.c
@@ -139,6 +139,7 @@ bool	allow_ddl_from_functions = false;
 int		restart_delay_default;
 int		restart_delay_on_exception;
 int		spock_replay_queue_size;
+int		spock_pause_timeout = 10;	/* seconds to wait for apply workers to pause */
 int		spock_feedback_frequency;
 bool	check_all_uc_indexes = false;
 int		log_origin_change = SPOCK_ORIGIN_NONE;
@@ -1138,6 +1139,21 @@ _PG_init(void)
 							INT_MAX,
 							PGC_SIGHUP,
 							0,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomIntVariable("spock.pause_timeout",
+							"Timeout in seconds for pausing apply workers during slot creation",
+							"Controls how long add_node waits for apply "
+							"workers to reach a between-transaction pause point. Increase "
+							"if add_node fails with a pause timeout under heavy load.",
+							&spock_pause_timeout,
+							10,
+							1,
+							300,
+							PGC_USERSET,
+							GUC_UNIT_S,
 							NULL,
 							NULL,
 							NULL);

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -720,6 +720,35 @@ action_error_callback(void *arg)
  * existing transaction).
  * Also provide a global snapshot and ensure we run in ApplyMessageContext.
  */
+
+/*
+ * If the pause flag is set (slot creation in progress for add_node),
+ * sleep on the ConditionVariable until resumed or timed out.
+ */
+static void
+maybe_pause_for_slot_creation(void)
+{
+	if (pg_atomic_read_u32(&SpockCtx->pause_apply) != 0)
+	{
+		MyApplyWorker->paused = true;
+		ConditionVariablePrepareToSleep(&SpockCtx->pause_cv);
+		while (pg_atomic_read_u32(&SpockCtx->pause_apply) != 0)
+		{
+			if (ConditionVariableTimedSleep(&SpockCtx->pause_cv,
+											spock_pause_timeout * 1000L,
+											WAIT_EVENT_LOGICAL_APPLY_MAIN))
+			{
+				elog(WARNING, "SPOCK: apply worker pause timed out after %ds, resuming",
+					 spock_pause_timeout);
+				pg_atomic_write_u32(&SpockCtx->pause_apply, 0);
+				break;
+			}
+		}
+		ConditionVariableCancelSleep();
+		MyApplyWorker->paused = false;
+	}
+}
+
 static bool
 begin_replication_step(void)
 {
@@ -736,6 +765,18 @@ begin_replication_step(void)
 
 	if (!IsTransactionState())
 	{
+		/*
+		 * Check if slot creation (add_node) needs us to pause.  This only
+		 * fires during add_node (a rare operation).  The fast path is a
+		 * single atomic read that almost always sees 0.
+		 *
+		 * Runs before StartTransactionCommand so the worker has no xid
+		 * while paused — pause_apply_workers can detect completion via
+		 * xid polling.  The previous transaction's commit is fully
+		 * complete, so progress reflects only committed state.
+		 */
+		maybe_pause_for_slot_creation();
+
 		StartTransactionCommand();
 		apply_api.on_begin();
 		result = true;
@@ -1168,6 +1209,8 @@ handle_commit(StringInfo s)
 	awake_transaction_waiters();
 
 	in_remote_transaction = false;
+
+	maybe_pause_for_slot_creation();
 
 	/*
 	 * Stop replay if we're doing limited replay and we've replayed up to the

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -129,6 +129,8 @@ PG_FUNCTION_INFO_V1(spock_wait_for_subscription_sync_complete);
 PG_FUNCTION_INFO_V1(spock_wait_for_table_sync_complete);
 
 PG_FUNCTION_INFO_V1(spock_create_sync_event);
+PG_FUNCTION_INFO_V1(spock_pause_apply_workers);
+PG_FUNCTION_INFO_V1(spock_resume_apply_workers);
 
 /* Replication set manipulation. */
 PG_FUNCTION_INFO_V1(spock_create_replication_set);
@@ -3110,6 +3112,104 @@ spock_create_sync_event(PG_FUNCTION_ARGS)
 	lsn = LogLogicalMessage(SPOCK_MESSAGE_PREFIX, (char *)&message, sizeof(message), true);
 
 	PG_RETURN_LSN(lsn);
+}
+
+/*
+ * spock_pause_apply_workers
+ *
+ * Temporarily pause all apply workers in this database during slot creation
+ * for add_node.  Sets a shared memory flag that workers check between
+ * transactions; workers sleep on a ConditionVariable until resumed.
+ *
+ * After this function returns, all apply workers have finished their current
+ * transaction and are paused, so pg_replication_origin_status reflects only
+ * committed state that is visible in any new snapshot.
+ */
+Datum
+spock_pause_apply_workers(PG_FUNCTION_ARGS)
+{
+	int			i;
+	int			max_wait_ms = spock_pause_timeout * 1000;
+	int			waited_ms = 0;
+
+	/* Signal apply workers to pause at their next between-transaction point. */
+	pg_atomic_write_u32(&SpockCtx->pause_apply, 1);
+
+	/*
+	 * Wait until all apply workers in this database have either:
+	 * - no active transaction (xid invalid = between transactions or idle), or
+	 * - set their paused flag (spinning on the pause_apply flag).
+	 *
+	 * Either state means the worker has committed its last transaction and
+	 * cannot apply new DML until the flag is cleared.
+	 */
+	while (waited_ms < max_wait_ms)
+	{
+		bool	all_paused = true;
+
+		for (i = 0; i < SpockCtx->total_workers; i++)
+		{
+			SpockWorker *w = &SpockCtx->workers[i];
+
+			if (w->worker_type != SPOCK_WORKER_APPLY)
+				continue;
+			if (w->dboid != MyDatabaseId)
+				continue;
+			if (w->proc == NULL)
+				continue;
+
+			/* Worker is paused (spinning on flag) — good. */
+			if (w->worker.apply.paused)
+				continue;
+
+			/* Worker has no active transaction — also good. */
+			if (!TransactionIdIsValid(w->proc->xid))
+				continue;
+
+			/* Worker is mid-transaction and not yet paused. */
+			all_paused = false;
+			break;
+		}
+
+		if (all_paused)
+			break;
+
+		CHECK_FOR_INTERRUPTS();
+		pg_usleep(1000);	/* 1ms */
+		waited_ms++;
+	}
+
+	if (waited_ms >= max_wait_ms)
+	{
+		pg_atomic_write_u32(&SpockCtx->pause_apply, 0);
+		ereport(ERROR,
+				(errcode(ERRCODE_LOCK_NOT_AVAILABLE),
+				 errmsg("timed out waiting for apply workers to pause after %d seconds",
+						spock_pause_timeout),
+				 errhint("Increase spock.pause_timeout if apply workers have long-running transactions.")));
+	}
+	else
+		elog(DEBUG1, "SPOCK pause_apply_workers: all workers paused after %d ms", waited_ms);
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * spock_resume_apply_workers
+ *
+ * Resume apply workers by clearing the flag and broadcasting on the
+ * ConditionVariable to wake all sleeping workers.
+ */
+Datum
+spock_resume_apply_workers(PG_FUNCTION_ARGS)
+{
+	/* Clear the flag and wake all sleeping workers. */
+	pg_atomic_write_u32(&SpockCtx->pause_apply, 0);
+	ConditionVariableBroadcast(&SpockCtx->pause_cv);
+
+	elog(DEBUG1, "SPOCK resume_apply_workers: workers resumed");
+
+	PG_RETURN_VOID();
 }
 
 /*

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -905,7 +905,8 @@ static List *
 copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 						   const char *target_dsn,
 						   const char *origin_snapshot,
-						   List *replication_sets, const char *origin_name)
+						   List *replication_sets, const char *origin_name,
+						   PGconn *resume_conn)
 {
 	PGconn	   *origin_conn;
 	PGconn	   *target_conn;
@@ -973,6 +974,21 @@ copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 	}
 
 	adjust_progress_info(origin_conn, target_conn);
+
+	/*
+	 * If apply workers were paused before slot creation (to prevent data loss
+	 * during add_node under write load), resume them now that progress has been
+	 * read consistently within the slot snapshot.
+	 */
+	if (resume_conn != NULL && PQstatus(resume_conn) == CONNECTION_OK)
+	{
+		PGresult *rres = PQexec(resume_conn,
+								"SELECT spock.resume_apply_workers()");
+		if (PQresultStatus(rres) != PGRES_TUPLES_OK)
+			elog(WARNING, "SPOCK: could not resume apply workers: %s",
+				 PQerrorMessage(resume_conn));
+		PQclear(rres);
+	}
 
 	/* Finish the transactions and disconnect. */
 	finish_copy_origin_tx(origin_conn);
@@ -1100,12 +1116,53 @@ spock_sync_subscription(SpockSubscription *sub)
 		origin_conn_repl = spock_connect_replica(sub->origin_if->dsn,
 													 sub->name, "snap");
 
-		snapshot = ensure_replication_slot_snapshot(origin_conn,
-													origin_conn_repl,
-													sub->slot_name,
-													use_failover_slot, &lsn);
+		/*
+		 * Pause apply workers on the origin before creating the replication
+		 * slot.  This prevents data loss when adding a node under write load:
+		 * without the pause, an apply worker could commit a transaction after
+		 * the slot is created but before adjust_progress_info reads
+		 * spock.progress, making the new node think it has already seen data
+		 * that was not included in the COPY snapshot.
+		 *
+		 * Workers are resumed inside copy_replication_sets_data after
+		 * adjust_progress_info completes.  If slot creation fails, the
+		 * PG_CATCH block below attempts a best-effort resume.
+		 */
+		{
+			PGresult *pres = PQexec(origin_conn,
+									"SELECT spock.pause_apply_workers()");
+			if (PQresultStatus(pres) != PGRES_TUPLES_OK)
+				elog(WARNING, "SPOCK: could not pause apply workers on origin: %s",
+					 PQerrorMessage(origin_conn));
+			PQclear(pres);
+		}
 
-		PQfinish(origin_conn);
+		PG_TRY();
+		{
+			snapshot = ensure_replication_slot_snapshot(origin_conn,
+														origin_conn_repl,
+														sub->slot_name,
+														use_failover_slot, &lsn);
+		}
+		PG_CATCH();
+		{
+			/* Best-effort resume on error — workers' CV timeout will also
+			 * recover them if this fails. */
+			if (PQstatus(origin_conn) == CONNECTION_OK)
+			{
+				PGresult *rres = PQexec(origin_conn,
+										"SELECT spock.resume_apply_workers()");
+				if (rres)
+					PQclear(rres);
+			}
+			PQfinish(origin_conn);
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
+
+		/* Keep origin_conn open — resume_conn is passed to
+		 * copy_replication_sets_data so workers are released after
+		 * adjust_progress_info reads progress within the slot snapshot. */
 
 		PG_ENSURE_ERROR_CLEANUP(spock_sync_worker_cleanup_error_cb,
 								PointerGetDatum(sub));
@@ -1168,7 +1225,13 @@ spock_sync_subscription(SpockSubscription *sub)
 														sub->target_if->dsn,
 														snapshot,
 														sub->replication_sets,
-														sub->slot_name);
+														sub->slot_name,
+														origin_conn);
+
+					/* origin_conn was kept open for the resume call inside
+					 * copy_replication_sets_data; close it now. */
+					PQfinish(origin_conn);
+					origin_conn = NULL;
 
 					/* Store info about all the synchronized tables. */
 					StartTransactionCommand();
@@ -1215,6 +1278,23 @@ spock_sync_subscription(SpockSubscription *sub)
 
 					restore_structure(sub, tmpfile, "post-data");
 				}
+
+				/*
+				 * If no data copy was done (structure-only sync), apply
+				 * workers are still paused — resume them now.
+				 */
+				if (origin_conn != NULL)
+				{
+					if (PQstatus(origin_conn) == CONNECTION_OK)
+					{
+						PGresult *rres = PQexec(origin_conn,
+												"SELECT spock.resume_apply_workers()");
+						if (rres)
+							PQclear(rres);
+					}
+					PQfinish(origin_conn);
+					origin_conn = NULL;
+				}
 			}
 			PG_END_ENSURE_ERROR_CLEANUP_SUFFIX(spock_sync_tmpfile_cleanup_cb,
 										CStringGetDatum(tmpfile), _suf);
@@ -1223,6 +1303,20 @@ spock_sync_subscription(SpockSubscription *sub)
 		}
 		PG_END_ENSURE_ERROR_CLEANUP(spock_sync_worker_cleanup_error_cb,
 									PointerGetDatum(sub));
+
+		/* Safety net: if origin_conn is still open (e.g. error before data
+		 * copy), resume workers and close it. */
+		if (origin_conn != NULL)
+		{
+			if (PQstatus(origin_conn) == CONNECTION_OK)
+			{
+				PGresult *rres = PQexec(origin_conn,
+										"SELECT spock.resume_apply_workers()");
+				if (rres)
+					PQclear(rres);
+			}
+			PQfinish(origin_conn);
+		}
 
 		PQfinish(origin_conn_repl);
 

--- a/src/spock_worker.c
+++ b/src/spock_worker.c
@@ -795,6 +795,8 @@ spock_worker_shmem_startup(void)
 		SpockCtx->lag_lock = &((GetNamedLWLockTranche("spock")[1]).lock);
 		SpockCtx->supervisor = NULL;
 		SpockCtx->subscriptions_changed = false;
+		pg_atomic_init_u32(&SpockCtx->pause_apply, 0);
+		ConditionVariableInit(&SpockCtx->pause_cv);
 		SpockCtx->total_workers = nworkers;
 		memset(SpockCtx->workers, 0,
 			   sizeof(SpockWorker) * SpockCtx->total_workers);

--- a/tests/docker/Dockerfile.el9
+++ b/tests/docker/Dockerfile.el9
@@ -71,9 +71,9 @@ RUN . /home/pgedge/.bashrc && export PG_CONFIG=/home/pgedge/pgedge/pg$PGVER/bin/
 RUN echo "==========Built Spock=========="
 
 #-----------------------------------------
-COPY tests/docker/entrypoint.sh tests/docker/run-tests.sh tests/docker/run-spock-regress.sh /home/pgedge
+COPY tests/docker/entrypoint.sh tests/docker/run-tests.sh tests/docker/run-spock-regress.sh tests/docker/run-spock-tap.sh /home/pgedge
 
-RUN sudo chmod +x /home/pgedge/entrypoint.sh /home/pgedge/run-tests.sh /home/pgedge/run-spock-regress.sh
+RUN sudo chmod +x /home/pgedge/entrypoint.sh /home/pgedge/run-tests.sh /home/pgedge/run-spock-regress.sh /home/pgedge/run-spock-tap.sh
 
 WORKDIR /home/pgedge/
 USER pgedge

--- a/tests/docker/run-spock-tap.sh
+++ b/tests/docker/run-spock-tap.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+###
+### Run selected TAP tests iteratively
+###
+
+source "${HOME}/.bashrc"
+
+# TAP tests create their own PostgreSQL instances via initdb, which only have
+# the OS user (pgedge) as superuser. Unset Docker-specific credentials to avoid
+# "role does not exist" errors.
+unset PGUSER PGPASSWORD PGDATABASE
+
+# PGVER should be previously set in the environment
+if [ -z "${PGVER}" ]
+then
+	echo "The PGVER environment variable must be set before running this command"
+	exit 1
+fi
+
+proven_tests="$1"
+iterations="$2"
+if [[ -z "$proven_tests" || -z "$iterations" ]]; then
+    echo "Command-line parameters are set incorrectly"
+    exit 1
+fi
+
+cd /home/pgedge/spock/
+
+status=0
+for i in $(seq 1 $iterations); do
+    echo "Iteration $i: running make check..."
+    env PROVE_TESTS="$proven_tests" make check_prove 1>out.txt 2>err.txt
+    status=$?
+    if [ $status -ne 0 ]; then
+        echo "make check failed with status $status on iteration $i"
+        break
+    fi
+done
+
+if [ $status -ne 0 ]
+then
+	echo "Errors in regression checks"
+	exit 1
+fi

--- a/tests/tap/t/SpockTest.pm
+++ b/tests/tap/t/SpockTest.pm
@@ -361,17 +361,10 @@ sub destroy_cluster {
     $test_name //= 'Destroy multi-node Spock cluster';
     
     if ($nodes_created) {
-        # Cleanup subscriptions and nodes (ignore errors for subscriptions that don't exist)
+        # Drop all subscriptions on each node regardless of naming convention
         for (my $i = 0; $i < $node_count; $i++) {
-            for (my $j = 0; $j < $node_count; $j++) {
-                next if $i == $j; # Skip self-subscription
-                
-                my $source_node = "n" . ($i + 1);
-                my $target_node = "n" . ($j + 1);
-                my $sub_name = "sub_${source_node}_${target_node}";
-                
-                system_maybe "$PG_BIN/psql", '-p', $node_ports[$i], '-d', $DB_NAME, '-c', "SELECT spock.sub_drop('$sub_name')";
-            }
+            system_maybe "$PG_BIN/psql", '-p', $node_ports[$i], '-d', $DB_NAME, '-c',
+                "SELECT spock.sub_drop(sub_name) FROM spock.subscription";
         }
         
         for (my $i = 0; $i < $node_count; $i++) {


### PR DESCRIPTION
An apply worker committing between ensure_replication_slot_snapshot and adjust_progress_info could advance spock.progress beyond the COPY snapshot boundary, causing the new node to skip those changes permanently.

Add an atomic pause flag and ConditionVariable in SpockContext. Apply workers check the flag in begin_replication_step and after handle_commit, sleeping until copy_replication_sets_data calls resume_apply_workers() after adjust_progress_info completes.

Add spock.pause_timeout GUC (default 10s) as a safety net against a crashed sync worker leaving workers paused indefinitely.

Backport of PR #392 from main, adapted for v5_STABLE architecture.