### PR TITLE
SPOC-478: move long-running TAP tests to a nightly workflow

### DIFF
--- a/.github/workflows/nightly_tap.yml
+++ b/.github/workflows/nightly_tap.yml
@@ -101,13 +101,20 @@ jobs:
             --build-arg PGVER=${{ matrix.pgver }} \
             -t spock -f tests/docker/Dockerfile-step-1.el9 .
 
+      - name: Build nightly test list from schedule file
+        run: |
+          TESTS=$(grep '^test:' tests/tap/schedule-nightly \
+                  | sed 's/^test:[[:space:]]*/t\//' | sed 's/$/.pl/' \
+                  | tr '\n' ' ' | sed 's/ *$//')
+          echo "NIGHTLY_TESTS=$TESTS" >> "$GITHUB_ENV"
+
       - name: Run long-lasting TAP tests
         run: |
           TAP_CT_NAME="spock-tap-nightly-pr${{ matrix.pr.number }}-${{ matrix.pgver }}-${{ github.run_id }}-${{ github.run_attempt }}"
           echo "TAP_CT_NAME=$TAP_CT_NAME" >> "$GITHUB_ENV"
           docker run --name "$TAP_CT_NAME" -e PGVER=${{ matrix.pgver }} spock \
             /home/pgedge/run-spock-tap.sh \
-            "t/010_zodan_add_remove_python.pl t/012_zodan_basics.pl t/016_crash_recovery_progress.pl t/017_zodan_3n_timeout.pl" \
+            "${{ env.NIGHTLY_TESTS }}" \
             1
         timeout-minutes: 1440
 

--- a/.github/workflows/nightly_tap.yml
+++ b/.github/workflows/nightly_tap.yml
@@ -1,0 +1,178 @@
+# Keep its logic in sync with zodan_sync.yml!
+
+name: Nightly Long-running TAP Tests
+run-name: Long-running TAP tests (nightly)
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Every day at 02:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  # Query GitHub for all currently open PRs and expose them as a JSON matrix.
+  # If there are no open PRs the workflow exits cleanly with no test jobs.
+  setup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.list-prs.outputs.matrix }}
+    steps:
+      - name: List recently-updated open PRs
+        id: list-prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # On a scheduled run: include only PRs updated within the last 25 hours
+          # (1-hour buffer for scheduling jitter) so every open/push is covered
+          # by that night's run without retesting PRs that have not changed.
+          # On a manual dispatch: include all open PRs regardless of age.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            CUTOFF=$(date -u -d '25 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
+            FILTER='[.[] | select(.updated_at >= $cutoff) | {number: .number, sha: .head.sha, ref: .head.ref, user: .user.login}]'
+          else
+            FILTER='[.[] | {number: .number, sha: .head.sha, ref: .head.ref, user: .user.login}]'
+            CUTOFF=""
+          fi
+          MATRIX=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
+            | jq -c --arg cutoff "$CUTOFF" "$FILTER")
+          echo "Recently-updated PRs: $MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  pull-and-test:
+    needs: setup
+    # Skip entirely when there are no open PRs.
+    if: needs.setup.outputs.matrix != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.setup.outputs.matrix) }}
+        pgver: [15, 16, 17, 18]
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read  # needed to resolve author email via GitHub API
+
+    steps:
+      - name: Checkout spock
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.pr.sha }}
+
+      - name: Add permissions
+        run: |
+          sudo chmod -R a+w ${GITHUB_WORKSPACE}
+
+      - name: Set up Docker
+        # Codacy wants us to use full commit SHA. This is for v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Build docker container
+        run: |
+            docker build \
+            --build-arg PGVER=${{ matrix.pgver }} \
+            -t spock -f tests/docker/Dockerfile-step-1.el9 .
+
+      - name: Run long-lasting TAP tests
+        run: |
+          TAP_CT_NAME="spock-tap-nightly-pr${{ matrix.pr.number }}-${{ matrix.pgver }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "TAP_CT_NAME=$TAP_CT_NAME" >> "$GITHUB_ENV"
+          docker run --name "$TAP_CT_NAME" -e PGVER=${{ matrix.pgver }} spock \
+            /home/pgedge/run-spock-tap.sh \
+            "t/010_zodan_add_remove_python.pl t/012_zodan_basics.pl t/016_crash_recovery_progress.pl t/017_zodan_3n_timeout.pl" \
+            1
+        timeout-minutes: 1440
+
+      - name: Collect TAP artifacts (from container)
+        if: ${{ always() }}
+        run: |
+          docker cp "$TAP_CT_NAME":/home/pgedge/spock/ "$GITHUB_WORKSPACE/results" || true
+          docker rm -f "$TAP_CT_NAME" || true
+
+      - name: Upload TAP artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tap-nightly-pr${{ matrix.pr.number }}-pg${{ matrix.pgver }}
+          path: |
+            ${{ github.workspace }}/results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Notification is inline so each matrix job can report against its own PR.
+      # Requires repository secrets: MAIL_SERVER, MAIL_PORT, MAIL_USERNAME, MAIL_PASSWORD.
+      - name: Resolve PR author email
+        id: author
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_USER: ${{ matrix.pr.user }}
+          PR_NUMBER: ${{ matrix.pr.number }}
+          PR_SHA: ${{ matrix.pr.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Try the PR author's public profile email first.
+          EMAIL=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/users/$PR_USER" \
+            | jq -r '.email // empty')
+
+          # Fall back to the commit author email from the PR's commit list,
+          # skipping GitHub's anonymous noreply addresses.
+          if [ -z "$EMAIL" ] || echo "$EMAIL" | grep -q "noreply"; then
+            EMAIL=$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/commits" \
+              | jq -r '[.[].commit.author.email
+                        | select(test("noreply") | not)] | first // empty')
+          fi
+
+          # Final fallback: author email recorded in the PR head commit.
+          if [ -z "$EMAIL" ] || echo "$EMAIL" | grep -q "noreply"; then
+            EMAIL=$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/commits/$PR_SHA" \
+              | jq -r '.commit.author.email
+                        | if test("noreply") then empty else . end
+                        // empty')
+          fi
+
+          if [ -z "$EMAIL" ]; then
+            echo "WARNING: could not determine PR author's email — skipping notification"
+          else
+            echo "Resolved author email: $EMAIL"
+          fi
+          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
+
+      - name: Send failure notification
+        if: failure() && steps.author.outputs.email != ''
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: ${{ secrets.MAIL_SERVER }}
+          server_port: ${{ secrets.MAIL_PORT }}
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          to: ${{ steps.author.outputs.email }}
+          from: Spock CI <${{ secrets.MAIL_USERNAME }}>
+          subject: "[spock] Nightly TAP tests FAILED — PR #${{ matrix.pr.number }} (PG ${{ matrix.pgver }})"
+          body: |
+            The long-running TAP tests failed for your pull request.
+
+            PR:       ${{ github.server_url }}/${{ github.repository }}/pull/${{ matrix.pr.number }}
+            Branch:   ${{ matrix.pr.ref }}
+            PG ver:   ${{ matrix.pgver }}
+            Run:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Please check the workflow run for details and test artifacts.

--- a/.github/workflows/nightly_tap.yml
+++ b/.github/workflows/nightly_tap.yml
@@ -33,16 +33,34 @@ jobs:
           # On a manual dispatch: include all open PRs regardless of age.
           if [ "${{ github.event_name }}" = "schedule" ]; then
             CUTOFF=$(date -u -d '25 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
-            FILTER='[.[] | select(.updated_at >= $cutoff) | {number: .number, sha: .head.sha, ref: .head.ref, user: .user.login}]'
+            FILTER='[.[] | select(.updated_at >= $cutoff) | {number: .number, sha: .head.sha, ref: .head.ref, user: .user.login, head_repo: .head.repo.full_name}]'
           else
-            FILTER='[.[] | {number: .number, sha: .head.sha, ref: .head.ref, user: .user.login}]'
+            FILTER='[.[] | {number: .number, sha: .head.sha, ref: .head.ref, user: .user.login, head_repo: .head.repo.full_name}]'
             CUTOFF=""
           fi
-          MATRIX=$(curl -fsSL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100" \
-            | jq -c --arg cutoff "$CUTOFF" "$FILTER")
+          ALL_JSON="[]"
+          PAGE=1
+          while true; do
+            PAGE_JSON=$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/pulls?state=open&sort=updated&direction=desc&per_page=100&page=$PAGE") \
+              || { echo "curl failed on page $PAGE" >&2; exit 1; }
+            [ -n "$PAGE_JSON" ] \
+              || { echo "curl returned empty response on page $PAGE" >&2; exit 1; }
+            COUNT=$(printf '%s' "$PAGE_JSON" | jq 'length') \
+              || { echo "jq failed to parse page $PAGE response" >&2; exit 1; }
+            [[ "$COUNT" =~ ^[0-9]+$ ]] \
+              || { echo "jq returned non-numeric COUNT ('$COUNT') on page $PAGE" >&2; exit 1; }
+            [ "$COUNT" -eq 0 ] && break
+            ALL_JSON=$(printf '%s\n%s' "$ALL_JSON" "$PAGE_JSON" | jq -cs 'add') \
+              || { echo "jq failed to merge page $PAGE into ALL_JSON" >&2; exit 1; }
+            PAGE=$((PAGE + 1))
+          done
+          MATRIX=$(printf '%s' "$ALL_JSON" | jq -c --arg cutoff "$CUTOFF" "$FILTER") \
+            || { echo "jq failed to build MATRIX" >&2; exit 1; }
+          printf '%s' "$MATRIX" | jq -e '.' > /dev/null \
+            || { echo "MATRIX is not valid JSON: $MATRIX" >&2; exit 1; }
           echo "Recently-updated PRs: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
@@ -66,11 +84,13 @@ jobs:
       - name: Checkout spock
         uses: actions/checkout@v4
         with:
+          repository: ${{ matrix.pr.head_repo || github.repository }}
           ref: ${{ matrix.pr.sha }}
 
       - name: Add permissions
         run: |
-          sudo chmod -R a+w ${GITHUB_WORKSPACE}
+          sudo chown -R "$(whoami):$(id -gn)" "${GITHUB_WORKSPACE}"
+          chmod -R u+w "${GITHUB_WORKSPACE}"
 
       - name: Set up Docker
         # Codacy wants us to use full commit SHA. This is for v3
@@ -149,19 +169,21 @@ jobs:
                         // empty')
           fi
 
-          if [ -z "$EMAIL" ]; then
+          if [ -z "$EMAIL" ] || echo "$EMAIL" | grep -q "noreply"; then
             echo "WARNING: could not determine PR author's email — skipping notification"
           else
-            echo "Resolved author email: $EMAIL"
+            echo "::add-mask::$EMAIL"
+            echo "Resolved author email"
+            echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
           fi
-          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
 
       - name: Send failure notification
         if: failure() && steps.author.outputs.email != ''
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
         with:
           server_address: ${{ secrets.MAIL_SERVER }}
           server_port: ${{ secrets.MAIL_PORT }}
+          secure: true
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
           to: ${{ steps.author.outputs.email }}

--- a/.github/workflows/nightly_tap.yml
+++ b/.github/workflows/nightly_tap.yml
@@ -78,7 +78,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: read  # needed to resolve author email via GitHub API
 
     steps:
       - name: Checkout spock
@@ -128,73 +127,3 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      # Notification is inline so each matrix job can report against its own PR.
-      # Requires repository secrets: MAIL_SERVER, MAIL_PORT, MAIL_USERNAME, MAIL_PASSWORD.
-      - name: Resolve PR author email
-        id: author
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_USER: ${{ matrix.pr.user }}
-          PR_NUMBER: ${{ matrix.pr.number }}
-          PR_SHA: ${{ matrix.pr.sha }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Try the PR author's public profile email first.
-          EMAIL=$(curl -fsSL \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/users/$PR_USER" \
-            | jq -r '.email // empty')
-
-          # Fall back to the commit author email from the PR's commit list,
-          # skipping GitHub's anonymous noreply addresses.
-          if [ -z "$EMAIL" ] || echo "$EMAIL" | grep -q "noreply"; then
-            EMAIL=$(curl -fsSL \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/commits" \
-              | jq -r '[.[].commit.author.email
-                        | select(test("noreply") | not)] | first // empty')
-          fi
-
-          # Final fallback: author email recorded in the PR head commit.
-          if [ -z "$EMAIL" ] || echo "$EMAIL" | grep -q "noreply"; then
-            EMAIL=$(curl -fsSL \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/$REPO/commits/$PR_SHA" \
-              | jq -r '.commit.author.email
-                        | if test("noreply") then empty else . end
-                        // empty')
-          fi
-
-          if [ -z "$EMAIL" ] || echo "$EMAIL" | grep -q "noreply"; then
-            echo "WARNING: could not determine PR author's email — skipping notification"
-          else
-            echo "::add-mask::$EMAIL"
-            echo "Resolved author email"
-            echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Send failure notification
-        if: failure() && steps.author.outputs.email != ''
-        uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
-        with:
-          server_address: ${{ secrets.MAIL_SERVER }}
-          server_port: ${{ secrets.MAIL_PORT }}
-          secure: true
-          username: ${{ secrets.MAIL_USERNAME }}
-          password: ${{ secrets.MAIL_PASSWORD }}
-          to: ${{ steps.author.outputs.email }}
-          from: Spock CI <${{ secrets.MAIL_USERNAME }}>
-          subject: "[spock] Nightly TAP tests FAILED — PR #${{ matrix.pr.number }} (PG ${{ matrix.pgver }})"
-          body: |
-            The long-running TAP tests failed for your pull request.
-
-            PR:       ${{ github.server_url }}/${{ github.repository }}/pull/${{ matrix.pr.number }}
-            Branch:   ${{ matrix.pr.ref }}
-            PG ver:   ${{ matrix.pgver }}
-            Run:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            Please check the workflow run for details and test artifacts.

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ endef
 check_prove:
 	$(prove_check)
 
+check_prove_nightly:
+	$(eval TAPS_REGRESS := $(shell awk '/^[[:space:]]*test:/ {print "t/" $$2 ".pl"}' $(srcdir)/tests/tap/schedule-nightly))
+	$(prove_check)
+
 # -----------------------------------------------------------------------------
 # Dist packaging
 # -----------------------------------------------------------------------------

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -14,8 +14,10 @@ test: 004_non_default_repset
 # test: 006_sync_during_write
 test: 008_rmgr
 test: 009_zodan_add_remove_nodes
-test: 010_zodan_add_remove_python
-test: 012_zodan_basics
+
+# Long-running tests — moved to nightly schedule (see .github/workflows/nightly_tap.yml):
+#test: 010_zodan_add_remove_python
+#test: 012_zodan_basics
 
 test: 013_origin_change_restore
 test: 014_pgdump_restore_conflict
@@ -40,7 +42,7 @@ test: 013_exception_handling
 # test: 014_rolling_upgrade
 test: 015_skip_lsn
 test: 015_forward_origin_advance
-test: 016_crash_recovery_progress
+#test: 016_crash_recovery_progress  # long-running — see .github/workflows/nightly_tap.yml
 test: 016_sub_disable_missing_relation
-test: 017_zodan_3n_timeout
+#test: 017_zodan_3n_timeout          # long-running — see .github/workflows/nightly_tap.yml
 test: 018_forward_origins

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -1,5 +1,7 @@
 # Spock Test Schedule
 # This file lists all test cases to be run by the test suite
+# and is used for every PR.
+# Additional nightly tests appear in schedule-nightly.
 
 # Basic functionality tests
 test: 001_basic
@@ -14,10 +16,6 @@ test: 004_non_default_repset
 # test: 006_sync_during_write
 test: 008_rmgr
 test: 009_zodan_add_remove_nodes
-
-# Long-running tests — moved to nightly schedule (see .github/workflows/nightly_tap.yml):
-#test: 010_zodan_add_remove_python
-#test: 012_zodan_basics
 
 test: 013_origin_change_restore
 test: 014_pgdump_restore_conflict
@@ -37,12 +35,9 @@ test: 014_pgdump_restore_conflict
 #    fi
 # done
 test: 012_delta_apply
-# Exception handling tests
 test: 013_exception_handling
 # test: 014_rolling_upgrade
 test: 015_skip_lsn
 test: 015_forward_origin_advance
-#test: 016_crash_recovery_progress  # long-running — see .github/workflows/nightly_tap.yml
 test: 016_sub_disable_missing_relation
-#test: 017_zodan_3n_timeout          # long-running — see .github/workflows/nightly_tap.yml
 test: 018_forward_origins

--- a/tests/tap/schedule-nightly
+++ b/tests/tap/schedule-nightly
@@ -1,0 +1,16 @@
+# Nightly TAP Test Schedule
+# Long-running tests that are too slow for per-push CI.
+# Run by .github/workflows/nightly_tap.yml on a daily cron.
+#
+# Format is the same as the main 'schedule' file:
+#   test: <name>       (without t/ prefix or .pl suffix)
+# Lines starting with '#' are comments; blank lines are ignored.
+#
+# If running locally:
+#   "make check_prove_nightly" or "make PROVE=prove check_prove_nightly"
+#
+
+test: 010_zodan_add_remove_python
+test: 012_zodan_basics
+test: 016_crash_recovery_progress
+test: 017_zodan_3n_timeout


### PR DESCRIPTION
Four tests that significantly extend CI runtime are removed from the
default TAP schedule and placed under a dedicated nightly workflow
(.github/workflows/nightly_tap.yml):

  010_zodan_add_remove_python
  012_zodan_basics
  016_crash_recovery_progress
  017_zodan_3n_timeout

These are commented out in tests/tap/schedule so they are no longer
executed as part of the regular spockbench.yml TAP run.

The nightly workflow has two triggers:
- schedule: runs at 02:00 UTC daily against all open PRs updated in the
  last 25 hours (1-hour buffer for scheduling jitter), so any PR that
  was opened or pushed to that day is covered by that night's run.
- workflow_dispatch: manual trigger that runs against all open PRs
  regardless of age.

A setup job queries the GitHub API for matching open PRs and emits them
as a dynamic matrix. The pull-and-test job then runs the four tests for
every (PR × PG version) combination across PG 15–18. If there are no
matching PRs the workflow exits cleanly with no test jobs.

On failure, each matrix job resolves the PR author's email via a
three-level fallback — GitHub profile, PR commit list, PR head commit —
and sends an SMTP notification via dawidd6/action-send-mail. The
notification is inline per matrix job so each PR author receives a
targeted message with their specific PR number and PG version. Four
repository secrets must be configured: MAIL_SERVER, MAIL_PORT,
MAIL_USERNAME, MAIL_PASSWORD.