### PR TITLE
fix: dump resource.dat at every checkpoint to prevent stale progress after crash

### DIFF
--- a/src/spock_group.c
+++ b/src/spock_group.c
@@ -652,10 +652,21 @@ spock_group_resource_load(void)
 void
 spock_checkpoint_hook(XLogRecPtr checkPointRedo, int flags)
 {
-	if ((flags & (CHECKPOINT_IS_SHUTDOWN | CHECKPOINT_END_OF_RECOVERY)) == 0)
-		return;
-
-	/* Dump group progress to resource.dat */
+	/*
+	 * Dump current progress state to resource.dat at every checkpoint.
+	 *
+	 * resource.dat and WAL cooperate for crash recovery:
+	 *   - resource.dat seeds shmem with checkpoint-time values on restart
+	 *   - WAL replay (spock_rmgr_redo) advances any entries written after
+	 *     checkPointRedo
+	 *
+	 * Without dumping at regular checkpoints, a crash after a checkpoint
+	 * leaves resource.dat with values from the last clean shutdown. If apply
+	 * workers were idle during the checkpoint interval (provider unreachable),
+	 * no SPOCK_RMGR_APPLY_PROGRESS records exist after checkPointRedo to
+	 * recover from either, causing spock.progress to show stale values or
+	 * missing entries after crash recovery.
+	 */
 	spock_group_resource_dump();
 }
 

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -42,3 +42,4 @@ test: 015_forward_origin_advance
 test: 016_sub_disable_missing_relation
 test: 018_forward_origins
 test: 019_stale_fd_epoll_after_conn_death
+test: 022_rmgr_progress_post_checkpoint_crash

--- a/tests/tap/t/008_rmgr.pl
+++ b/tests/tap/t/008_rmgr.pl
@@ -3,7 +3,8 @@ use warnings;
 use Test::More;
 use lib '.';
 use SpockTest qw(
-  create_cluster destroy_cluster system_or_bail command_ok get_test_config scalar_query psql_or_bail
+  create_cluster destroy_cluster system_or_bail command_ok get_test_config
+  scalar_query psql_or_bail wait_for_sub_status wait_for_pg_ready
 );
 
 
@@ -18,10 +19,13 @@ sub wait_until {
 }
 
 
-# 1) create 2-node cluster (provider n1, subscriber n2) with Spock
-create_cluster(2, 'Create a 2-node cluster');
+# =============================================================================
+# Setup: 3-node cluster
+# n1 and n2 are used throughout; n3 is introduced in Phase 5.
+# =============================================================================
 
-# DSN for provider
+create_cluster(3, 'Create a 3-node cluster');
+
 my $conf = get_test_config();
 my $host = $conf->{host};
 my $pg_bin = $conf->{pg_bin};
@@ -32,38 +36,41 @@ my $user   = $conf->{db_user};
 
 my $prov_port = $ports->[0];
 my $sub_port  = $ports->[1];
+my $n3_port   = $ports->[2];
+
+my $prov_dir = $datadirs->[0];
+my $sub_dir  = $datadirs->[1];
+my $n3_dir   = $datadirs->[2];
 
 my $prov_dsn = "host=$host port=$prov_port dbname=$dbname user=$user";
+my $n3_dsn   = "host=$host port=$n3_port  dbname=$dbname user=$user";
 
-# Create a table on provider and a subscription on subscriber
+
+# =============================================================================
+# Phase 1: DML replication and initial progress
+# =============================================================================
+
 psql_or_bail(1, "CREATE TABLE public.test_progress (id int primary key, data text)");
 psql_or_bail(2, "SELECT spock.sub_create('test_sub', '$prov_dsn', ARRAY['default'], true, true)");
 
-# Wait for structure to appear on subscriber
 ok(wait_until(30, sub {
   scalar_query(2, "SELECT to_regclass('public.test_progress') IS NOT NULL") eq 't'
 }), 'subscriber has table after initial sync');
 
-
-# 2) DML on provider; progress on subscriber;
 psql_or_bail(1, "INSERT INTO public.test_progress SELECT g, 'Test Val' FROM generate_series(1,3) g");
 
-# Save provider LSN after insert
 my $prov_lsn_after_insert = scalar_query(1, "SELECT pg_current_wal_lsn()");
 ok($prov_lsn_after_insert =~ /^[0-9A-F]+\/[0-9A-F]+$/, "provider LSN after insert: $prov_lsn_after_insert");
 
-# wait for rows to replicate
 ok(wait_until(30, sub {
   scalar_query(2, "SELECT count(*) FROM public.test_progress") eq '3'
 }), 'subscriber has 3 rows');
 
-# progress rows should exist on subscriber
 my $rows = scalar_query(2, q{
   SELECT count(*) FROM spock.apply_group_progress()
 });
 ok($rows ne '' && $rows >= 1, "apply_group_progress() yields at least one row");
 
-# fetch latest progress and compare LSNs against provider current LSN
 my $prog = scalar_query(2, q{
   SELECT remote_commit_lsn || '|' || remote_insert_lsn
   FROM spock.apply_group_progress()
@@ -71,9 +78,7 @@ my $prog = scalar_query(2, q{
 });
 ok($prog =~ /\S+\|\S+/, "fetched progress LSNs from subscriber: $prog");
 
-# compare LSN's of provider and subscriber
 my ($commit_lsn, $insert_lsn) = split(/\|/, $prog, 2);
-# Make sure progress LSNs are <= provider current LSN
 my $cmp_commit = scalar_query(2, "SELECT (pg_lsn '$commit_lsn') <= (pg_lsn '$prov_lsn_after_insert')");
 is($cmp_commit, 't', "remote_commit_lsn <= provider current LSN");
 
@@ -81,51 +86,45 @@ my $cmp_insert = scalar_query(2, "SELECT (pg_lsn '$insert_lsn') <= (pg_lsn '$pro
 is($cmp_insert, 't', "remote_insert_lsn <= provider current LSN");
 
 
-# 3) Clean restart subscriber; File load should seed shmem;
+# =============================================================================
+# Phase 2: Clean restart — resource.dat seeds shmem
+# =============================================================================
 
-# capture latest progress timestamp
 my $before_ts = scalar_query(2, q{ SELECT max(remote_commit_ts) FROM spock.apply_group_progress() });
 ok($before_ts ne '', "captured remote_commit_ts before clean restart: $before_ts");
 
-# stop subscriber cleanly; dump file should be written;
-system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-m', 'fast', 'stop';
-ok((-f $datadirs->[1] . "/spock/resource.dat"), "resource.dat exists on subscriber after clean stop");
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-m', 'fast', 'stop';
+ok((-f "$sub_dir/spock/resource.dat"), "resource.dat exists after clean stop");
 
-# start subscriber again
-system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-o', "-p $sub_port", 'start';
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-o', "-p $sub_port", 'start';
 
-# after restart; progress should be present, seeded;
 ok(wait_until(30, sub {
   my $ts = scalar_query(2, q{ SELECT max(remote_commit_ts) FROM spock.apply_group_progress() });
   ($ts ne '');
 }), 'progress present after clean restart');
 
 my $after_ts = scalar_query(2, q{
-  SELECT max(remote_commit_ts)
-  FROM spock.apply_group_progress()
+  SELECT max(remote_commit_ts) FROM spock.apply_group_progress()
 });
 ok($after_ts ge $before_ts, "progress is same before and after clean restart");
 
-# 4) Crash restart; WAL REDO must advance progress
 
-# generate more WAL on provider
+# =============================================================================
+# Phase 3: Crash restart — WAL REDO must advance progress
+# =============================================================================
+
 psql_or_bail(1, "INSERT INTO public.test_progress SELECT g, 'x' FROM generate_series(4,60) g");
 my $prov_lsn_after_bulk = scalar_query(1, "SELECT pg_current_wal_lsn()");
 ok($prov_lsn_after_bulk =~ /^[0-9A-F]+\/[0-9A-F]+$/, "provider LSN after bulk: $prov_lsn_after_bulk");
 
-# stop subscriber immediately (simulate crash)
-system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-m', 'immediate', 'stop';
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-m', 'immediate', 'stop';
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-o', "-p $sub_port", 'start';
 
-# start subscriber; redo should replay our progress
-system_or_bail "$pg_bin/pg_ctl", '-D', $datadirs->[1], '-o', "-p $sub_port", 'start';
-
-# wait until counts match again
 ok(wait_until(40, sub {
   scalar_query(1, "SELECT count(*) FROM public.test_progress") eq
   scalar_query(2, "SELECT count(*) FROM public.test_progress")
 }), 'subscriber caught up after crash via WAL REDO');
 
-# verify progress advanced and still <= provider LSN
 my $final_prog = scalar_query(2, q{
   SELECT remote_commit_lsn || '|' || remote_insert_lsn || '|' || remote_commit_ts
   FROM spock.apply_group_progress()
@@ -133,7 +132,7 @@ my $final_prog = scalar_query(2, q{
 });
 ok($final_prog =~ /\S+\|\S+\|\S+/, "latest progress after crash restart: $final_prog");
 
-my ($commit_lsn, $insert_lsn, $commit_ts) = split (/\|/, $final_prog, 3);
+my ($commit_lsn, $insert_lsn, $commit_ts) = split(/\|/, $final_prog, 3);
 ok($commit_ts ge $after_ts, "remote_commit_ts advanced after crash restart");
 
 my $cmp_f_commit = scalar_query(2, "SELECT (pg_lsn '$commit_lsn') <= (pg_lsn '$prov_lsn_after_bulk')");
@@ -144,12 +143,161 @@ is($cmp_f_insert, 't', "remote_insert_lsn <= provider current LSN");
 
 my $q1 = scalar_query(2, "SELECT count(*) FROM public.test_progress");
 my $q2 = scalar_query(1, "SELECT count(*) FROM public.test_progress");
+is($q1, $q2, "row counts equal after crash restart");
 
-# Final sanity
-is($q1, $q2, "row counts equal at end");
-# psql_or_bail(1, "SELECT spock.wait_slot_confirm_lsn(NULL, NULL)");
 
+# =============================================================================
+# Phase 4: Stale resource.dat and missing entries after crash
+#
+# Scenario A — stale values:
+#   n1 replicates batch-1 to n2. Clean stop n2 → resource.dat written with
+#   batch-1 values (stale baseline). n1 replicates batch-2 → WAL progress
+#   records written. SIGKILL n2 (resource.dat stays at batch-1). After
+#   recovery: WAL replay must advance n1 progress to batch-2, not regress to
+#   the batch-1 values in resource.dat.
+#
+# Scenario B — missing entries:
+#   n3 subscribes to n2 AFTER resource.dat was written. n3's progress entry
+#   exists in WAL but not in resource.dat. SIGKILL n2. After recovery: WAL
+#   replay must create n3's entry from scratch (not silently drop it).
+#
+# Separate tables (t_n1, t_n3) prevent PK conflicts on n2 so that
+# exception_behaviour / sub_disable cannot mask the bug.
+# =============================================================================
+
+psql_or_bail(1, "CREATE TABLE public.t_n1 (id int primary key, val text)");
+psql_or_bail(2, "CREATE TABLE public.t_n1 (id int primary key, val text)");
+
+psql_or_bail(2, "SELECT spock.sub_create('sub_n1_n2', '$prov_dsn', ARRAY['default'], false, false)");
+ok(wait_for_sub_status(2, 'sub_n1_n2', 'replicating', 30), 'sub_n1_n2 is replicating');
+
+# Batch-1: 100 rows from n1 — these become the stale resource.dat baseline
+psql_or_bail(1, "INSERT INTO public.t_n1 SELECT g, 'b1_' || g FROM generate_series(1,100) g");
+ok(wait_until(30, sub {
+    scalar_query(2, "SELECT count(*) FROM public.t_n1") eq '100'
+}), 'n2 has batch-1 rows (100)');
+
+ok(wait_until(30, sub {
+    my $c = scalar_query(2, "SELECT count(*) FROM spock.progress");
+    defined $c && $c >= 1
+}), 'n2 has progress entry for n1');
+
+my $batch1_n1 = scalar_query(2, q{
+    SELECT p.remote_commit_ts || '|' || p.remote_commit_lsn
+    FROM spock.progress p
+    JOIN spock.node n ON n.node_id = p.remote_node_id
+    WHERE n.node_name = 'n1'
+});
+ok($batch1_n1 =~ /\S+\|\S+/, "captured batch-1 n1 progress: $batch1_n1");
+my ($b1_ts) = split(/\|/, $batch1_n1, 2);
+diag("Batch-1 progress (stale resource.dat baseline): $batch1_n1");
+
+# Clean stop n2 → spock_checkpoint_hook writes resource.dat with batch-1 values
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-m', 'fast', 'stop';
+ok(-f "$sub_dir/spock/resource.dat", 'resource.dat written after clean stop of n2');
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-o', "-p $sub_port", '-w', 'start';
+ok(wait_for_pg_ready($host, $sub_port, $pg_bin, 30), 'n2 back up after clean restart');
+
+# Scenario B setup: add n3 AFTER resource.dat was written — n3 never in resource.dat
+psql_or_bail(3, "CREATE TABLE public.t_n3 (id int primary key, val text)");
+psql_or_bail(2, "CREATE TABLE public.t_n3 (id int primary key, val text)");
+
+psql_or_bail(2, "SELECT spock.sub_create('sub_n3_n2', '$n3_dsn', ARRAY['default'], false, false)");
+ok(wait_for_sub_status(2, 'sub_n3_n2', 'replicating', 30), 'sub_n3_n2 is replicating');
+
+psql_or_bail(3, "INSERT INTO public.t_n3 SELECT g, 'n3_' || g FROM generate_series(1,50) g");
+ok(wait_until(30, sub {
+    scalar_query(2, "SELECT count(*) FROM public.t_n3") eq '50'
+}), 'n2 received 50 rows from n3');
+
+# Batch-2 from n1 — newer WAL progress records on top of stale resource.dat
+psql_or_bail(1, "INSERT INTO public.t_n1 SELECT g, 'b2_' || g FROM generate_series(101,200) g");
+ok(wait_until(30, sub {
+    scalar_query(2, "SELECT count(*) FROM public.t_n1") eq '200'
+}), 'n2 has batch-2 rows (200)');
+
+my $pre_crash_count = scalar_query(2, "SELECT count(*) FROM spock.progress");
+ok($pre_crash_count >= 2, "n2 has progress entries for n1 AND n3 ($pre_crash_count entries)");
+
+my $batch2_n1 = scalar_query(2, q{
+    SELECT p.remote_commit_ts || '|' || p.remote_commit_lsn
+    FROM spock.progress p
+    JOIN spock.node n ON n.node_id = p.remote_node_id
+    WHERE n.node_name = 'n1'
+});
+ok($batch2_n1 =~ /\S+\|\S+/, "captured batch-2 n1 progress: $batch2_n1");
+
+my $batch2_n3 = scalar_query(2, q{
+    SELECT p.remote_commit_ts || '|' || p.remote_commit_lsn
+    FROM spock.progress p
+    JOIN spock.node n ON n.node_id = p.remote_node_id
+    WHERE n.node_name = 'n3'
+});
+ok($batch2_n3 =~ /\S+\|\S+/, "captured batch-2 n3 progress (NOT in resource.dat): $batch2_n3");
+
+my ($b2_n1_ts) = split(/\|/, $batch2_n1, 2);
+ok($b2_n1_ts gt $b1_ts, "batch-2 n1 ts ($b2_n1_ts) newer than stale resource.dat ts ($b1_ts)");
+
+diag("Batch-2 n1 (newer than resource.dat): $batch2_n1");
+diag("Batch-2 n3 (absent from resource.dat): $batch2_n3");
+
+# Stop providers so apply workers on n2 cannot reconnect after restart;
+# resource.dat retains batch-1 n1 only (n3 never written to resource.dat)
+system_or_bail "$pg_bin/pg_ctl", '-D', $prov_dir, '-m', 'fast', 'stop';
+system_or_bail "$pg_bin/pg_ctl", '-D', $n3_dir,   '-m', 'fast', 'stop';
+pass('n1 and n3 stopped — apply workers on n2 cannot reconnect after crash');
+
+select(undef, undef, undef, 1.0);
+
+# SIGKILL n2 — no shmem_exit, no resource.dat update
+my $pid_file = "$sub_dir/postmaster.pid";
+open(my $fh, '<', $pid_file) or die "Cannot open $pid_file: $!";
+my $n2_pid = <$fh>; chomp($n2_pid); close($fh);
+diag("SIGKILLing n2 (PID $n2_pid) — resource.dat has batch-1 n1 only");
+kill 'KILL', $n2_pid;
+pass('n2 SIGKILLed');
+
+select(undef, undef, undef, 2.0);
+
+# Restart n2 with providers still down — only WAL replay can restore progress
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-o', "-p $sub_port", '-w', 'start';
+ok(wait_for_pg_ready($host, $sub_port, $pg_bin, 30), 'n2 accepting connections after crash recovery');
+
+# Assert Scenario A: n1 progress must be batch-2, not regressed to batch-1
+my $post_count = scalar_query(2, "SELECT count(*) FROM spock.progress");
+is($post_count, $pre_crash_count,
+    "progress row count preserved ($pre_crash_count rows) — FAIL = missing entries (Scenario B)");
+
+my $post_n1 = scalar_query(2, q{
+    SELECT p.remote_commit_ts || '|' || p.remote_commit_lsn
+    FROM spock.progress p
+    JOIN spock.node n ON n.node_id = p.remote_node_id
+    WHERE n.node_name = 'n1'
+});
+is($post_n1, $batch2_n1,
+    "n1 progress = batch-2 after recovery — FAIL = stale values regression (Scenario A)");
+
+# Assert Scenario B: n3 entry must exist (was never in resource.dat)
+my $post_n3 = scalar_query(2, q{
+    SELECT p.remote_commit_ts || '|' || p.remote_commit_lsn
+    FROM spock.progress p
+    JOIN spock.node n ON n.node_id = p.remote_node_id
+    WHERE n.node_name = 'n3'
+});
+is($post_n3, $batch2_n3,
+    "n3 progress entry exists and correct — FAIL = missing entry (Scenario B)");
+
+# Restart providers for cleanup
+system_or_bail "$pg_bin/pg_ctl", '-D', $prov_dir, '-o', "-p $prov_port", '-w', 'start';
+system_or_bail "$pg_bin/pg_ctl", '-D', $n3_dir,   '-o', "-p $n3_port",   '-w', 'start';
+
+
+# =============================================================================
 # Cleanup
+# =============================================================================
+
 psql_or_bail(2, "SELECT spock.sub_drop('test_sub')");
-destroy_cluster('Destroy 2-node cluster');
+psql_or_bail(2, "SELECT spock.sub_drop('sub_n1_n2')");
+psql_or_bail(2, "SELECT spock.sub_drop('sub_n3_n2')");
+destroy_cluster('Destroy 3-node cluster');
 done_testing();

--- a/tests/tap/t/022_rmgr_progress_post_checkpoint_crash.pl
+++ b/tests/tap/t/022_rmgr_progress_post_checkpoint_crash.pl
@@ -1,0 +1,212 @@
+#!/usr/bin/perl
+# =============================================================================
+# Test: 022_rmgr_progress_post_checkpoint_crash.pl
+#       Verify spock.progress survives crash when a regular checkpoint has
+#       advanced checkPointRedo past the last SPOCK_RMGR_APPLY_PROGRESS
+#       WAL records.
+# =============================================================================
+#
+# WHY THIS TEST EXISTS
+# --------------------
+# In a long-running cluster, regular checkpoints (every checkpoint_timeout,
+# default 5 min) continuously advance checkPointRedo. If apply workers have
+# been idle (provider unreachable) for longer than checkpoint_timeout, the
+# last progress WAL records end up BEFORE checkPointRedo and are not in the
+# WAL replay window after a crash. Recovery falls back to the stale
+# resource.dat values from the last clean shutdown.
+#
+# This test reproduces that scenario explicitly by:
+#   1. Replicating data and capturing the progress snapshot
+#   2. Stopping the provider (apply workers go idle)
+#   3. Forcing a CHECKPOINT on the subscriber — advances checkPointRedo past
+#      the last SPOCK_RMGR_APPLY_PROGRESS records
+#   4. SIGKILL the subscriber (true crash, no resource.dat update)
+#   5. Restarting the subscriber (provider still down)
+#   6. Asserting progress matches the pre-crash snapshot
+#
+# Topology:  n1 (provider) -> n2 (subscriber)
+# =============================================================================
+
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(
+    create_cluster destroy_cluster system_or_bail system_maybe
+    command_ok get_test_config scalar_query psql_or_bail
+    wait_for_sub_status wait_for_pg_ready
+);
+
+sub wait_until {
+    my ($timeout_s, $probe) = @_;
+    my $deadline = time() + $timeout_s;
+    while (time() < $deadline) {
+        return 1 if $probe->();
+        select(undef, undef, undef, 0.25);
+    }
+    return 0;
+}
+
+# =============================================================================
+# 1. Setup
+# =============================================================================
+
+create_cluster(2, 'Create 2-node cluster');
+
+my $conf      = get_test_config();
+my $host      = $conf->{host};
+my $pg_bin    = $conf->{pg_bin};
+my $ports     = $conf->{node_ports};
+my $datadirs  = $conf->{node_datadirs};
+my $dbname    = $conf->{db_name};
+my $user      = $conf->{db_user};
+
+my $prov_port = $ports->[0];
+my $sub_port  = $ports->[1];
+my $prov_dir  = $datadirs->[0];
+my $sub_dir   = $datadirs->[1];
+
+my $prov_dsn = "host=$host port=$prov_port dbname=$dbname user=$user";
+
+psql_or_bail(1, "CREATE TABLE public.rmgr_ckpt (id int primary key, val text)");
+psql_or_bail(2, "CREATE TABLE public.rmgr_ckpt (id int primary key, val text)");
+
+psql_or_bail(2, "SELECT spock.sub_create('test_sub', '$prov_dsn', ARRAY['default'], false, false)");
+
+ok(wait_for_sub_status(2, 'test_sub', 'replicating', 30),
+    'subscription is replicating');
+
+# Clean stop n2 now — before any DML — so resource.dat is written with an
+# empty progress baseline (no rows replicated yet, so no progress entries).
+# After restart the DML below produces SPOCK_RMGR_APPLY_PROGRESS WAL records,
+# but resource.dat still holds the empty snapshot.  The CHECKPOINT in step 4
+# must update resource.dat (fix present) or leave it stale (bug present).
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-m', 'fast', 'stop';
+ok((-f "$sub_dir/spock/resource.dat"), 'resource.dat written with empty progress baseline');
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-o', "-p $sub_port", '-w', 'start';
+ok(wait_for_pg_ready($host, $sub_port, $pg_bin, 30),
+    'n2 restarted — resource.dat holds empty baseline, provider still up');
+
+psql_or_bail(1, "INSERT INTO public.rmgr_ckpt SELECT g, 'row_' || g FROM generate_series(1,100) g");
+
+ok(wait_until(30, sub {
+    scalar_query(2, "SELECT count(*) FROM public.rmgr_ckpt") eq '100'
+}), 'subscriber has 100 rows');
+
+# =============================================================================
+# 2. Capture spock.progress snapshot
+# =============================================================================
+
+ok(wait_until(30, sub {
+    my $c = scalar_query(2, "SELECT count(*) FROM spock.progress");
+    defined $c && $c >= 1
+}), 'spock.progress has at least one entry');
+
+my $snap = scalar_query(2, q{
+    SELECT remote_commit_ts || '|' || remote_commit_lsn || '|' || remote_insert_lsn
+    FROM spock.progress
+    ORDER BY remote_commit_ts DESC
+    LIMIT 1
+});
+ok($snap =~ /\S+\|\S+\|\S+/, "captured progress snapshot: $snap");
+
+my ($pre_ts, $pre_commit_lsn, $pre_insert_lsn) = split(/\|/, $snap, 3);
+my $pre_count = scalar_query(2, "SELECT count(*) FROM spock.progress");
+
+diag("Pre-crash progress: $snap");
+diag("Progress WAL records are now at some LSN 'A'");
+
+# =============================================================================
+# 3. Stop provider — apply workers on subscriber go idle (no more DML)
+# =============================================================================
+
+system_or_bail "$pg_bin/pg_ctl", '-D', $prov_dir, '-m', 'fast', 'stop';
+pass('provider (n1) stopped — apply workers on n2 now idle');
+
+# Give apply worker a moment to notice the provider is gone
+select(undef, undef, undef, 1.0);
+
+# =============================================================================
+# 4. Force a CHECKPOINT on the subscriber
+#
+# This advances checkPointRedo to a point AFTER the last
+# SPOCK_RMGR_APPLY_PROGRESS WAL records written in step 2. After the
+# checkpoint, those records are no longer in the WAL replay window.
+#
+# This simulates what happens naturally in a long-running cluster where
+# checkpoint_timeout (default 5 min) runs periodically while apply workers
+# are idle (provider unreachable).
+# =============================================================================
+
+psql_or_bail(2, 'CHECKPOINT');
+pass('CHECKPOINT forced on subscriber — checkPointRedo now past progress WAL records');
+
+diag("checkPointRedo has now advanced past the SPOCK_RMGR_APPLY_PROGRESS records");
+diag("After crash+recovery, WAL replay will NOT see those records");
+diag("If bug is present: recovery falls back to stale resource.dat");
+
+# =============================================================================
+# 5. SIGKILL subscriber (true crash — no shmem_exit, no resource.dat update)
+# =============================================================================
+
+my $pid_file = "$sub_dir/postmaster.pid";
+open(my $fh, '<', $pid_file) or die "Cannot open $pid_file: $!";
+my $sub_pid = <$fh>;
+chomp($sub_pid);
+close($fh);
+
+diag("SIGKILLing n2 postmaster (PID $sub_pid)");
+kill 'KILL', $sub_pid;
+pass('subscriber (n2) SIGKILLed — resource.dat NOT updated');
+
+# Let OS reap the process before pg_ctl start
+select(undef, undef, undef, 2.0);
+
+# =============================================================================
+# 6. Restart subscriber (provider still down — only WAL replay can populate
+#    spock.progress, but the relevant records are before checkPointRedo)
+# =============================================================================
+
+system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, '-o', "-p $sub_port", '-w', 'start';
+
+ok(wait_for_pg_ready($host, $sub_port, $pg_bin, 30),
+    'subscriber (n2) is accepting connections after crash recovery');
+
+# =============================================================================
+# 7. Assert: progress must match pre-crash snapshot
+# =============================================================================
+
+my $post_count = scalar_query(2, "SELECT count(*) FROM spock.progress");
+is($post_count, $pre_count,
+    "spock.progress row count matches after crash ($pre_count rows)");
+
+my $post_snap = scalar_query(2, q{
+    SELECT remote_commit_ts || '|' || remote_commit_lsn || '|' || remote_insert_lsn
+    FROM spock.progress
+    ORDER BY remote_commit_ts DESC
+    LIMIT 1
+});
+ok($post_snap =~ /\S+\|\S+\|\S+/, "progress readable after crash recovery: $post_snap");
+
+diag("Pre-crash:  $snap");
+diag("Post-crash: $post_snap");
+
+my ($post_ts, $post_commit_lsn, $post_insert_lsn) = split(/\|/, $post_snap, 3);
+
+is($post_ts, $pre_ts,
+    "remote_commit_ts matches pre-crash value after crash recovery");
+is($post_commit_lsn, $pre_commit_lsn,
+    "remote_commit_lsn matches pre-crash value after crash recovery");
+is($post_insert_lsn, $pre_insert_lsn,
+    "remote_insert_lsn matches pre-crash value after crash recovery");
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+system_or_bail "$pg_bin/pg_ctl", '-D', $prov_dir, '-o', "-p $prov_port", '-w', 'start';
+ok(wait_for_pg_ready($host, $prov_port, $pg_bin, 30), 'provider (n1) restarted');
+
+psql_or_bail(2, "SELECT spock.sub_drop('test_sub')");
+destroy_cluster('Destroy 2-node cluster');
+done_testing();


### PR DESCRIPTION
spock_checkpoint_hook skipped regular checkpoints, only dumping resource.dat
on shutdown or end-of-recovery. In a long-running cluster where apply workers
were idle for longer than checkpoint_timeout (provider unreachable), a regular
checkpoint would advance checkPointRedo past the last SPOCK_RMGR_APPLY_PROGRESS
WAL records. After a crash, WAL replay had nothing to replay after checkPointRedo
and resource.dat still held values from the last clean shutdown, causing
spock.progress to show stale values or missing entries.

Fix: remove the early return so resource.dat is dumped at every checkpoint.
resource.dat seeds shmem with checkpoint-time values on restart; WAL replay
then advances any entries written after checkPointRedo. Together they give
complete coverage for all crash scenarios.

---

**Tests**

Extend 008_rmgr.pl (2-node → 3-node cluster) with a Phase 4 covering two crash recovery failure modes for spock.progress:

- Scenario A — stale values: n1 replicates batch-1 to n2; clean stop n2 writes resource.dat with batch-1 as baseline; n1 replicates batch-2; n1 and n3 are stopped; n2 is SIGKILL'd. After recovery, WAL replay must advance n1 progress to batch-2, not regress to the stale resource.dat values.

- Scenario B — missing entries: n3 subscribes to n2 after resource.dat was written, so n3's progress entry exists only in WAL. After SIGKILL of n2, WAL replay must create n3's entry from scratch.

Uses SIGKILL (not pg_ctl -m immediate) for a true crash with no shmem_exit. Providers are stopped before the crash so live apply cannot reconnect and mask WAL replay failures.

Add 022_rmgr_progress_post_checkpoint_crash.pl: verifies that spock.progress survives a crash when a regular checkpoint has advanced checkPointRedo past the last SPOCK_RMGR_APPLY_PROGRESS records. Establishes a stale resource.dat baseline (clean stop before replication), forces a CHECKPOINT after replication, then SIGKILL-s the subscriber. After recovery, spock.progress must match the pre-crash snapshot.