### PR TITLE
SPOC-502: Replace opaque "unavailable" message in exception_log with informative discard context

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1187,19 +1187,54 @@ handle_relation(StringInfo s)
 	(void) spock_read_rel(s);
 }
 
+/* Return the GUC name of the active exception behaviour mode. */
+static const char *
+get_exception_behaviour_name(void)
+{
+	switch (exception_behaviour)
+	{
+		case DISCARD:
+			return "discard";
+		case TRANSDISCARD:
+			return "transdiscard";
+		case SUB_DISABLE:
+			return "sub_disable";
+		default:
+			return "unknown";
+	}
+}
+
+/*
+ * Log a replication exception to spock.exception_log.
+ *
+ * Called for INSERT, UPDATE, DELETE, and TRUNCATE operations.  'failed'
+ * is true when an actual error occurred (relation not found, or subtransaction
+ * raised an error in DISCARD mode) and false when the operation was
+ * deliberately skipped during dry-run replay (TRANSDISCARD/SUB_DISABLE mode).
+ *
+ * When 'errmsg' is NULL — i.e. the tuple is being discarded because another
+ * command in the same transaction failed, not this one — a synthetic message
+ * is generated that names the active exception behaviour and the
+ * failed_action counter so the operator can cross-reference the root cause.
+ */
 static void
 log_insert_exception(bool failed, char *errmsg, SpockRelation *rel,
 					 SpockTupleData *oldtup, SpockTupleData *newtup,
 					 const char *action_name)
 {
-	RepOriginId local_origin = InvalidRepOriginId;
-	TimestampTz local_commit_ts = 0;
-	TransactionId xmin = InvalidTransactionId;
-	bool		local_origin_found = false;
-	HeapTuple	localtup;
+	RepOriginId		local_origin = InvalidRepOriginId;
+	TimestampTz		local_commit_ts = 0;
+	TransactionId	xmin = InvalidTransactionId;
+	bool			local_origin_found = false;
+	HeapTuple		localtup;
 
 	if (!should_log_exception(failed))
 		return;
+
+	if (errmsg == NULL)
+		errmsg = psprintf("%s: tuple discarded due to exception at command_counter %u",
+						  get_exception_behaviour_name(),
+						  exception_log_ptr[my_exception_log_index].failed_action);
 
 	localtup = exception_log_ptr[my_exception_log_index].local_tuple;
 	if (localtup != NULL)
@@ -1251,6 +1286,9 @@ handle_insert(StringInfo s)
 
 	started_tx = begin_replication_step();
 
+	errcallback_arg.action_name = "INSERT";
+	xact_action_counter++;
+
 	oldcontext = MemoryContextSwitchTo(ApplyOperationContext);
 
 	rel = spock_read_insert(s, RowExclusiveLock, &newtup);
@@ -1279,9 +1317,7 @@ handle_insert(StringInfo s)
 		return;
 	}
 
-	errcallback_arg.action_name = "INSERT";
 	errcallback_arg.rel = rel;
-	xact_action_counter++;
 
 	/* If in list of relations which are being synchronized, skip. */
 	if (!should_apply_changes_for_rel(rel->nspname, rel->relname))
@@ -2369,13 +2405,14 @@ handle_sql_or_exception(QueuedMessage *queued_message, bool tx_just_started)
 
 			if (failed)
 				error_msg = edata->message;
-			else
-				error_msg =
-					(xact_action_counter ==
+			else if (xact_action_counter ==
 					 exception_log_ptr[my_exception_log_index].failed_action &&
-					 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0') ?
-					exception_log_ptr[my_exception_log_index].initial_error_message :
-					NULL;
+					 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0')
+				error_msg = exception_log_ptr[my_exception_log_index].initial_error_message;
+			else
+				error_msg = psprintf("%s: tuple discarded due to exception at command_counter %u",
+									 get_exception_behaviour_name(),
+									 exception_log_ptr[my_exception_log_index].failed_action);
 
 			add_entry_to_exception_log(remote_origin_id,
 									   replorigin_session_origin_timestamp,

--- a/src/spock_exception_handler.c
+++ b/src/spock_exception_handler.c
@@ -188,10 +188,10 @@ add_entry_to_exception_log(Oid remote_origin, TimestampTz remote_commit_ts,
 		values[Anum_exception_log_ddl_user - 1] = CStringGetTextDatum(ddl_user);
 	}
 
-	if (error_message == NULL)
-		values[Anum_exception_log_error_message - 1] = CStringGetTextDatum("unavailable");
-	else
-		values[Anum_exception_log_error_message - 1] = CStringGetTextDatum(error_message);
+	Assert(error_message != NULL);
+
+	values[Anum_exception_log_error_message - 1] =
+		CStringGetTextDatum(error_message != NULL ? error_message : "unavailable");
 	values[Anum_exception_log_retry_errored_at - 1] = TimestampTzGetDatum(GetCurrentTimestamp());
 
 	tup = heap_form_tuple(tupDesc, values, nulls);

--- a/src/spock_injection.c
+++ b/src/spock_injection.c
@@ -23,6 +23,8 @@
 #include "common/pg_prng.h"
 #include "port.h"
 
+#include "spock_injection.h"
+
 /* Maximum random delay, in milliseconds. */
 #define SPOCK_INJ_MAX_DELAY_MS	100
 

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -461,24 +461,24 @@ SELECT
   ) AS error_message
 FROM spock.exception_log
 ORDER BY table_schema COLLATE "C",table_name COLLATE "C",remote_commit_ts;
- table_schema | table_name | operation |                   remote_new_tup                   |       error_message       
---------------+------------+-----------+----------------------------------------------------+---------------------------
+ table_schema | table_name | operation |                   remote_new_tup                   |                            error_message                            
+--------------+------------+-----------+----------------------------------------------------+---------------------------------------------------------------------
               |            | INSERT    |                                                    | Spock can't find relation
               |            | INSERT    |                                                    | Spock can't find relation
               |            | INSERT    |                                                    | Spock can't find relation
               |            | INSERT    |                                                    | Spock can't find relation
- public       | spoc_102g  | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | unavailable
+ public       | spoc_102g  | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | transdiscard: tuple discarded due to exception at command_counter 2
 (5 rows)
 
 -- Check exception_log
 SELECT table_schema, table_name, operation, remote_new_tup, error_message
 FROM spock.exception_log
 ORDER BY command_counter;
- table_schema | table_name | operation |                   remote_new_tup                   |       error_message       
---------------+------------+-----------+----------------------------------------------------+---------------------------
+ table_schema | table_name | operation |                   remote_new_tup                   |                            error_message                            
+--------------+------------+-----------+----------------------------------------------------+---------------------------------------------------------------------
               |            | INSERT    |                                                    | Spock can't find relation
               |            | INSERT    |                                                    | Spock can't find relation
- public       | spoc_102g  | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | unavailable
+ public       | spoc_102g  | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | transdiscard: tuple discarded due to exception at command_counter 2
               |            | INSERT    |                                                    | Spock can't find relation
               |            | INSERT    |                                                    | Spock can't find relation
 (5 rows)
@@ -598,7 +598,7 @@ ORDER BY table_schema COLLATE "C",table_name COLLATE "C",remote_commit_ts;
               |             | INSERT    |                                                    | Spock can't find relation
               |             | UPDATE    |                                                    | Spock can't find relation
               |             | UPDATE    |                                                    | Spock can't find relation
- public       | spoc_102g   | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | unavailable
+ public       | spoc_102g   | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | transdiscard: tuple discarded due to exception at command_counter 2
  public       | spoc_102l_u | UPDATE    | [{"value": -3, "attname": "x", "atttype": "int4"}] | logical replication did not find row to be updated in replication target relation (public.spoc_102l_u)
 (8 rows)
 
@@ -610,7 +610,7 @@ ORDER BY command_counter;
 --------------+-------------+-----------+----------------------------------------------------+--------------------------------------------------------------------------------------------------------
               |             | INSERT    |                                                    | Spock can't find relation
               |             | INSERT    |                                                    | Spock can't find relation
- public       | spoc_102g   | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | unavailable
+ public       | spoc_102g   | INSERT    | [{"value": -4, "attname": "x", "atttype": "int4"}] | transdiscard: tuple discarded due to exception at command_counter 2
               |             | INSERT    |                                                    | Spock can't find relation
               |             | INSERT    |                                                    | Spock can't find relation
               |             | UPDATE    |                                                    | Spock can't find relation


### PR DESCRIPTION

The message names the active `spock.exception_behaviour` GUC value and the `failed_action` counter from the exception log slot, allowing an operator to cross-reference the log entry that holds the actual error.

Key design decisions:

- Message construction happens in `log_insert_exception` (covering INSERT/UPDATE/DELETE/TRUNCATE) and inline in `handle_sql_or_exception` (covering DDL/SQL queued messages), where all required context is naturally available — keeping `add_entry_to_exception_log` a thin persistence layer with no knowledge of exception modes.
- A small static helper `get_exception_behaviour_name()` maps the enum to its GUC string, avoiding duplication between the two call sites.
- `add_entry_to_exception_log` now asserts `error_message != NULL`, making the contract explicit.

### Additional fix

`handle_insert` incremented `xact_action_counter` and set `errcallback_arg.action_name` *after* `spock_read_insert`, whereas `handle_update` and `handle_delete` both do so *before* the read. This asymmetry meant that a "can't find relation" failure in INSERT was not counted as an action. Both are moved before the read to match the established pattern.
