### PR TITLE
Port detailed documentation from main branch to v5_STABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Building the Spock Documentation](README.md#building-the-spock-documentation)
 - [Basic Configuration and Usage](README.md#basic-configuration-and-usage)
 - [Upgrading a Spock Installation](docs/upgrading_spock.md)
-- [Advanced Configuration Options](docs/install_spock.md#advanced-configuration-options-for-spock)
+- [Advanced Configuration Options](docs/configuring.md)
 - [Spock Management Features](docs/managing/index.md)
 - [Modifying a Cluster](docs/modify/index.md)
 - [Monitoring your Cluster](docs/monitoring/index.md)
@@ -73,7 +73,7 @@ primary key, btree, for table "public.table_a"
 
 * `CHECK` constraints and `NOT NULL` constraints must be the same or more permissive on any standby node that acts only as a subscriber.
 
-For more information about the Spock extension's advanced functionality, visit [here](docs/features.md).
+For more information about the Spock extension's advanced functionality, visit the [Spock documentation](docs/install_spock.md).
 
 
 ## Building the Spock Extension

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1,6 +1,6 @@
 # Configuring Spock
 
-Add the following `postgresql.conf` settings on each node in your Spock
+Add the following `postgresql.conf` settings on each node in your Spock 
 replication scenario before creating the Spock extension:
 
 ```sql
@@ -18,16 +18,11 @@ with your OS-specific restart command, connect with psql and create the Spock
 extension:
 
 ```sql
-[pg18]$ sudo -u postgres psql -U postgres -p 5432
-psql (18.1)
-Type "help" for help.
-
-postgres=# CREATE EXTENSION spock;
-CREATE EXTENSION
+CREATE EXTENSION spock;
 ```
 
 You will also need to modify your
-[`pg_hba.conf` file](https://www.postgresql.org/docs/18/auth-pg-hba-conf.html)
+[`pg_hba.conf` file](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
 to allow logical replication connections from localhost and between nodes.
 Logical replication connections are treated by `pg_hba.conf` as regular
 connections to the provider database.
@@ -52,6 +47,12 @@ functions adhere to the same rule previously described for
 `include_ddl_repset`. If a table possesses a defined primary key, it will be
 added into the `default` replication set; alternatively, they will be added
 to the `default_insert_only` replication set.
+
+### `spock.batch_inserts`
+
+`spock.batch_inserts` tells Spock to use batch insert mechanism if
+possible. The batch mechanism uses Postgres internal batch insert mode which
+is also used by `COPY` command.
 
 ### `spock.channel_counters`
 
@@ -159,9 +160,7 @@ exception log table:
 * `none` - Instructs the server to not log any operation or transactions to
   the exception log table.
 
-### `spock.exception_replay_queue_size` - DEPRECATED
-
-This parameter will not be supported after version 5.X.
+### `spock.exception_replay_queue_size`
 
 When Spock encounters a replication exception, it attempts to resolve the
 exception by entering exception-handling mode, based on the value of
@@ -171,8 +170,8 @@ transaction from memory.  This provides a massive speed and performance
 increase in the handling of the vast majority of exceptions.  The memory
 size is configurable with `spock.exception_replay_queue_size`.
 
-Now, Spock performs as specified by the
-[`spock.exception_behaviour`](#spock-exception_behaviour) parameter.
+If the transaction exceeds the configured size, Spock performs as specified
+by the [`spock.exception_behaviour`](#spock-exception_behaviour) parameter.
 
 ### `spock.extra_connection_options`
 
@@ -185,33 +184,14 @@ keepalive options, etc.
 the upstream server disappears unexpectedly. To disable them add
 `keepalives = 0` to `spock.extra_connection_options`.
 
-### `wal_sender_timeout`
+### `spock.feedback_frequency`
 
-For Spock replication, set `wal_sender_timeout` to a conservative value such
-as `5min` (300000ms) on each node in `postgresql.conf`:
-
-```
-wal_sender_timeout = '5min'
-```
-
-The default PostgreSQL value of `60s` can cause spurious disconnects when
-the subscriber is busy applying a large transaction and cannot send feedback
-in time. A higher value gives the apply worker enough headroom while still
-detecting truly dead connections. Liveness detection is primarily handled by
-TCP keepalives, and `spock.apply_idle_timeout` provides an additional
-subscriber-side safety net.
-
-### `spock.apply_idle_timeout`
-
-Maximum idle time (in seconds) before the apply worker reconnects to the
-provider. This acts as a safety net for detecting a hung walsender that keeps
-the TCP connection alive but stops sending data. The timer resets on any
-received message. Set to `0` to disable and rely solely on TCP keepalive for
-liveness detection. Default: `300` (5 minutes).
-
-```
-spock.apply_idle_timeout = 300
-```
+Controls how many WAL messages the apply worker processes before sending
+an LSN feedback packet to the provider. Lower values increase feedback
+overhead due to synchronous socket flushes; higher values reduce overhead
+during bulk catch-up. There is a time-based guard (wal_sender_timeout / 2)
+that ensures connection liveness regardless of this setting. The default
+is 200.
 
 ### `spock.include_ddl_repset`
 
@@ -252,22 +232,6 @@ The following configuration values are possible:
 logs all conflict resolutions to the `spock.resolutions` table. This option
 can only be set when the postmaster starts.
 
-### `spock.resolutions_retention_days`
-
-`spock.resolutions_retention_days` controls how long rows are kept in the
-`spock.resolutions` table. Rows with a `log_time` older than this many days
-are deleted automatically by the apply worker, which runs the cleanup at most
-once per day. The default is `100` days. Set to `0` to disable automatic
-cleanup entirely.
-
-This GUC has no effect when `spock.save_resolutions` is `off`.
-
-Cleanup can also be triggered manually at any time by a superuser:
-
-```sql
-SELECT spock.cleanup_resolutions();
-```
-
 ### `spock.stats_max_entries`
 
 `spock.stats_max_entries` specifies the maximum number of entries that can
@@ -282,5 +246,3 @@ the postmaster starts.  The parameter accepts values from `-1` to `INT_MAX`
   and be writable by the user running Postgres. The default is `empty`,
   which tells Spock to use the default temporary directory based on
   environment or operating system settings.
-
-

--- a/docs/install_spock.md
+++ b/docs/install_spock.md
@@ -18,11 +18,11 @@ For detailed information about using Spock to create a two-node cluster,
 visit [here](two_node_cluster.md).
 
 
-## Installing Spock with pgEdge Enterprise Postgres
+## Installing Spock with pgEdge Distributed or Enterprise Postgres
 
-The latest Spock extension is automatically installed with any
-[pgEdge Enterprise Postgres](https://docs.pgedge.com/enterprise) installation.
-A pgEdge deployment provides quick and easy access to:
+The latest Spock extension is automatically installed and created with any
+[pgEdge Distributed or Enterprise Postgres](https://docs.pgedge.com/)
+installation. A pgEdge deployment provides quick and easy access to:
 
 *  the latest minor version of your preferred Postgres version.
 *  Spock [functions and procedures](spock_functions/index.md).
@@ -76,33 +76,14 @@ other Postgres extension:
 ## Configuring Postgres for Spock Replication
 
 After installing Postgres on each node that will host a spock instance,
-use [initdb](https://www.postgresql.org/docs/18/app-initdb.html) to initialize
+use [initdb](https://www.postgresql.org/docs/current/app-initdb.html) to initialize
 a Postgres cluster. After initializing the cluster, you can connect
 with psql, and query the server for file locations and cluster details:
 
 ```sql
-[sdouglas@lima-pg3 pg18]$ sudo -u postgres psql -U postgres -p 5432
-psql (18.1)
-Type "help" for help.
-
-postgres=# SHOW data_directory;
+SHOW data_directory;
 SHOW config_file;
 SHOW hba_file;
-
-     data_directory     
-------------------------
- /var/lib/pgsql/18/data
-(1 row)
-
-              config_file               
-----------------------------------------
- /var/lib/pgsql/18/data/postgresql.conf
-(1 row)
-
-              hba_file              
-------------------------------------
- /var/lib/pgsql/18/data/pg_hba.conf
-(1 row)
 ```
 
 Then, use your choice of editor to update the `postgresql.conf` file, adding
@@ -117,36 +98,16 @@ shared_preload_libraries = 'spock'
 track_commit_timestamp = on
 ```
 
-**Note on replication origin states:**
-
-- **PostgreSQL 15-17:** The `max_replication_slots` parameter controls both the
-  number of replication slots *and* the number of replication origin states.
-  When sizing this parameter, account for both slots and origins (typically one
-  origin per subscription).
-
-- **PostgreSQL 18+:** A new parameter `max_active_replication_origins` was
-  introduced to separately control the number of replication origin states.
-  The default value is 10, which may be insufficient for clusters with many
-  subscriptions. Set this to at least the number of subscriptions plus some
-  headroom (similar sizing to `max_replication_slots`).
+For detailed information about advanced configuration options (GUCs),
+see [Using Advanced Configuration Options](configuring.md).
 
 After modifying the Postgres parameters, use your OS-specific command to 
-restart the Postgres server:
-
-```bash
-[sdouglas@lima-pg3 pg18]$ sudo systemctl restart postgresql-18
-[sdouglas@lima-pg3 pg18]$ sudo systemctl status postgresql-18
-● postgresql-18.service - PostgreSQL 18 database server
-     Loaded: loaded (/usr/lib/systemd/system/postgresql-18.service; enabled; preset: disabled)
-     Active: active (running) since Wed 2026-02-11 11:44:11 EST; 7s ago
-```
+restart the Postgres server.
 
 Then, connect to the psql command line, and create the spock extension:
   
 ```sql
-postgres=# CREATE EXTENSION spock;
-CREATE EXTENSION
-postgres=# 
+CREATE EXTENSION spock;
 ```
 
 On each node that will host spock, modify the
@@ -155,13 +116,13 @@ and allow connections between `n1` and `n2`. The following snippet is provided
 as an example only, and is not recommended for a production system as they
 will open your system for connection from any client:
 
-    ```sql
-    host    all          all          <node_1_IP_address>/32    trust
-    host    all          all          <node_2_IP_address>/32    trust
+```sql
+host    all          all          <node_1_IP_address>/32    trust
+host    all          all          <node_2_IP_address>/32    trust
 
-    host    replication  all          <node_1_IP_address>/32    trust
-    host    replication  all          <node_2_IP_address>/32    trust
-
+host    replication  all          <node_1_IP_address>/32    trust
+host    replication  all          <node_2_IP_address>/32    trust
+```
 
 
 ### Creating a Replication Scenario

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -37,24 +37,22 @@ You can have additional unique constraints upstream if the downstream consumer g
 
 Partial secondary unique indexes are permitted, but will be ignored for conflict resolution purposes.
 
-`spock.check_all_uc_indexes` is an experimental [GUC](https://github.com/pgEdge/spock/blob/main/docs/guc_settings.md) that adds `INSERT` conflict resolution by allowing Spock to consider all unique constraints, not just the primary key or replica identity.
+`spock.check_all_uc_indexes` is an experimental [GUC](configuring.md#spockcheck_all_uc_indexes) that adds `INSERT` conflict resolution by allowing Spock to consider all unique constraints, not just the primary key or replica identity.
 
 ### Unique constraints must not be deferrable
 
-Deferrable unique constraints and primary keys are **silently skipped** during
-INSERT conflict resolution. This means that if your only unique constraint on a
-table is deferrable, INSERT conflicts will not be detected, potentially leading
-to duplicate rows on subscriber nodes.
+Deferrable unique constraints and primary keys are skipped during INSERT
+conflict resolution. If the only unique constraint on a table is deferrable,
+INSERT conflicts will not be detected, which may lead to duplicate rows on
+subscriber nodes.
 
 On the downstream end, spock may also emit the error:
 
 `ERROR: spock doesn't support index rechecks needed for deferrable indexes`
 `DETAIL: relation "public"."test_relation" has deferrable indexes: "index1", "index2"`
 
-in certain apply scenarios.
-
-**Recommendation:** Ensure all tables have at least one non-deferrable unique
-constraint (preferably the primary key) for reliable conflict detection.
+in certain apply scenarios. Ensure all tables have at least one non-deferrable
+unique constraint (preferably the primary key) for reliable conflict detection.
 
 ### No replication queue flush
 
@@ -159,17 +157,20 @@ Note that DDL limitations apply, so extra care needs to be taken when using
 
 ### Delta-Apply Column Requirements
 
-Columns configured for Delta-Apply conflict resolution **must** have a `NOT NULL`
-constraint. If a NULL value is encountered during delta application, the apply
-worker will error with:
+Columns configured for Delta-Apply conflict resolution should have a `NOT NULL`
+constraint and `LOG_OLD_VALUE` enabled. If a NULL old value is encountered
+during delta application, Spock will fall back to applying the plain NEW value
+instead of computing a delta. While this fallback prevents errors, it can lead
+to unexpected results if the local value differs from the provider's old value.
 
-`ERROR: delta apply column can't operate NULL values`
-
-Ensure all Delta-Apply columns are defined with `NOT NULL` before enabling this feature.
+For reliable delta-apply behavior, ensure all Delta-Apply columns are defined
+with `NOT NULL`.
 
 ### Mixed Spock and Native Logical Replication
 
-Spock uses its own 16-bit node_id (derived from node name hash) to track transaction origins in commit timestamps, rather than PostgreSQL's RepOriginId. Both ID spaces overlap (0-65535), which can cause ambiguity if Spock and native PostgreSQL logical replication run on the same database.
-
-**Recommendation:** Avoid running Spock and native logical replication subscriptions on the same database.
+Spock uses its own 16-bit `node_id` (derived from the node name hash) to track
+transaction origins in commit timestamps, rather than PostgreSQL's
+`RepOriginId`. Both ID spaces overlap (0-65535), which can cause ambiguity if
+Spock and native PostgreSQL logical replication run on the same database. Avoid
+running Spock and native logical replication subscriptions on the same database.
 

--- a/docs/spock_functions/functions/spock_gen_slot_name.md
+++ b/docs/spock_functions/functions/spock_gen_slot_name.md
@@ -1,50 +1,23 @@
 ## NAME
 
-spock.spock_gen_slot_name()
+`spock.spock_gen_slot_name()`
 
 ### SYNOPSIS
 
-spock.spock_gen_slot_name(dbname name, provider_node name,
-subscription name)
-
-### RETURNS
-
-The generated replication slot name as a name type.
+`spock.spock_gen_slot_name (dbname name, provider_node name, subscription name)`
 
 ### DESCRIPTION
 
-Generates a standardized replication slot name for a Spock subscription.
-
-This function creates a consistent naming convention for replication slots
-based on the database name, provider node name, and subscription name. The
-generated name follows Spock's internal naming scheme to ensure uniqueness
-and traceability.
-
-This function that performs a calculation without accessing the
-database or modifying any data. It can be used to predict what slot name
-Spock will generate for a given subscription configuration.
-
-### ARGUMENTS
-
-dbname
-
-    The name of the database.
-
-provider_node
-
-    The name of the provider node.
-
-subscription
-
-    The name of the subscription.
+Generates a replication slot name from the given database, provider node, and subscription names. This is used internally by Spock to create consistent slot names for replication connections.
 
 ### EXAMPLE
 
-The following example executes the function; the database name is postgres,
-the node name is n1, and the subscription name is sub_n2n1:
+`SELECT spock.spock_gen_slot_name('mydb', 'n1', 'sub_n2n1');`
 
-    postgres=# SELECT spock.spock_gen_slot_name('postgres', 'n1', 'sub_n2n1');
-       spock_gen_slot_name
-    --------------------------
-     spk_postgres_n1_sub_n2n1
-    (1 row)
+### ARGUMENTS
+    dbname
+        The name of the database.
+    provider_node
+        The name of the provider node.
+    subscription
+        The name of the subscription.

--- a/docs/spock_functions/functions/spock_get_country.md
+++ b/docs/spock_functions/functions/spock_get_country.md
@@ -1,47 +1,15 @@
 ## NAME
 
-spock.get_country()
+`spock.get_country()`
 
 ### SYNOPSIS
 
-spock.get_country ()
-
-### RETURNS
-
-The country code configured for the node as text, or `??` if not set.
+`spock.get_country ()`
 
 ### DESCRIPTION
 
-Returns the spock.country property that was set during node creation. You can
-modify the property after configuration; modification requires a server
-restart to apply the change.
-
-This function retrieves the value of the spock.country configuration
-parameter for the current session. The country code is typically used in
-multi-region or geo-distributed replication topologies to identify the
-geographic location of nodes and apply region-specific routing or filtering
-rules.
-
-This function does not modify any data.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Returns the country code for the current node. The country code is set via the `spock.country` GUC parameter. If the country has not been explicitly set, the function returns `??`.
 
 ### EXAMPLE
 
-If the spock.country parameter has not been set, the function returns:
-
-    postgres=# SELECT spock.get_country();
-     get_country
-    -------------
-     ??
-    (1 row)
-
-If spock.country is set to `US`, the function returns:
-
-    postgres=# SELECT spock.get_country();
-     get_country
-    -------------
-     US
-    (1 row)
+`SELECT spock.get_country();`

--- a/docs/spock_functions/functions/spock_max_proto_version.md
+++ b/docs/spock_functions/functions/spock_max_proto_version.md
@@ -1,48 +1,21 @@
 ## NAME
 
-spock.spock_max_proto_version()
+`spock.spock_max_proto_version()`
 
 ### SYNOPSIS
 
-spock.spock_max_proto_version()
-
-### RETURNS
-
-The maximum spock protocol version supported by the installed Spock extension
-as an integer.  The protocol version determines compatibility between Spock
-versions.
+`spock.spock_max_proto_version ()`
 
 ### DESCRIPTION
 
-Returns the maximum protocol version supported by the Spock extension.
-
-This function queries the Spock extension and returns the highest protocol
-version number it can use for replication communication. The protocol
-version determines the features and capabilities available for replication
-between nodes.
-
-When establishing replication connections between nodes running different
-Spock versions, the nodes negotiate to use the lower of the two maximum
-protocol versions. This ensures compatibility between nodes running
-different Spock releases.
-
-The protocol version is returned as an integer value. Higher numbers
-indicate newer protocol versions with additional features.
-
-This is a read-only query function that does not modify data.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Returns the highest Spock native protocol version supported by the current binary. This is used during connection negotiation between provider and subscriber nodes to determine the protocol version to use.
 
 ### EXAMPLE
 
-The following command shows that the current version of Spock uses protocol
-version 4:
-
-    postgres=# SELECT spock.spock_max_proto_version();
-     spock_max_proto_version
-    -------------------------
-                           4
-    (1 row)
-
+```sql
+postgres=# SELECT spock.spock_max_proto_version();
+ spock_max_proto_version
+-------------------------
+                       1
+(1 row)
+```

--- a/docs/spock_functions/functions/spock_min_proto_version.md
+++ b/docs/spock_functions/functions/spock_min_proto_version.md
@@ -1,49 +1,21 @@
 ## NAME
 
-spock.spock_min_proto_version()
+`spock.spock_min_proto_version()`
 
 ### SYNOPSIS
 
-spock.spock_min_proto_version()
-
-### RETURNS
-
-The minimum Spock protocol version supported by the installed Spock extension
-as an integer. The protocol version determines compatibility between Spock
-versions.
+`spock.spock_min_proto_version ()`
 
 ### DESCRIPTION
 
-Returns the minimum protocol version supported by the Spock extension.
-
-This function queries the Spock extension and returns the lowest protocol
-version number it can use for replication communication. The protocol
-version determines the features and capabilities available for replication
-between nodes.
-
-When establishing replication connections between nodes running different
-Spock versions, the nodes negotiate to use a protocol version that falls
-within the supported range of both nodes. The minimum protocol version
-defines the lower bound of compatibility - nodes supporting only protocol
-versions below this minimum cannot replicate with this Spock installation.
-
-The protocol version is returned as an integer value. This minimum version
-ensures backward compatibility with older Spock releases while still
-allowing the use of newer protocol features when both nodes support them.
-
-This is a read-only query function that does not modify data.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Returns the lowest Spock native protocol version for which the current binary is backward compatible. This is used during connection negotiation between provider and subscriber nodes.
 
 ### EXAMPLE
 
-The following command shows that the version of Spock in use is using protocol
-version 3:
-
-    postgres=# SELECT spock.spock_min_proto_version();
-     spock_min_proto_version
-    -------------------------
-                           3
-    (1 row)
+```sql
+postgres=# SELECT spock.spock_min_proto_version();
+ spock_min_proto_version
+-------------------------
+                       1
+(1 row)
+```

--- a/docs/spock_functions/functions/spock_node_info.md
+++ b/docs/spock_functions/functions/spock_node_info.md
@@ -1,48 +1,26 @@
 ## NAME
 
-spock.node_info()
+`spock.node_info()`
 
 ### SYNOPSIS
 
-spock.node_info()
-
-### RETURNS
-
-A record containing information about the local Spock node:
-
-  - node_id is the OID of the node.
-  - node_name is the name of the node.
-  - sysid is the system identifier.
-  - dbname is the database name.
-  - replication_sets is the available replication sets.
-  - location is the node location (if set).
-  - country is the node country (if set).
-  - info is additional metadata stored in JSONB format (if set).
+`spock.node_info ()`
 
 ### DESCRIPTION
 
-Returns information about the local Spock node.
-
-This function queries the Spock catalogs and returns metadata about the
-current node, including its identifier, name, database information, and any
-optional descriptive fields that were set during node creation.
-
-This is a read-only query function that does not modify data.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Returns information about the local Spock node, including the node identifier, name, system identifier, database name, available replication sets, and any optional descriptive fields that were set during node creation.
 
 ### EXAMPLE
 
-    postgres=# SELECT * FROM spock.node_info();
-
-    -[ RECORD 1 ]----+--------------------------------------
-    node_id          | 49708
-    node_name        | n1
-    sysid            | 7600444661598442547
-    dbname           | postgres
-    replication_sets | "default",default_insert_only,ddl_sql
-    location         |
-    country          |
-    info             | 
+```sql
+postgres=# SELECT * FROM spock.node_info();
+-[ RECORD 1 ]----+--------------------------------------
+node_id          | 49708
+node_name        | n1
+sysid            | 7600444661598442547
+dbname           | postgres
+replication_sets | "default",default_insert_only,ddl_sql
+location         |
+country          |
+info             | 
+```

--- a/docs/spock_functions/functions/spock_repset_show_table.md
+++ b/docs/spock_functions/functions/spock_repset_show_table.md
@@ -1,74 +1,32 @@
 ## NAME
 
-spock.repset_show_table()
+`spock.repset_show_table()`
 
 ### SYNOPSIS
 
-spock.repset_show_table (relation regclass, repsets text[])
-
-### RETURNS
-
-A record containing detailed information about how a table is configured
-for replication:
-
-  - relid is the OID of the table relation.
-  - nspname is the schema name of the table.
-  - relname is the table name.
-  - att_list is an array of column names included in replication.
-  - has_row_filter is true if a row filter is applied to the table.
-  - relkind is the relation kind ('r' for regular table, 'p' for
-    partitioned table).
-  - relispartition is true if the table is a partition of a partitioned
-    table.
+`spock.repset_show_table (relation regclass, repsets text[])`
 
 ### DESCRIPTION
 
-Returns detailed replication configuration information for a specific table
-within the specified replication sets.
-
-This function queries how a table is configured for replication across one
-or more replication sets. It shows which columns are included in
-replication, whether row filtering is applied, and metadata about the table
-type and partition status.
-
-The att_list field shows the specific columns that will be replicated. If
-all columns are replicated, this will contain all column names. If column
-filtering was configured when the table was added to a replication set,
-only the specified columns appear in this list.
-
-The has_row_filter field indicates whether a row filter expression is
-applied to the table, which would limit which rows are replicated based on
-custom criteria.
-
-The repsets parameter allows you to check the table's configuration across
-multiple replication sets. The function returns information based on how
-the table is configured in those sets.
-
-This is a read-only query function that does not modify any data.
-
-### ARGUMENTS
-
-relation
-
-    The table to query information about.
-
-repsets
-
-    An array of replication set names to check the table's
-    configuration within.
+Returns detailed replication configuration information for a specific table within the specified replication sets, including which columns are replicated, whether row filtering is applied, and metadata about the table type and partition status.
 
 ### EXAMPLE
 
-The following command shows detailed information about the public.invoices
-table:
+```sql
+postgres=# SELECT * FROM spock.repset_show_table('public.invoices',
+    ARRAY['default', 'ddl_sql']);
+-[ RECORD 1 ]--+-----------------------------------------
+relid          | 17241
+nspname        | public
+relname        | invoices
+att_list       | {order_id,customer_id,order_date,amount}
+has_row_filter | f
+relkind        | r
+relispartition | f
+```
 
-    postgres=# SELECT * FROM spock.repset_show_table('public.invoices',
-        ARRAY['default', 'ddl_sql']);
-    -[ RECORD 1 ]--+-----------------------------------------
-    relid          | 17241
-    nspname        | public
-    relname        | invoices
-    att_list       | {order_id,customer_id,order_date,amount}
-    has_row_filter | f
-    relkind        | r
-    relispartition | f
+### ARGUMENTS
+    relation
+        The table to query information about.
+    repsets
+        An array of replication set names to check the table's configuration within.

--- a/docs/spock_functions/functions/spock_sub_alter_skiplsn.md
+++ b/docs/spock_functions/functions/spock_sub_alter_skiplsn.md
@@ -1,50 +1,23 @@
 ## NAME
 
-NAME
-
-spock.sub_alter_skiplsn()
+`spock.sub_alter_skiplsn()`
 
 ### SYNOPSIS
 
-spock.sub_alter_skiplsn (subscription_name name, lsn pg_lsn)
-
-### RETURNS
-
-    - true if the subscription LSN was successfully advanced.
-
-    - false if the subscription does not exist.
+`spock.sub_alter_skiplsn (subscription_name name, lsn pg_lsn)`
 
 ### DESCRIPTION
 
-Advances the replication position of an existing Spock subscription to the
-specified Log Sequence Number (LSN).
-
-This function is typically used as a recovery or repair operation when a
-subscription is unable to proceed due to a problematic or corrupted change in
-the replication stream. By skipping forward to a known good LSN, replication
-can resume without replaying the offending transaction.
-
-This operation does not replay or repair the skipped data. Any changes
-between the old LSN and the specified LSN will be permanently ignored by the
-subscriber. This should be used with caution and only when the administrator
-understands the data implications.
-
-This function writes metadata into the Spock catalogs but does not modify
-PostgreSQL server configuration.
+Advances the replication position of an existing subscription to the specified Log Sequence Number (LSN). This is typically used as a recovery operation when a subscription is unable to proceed due to a problematic change in the replication stream. Any changes between the old LSN and the specified LSN will be permanently skipped.
 
 This command must be executed by a superuser.
 
+### EXAMPLE
+
+`SELECT spock.sub_alter_skiplsn('sub_n1_to_n2', '0/16B6A50');`
+
 ### ARGUMENTS
-
-subscription_name
-
-    The name of an existing Spock subscription.
-
-lsn
-
-    The Log Sequence Number to which the subscription should
-    advance.
-
-## EXAMPLE
-
-    SELECT spock.sub_alter_skiplsn('sub_n1_to_n2', '0/16B6A50');
+    subscription_name
+        The name of an existing subscription.
+    lsn
+        The Log Sequence Number to which the subscription should advance.

--- a/docs/spock_functions/functions/spock_sync_event.md
+++ b/docs/spock_functions/functions/spock_sync_event.md
@@ -1,42 +1,15 @@
 ## NAME
 
-spock.sync_event()
+`spock.sync_event()`
 
 ### SYNOPSIS
 
-spock.sync_event ()
-
-### RETURNS
-
-The Log Sequence Number (LSN) of the created synchronization event as
-pg_lsn.
+`spock.sync_event ()`
 
 ### DESCRIPTION
 
-Creates a synchronization event in the replication stream and returns its
-LSN.
-
-This function inserts a special synchronization marker into the logical
-replication stream at the current write position. The returned LSN
-identifies this marker's location in the write-ahead log and can be used
-with functions like spock.wait_slot_confirm_lsn() to verify that
-subscribers have processed replication up to this point.
-
-Synchronization events are useful for coordinating activities across
-multiple nodes in a replication topology. By creating a sync event on a
-provider and then waiting for subscribers to reach that LSN, you can ensure
-all nodes have processed a consistent set of changes before proceeding with
-operations that depend on synchronized state.
-
-The sync event itself does not contain data or modify any tables - it
-serves purely as a coordination marker in the replication stream.
-
-This function modifies the replication stream by inserting a sync marker.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Creates a synchronization event in the replication stream and returns its LSN. The returned LSN can be used with `spock.wait_slot_confirm_lsn()` to verify that subscribers have processed replication up to this point.
 
 ### EXAMPLE
 
-    SELECT spock.sync_event();
+`SELECT spock.sync_event();`

--- a/docs/spock_functions/functions/spock_version.md
+++ b/docs/spock_functions/functions/spock_version.md
@@ -1,35 +1,21 @@
 ## NAME
 
-spock.spock_version()
+`spock.spock_version()`
 
 ### SYNOPSIS
 
-spock.spock_version ()
-
-### RETURNS
-
-The version string of the installed Spock extension.
+`spock.spock_version ()`
 
 ### DESCRIPTION
 
-Returns the version number of the Spock extension.
-
-This function queries the Spock extension and returns its version as a text
-string. The version string typically follows semantic versioning format
-(e.g., "4.0.1" or "5.0.4").
-
-This is a read-only query function that does not modify any data.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Returns the Spock version in a human-readable major/minor form (for example, `5.0.5`).
 
 ### EXAMPLE
 
-The following command returns the Spock version:
-
-    postgres=# SELECT spock.spock_version();
-     spock_version 
-    ---------------
-     5.0.4
-    (1 row)
+```sql
+postgres=# SELECT spock.spock_version();
+ spock_version
+---------------
+ 5.0.5
+(1 row)
+```

--- a/docs/spock_functions/functions/spock_version_num.md
+++ b/docs/spock_functions/functions/spock_version_num.md
@@ -1,33 +1,21 @@
 ## NAME
 
-spock.spock_version_num()
+`spock.spock_version_num()`
 
 ### SYNOPSIS
 
-spock.spock_version_num ()
-
-### RETURNS
-
-The version number of the installed Spock extension as an integer.
+`spock.spock_version_num ()`
 
 ### DESCRIPTION
 
-Returns the version number of the Spock extension as an integer.
-
-This function queries the Spock extension and returns its version encoded as
-an integer value. The integer format allows for easy version comparison in
-SQL queries without string parsing.
-
-The integer typically represents the version in a format like XXYYZZ where XX
-is the major version, YY is the minor version, and ZZ is the patch version.
-For example, version 3.1.0 might be represented as 30100.
-
-This is a read-only query function that does not modify any data.
-
-### ARGUMENTS
-
-This function takes no arguments.
+Returns the Spock version as a single integer (for example, `50005` for version 5.0.5). This is useful for programmatic version comparisons.
 
 ### EXAMPLE
 
-    SELECT spock.spock_version_num();
+```sql
+postgres=# SELECT spock.spock_version_num();
+ spock_version_num
+-------------------
+             50005
+(1 row)
+```

--- a/docs/spock_functions/functions/spock_wait_slot_confirm_lsn.md
+++ b/docs/spock_functions/functions/spock_wait_slot_confirm_lsn.md
@@ -1,54 +1,21 @@
 ## NAME
 
-spock.wait_slot_confirm_lsn()
+`spock.wait_slot_confirm_lsn()`
 
 ### SYNOPSIS
 
-spock.wait_slot_confirm_lsn (slotname name, target pg_lsn)
-
-### RETURNS
-
-void (returns nothing upon successful completion).
+`spock.wait_slot_confirm_lsn (slotname name, target pg_lsn)`
 
 ### DESCRIPTION
 
-Waits until the specified replication slot has confirmed receipt of changes
-up to the target Log Sequence Number (LSN).
-
-This function blocks the current session until the replication slot's
-confirmed flush LSN reaches or exceeds the specified target LSN. This is
-useful for ensuring that a subscriber has received and acknowledged
-replication changes before proceeding with subsequent operations.
-
-The confirmed flush LSN represents the position up to which the subscriber
-has successfully received, applied, and durably stored the replicated
-changes. This function provides a synchronization mechanism to coordinate
-activities between the provider and subscriber nodes.
-
-If the replication slot does not exist, the function will raise an error.
-The function will continue waiting indefinitely until the target LSN is
-reached, so callers should ensure the target LSN is reachable and that the
-subscription is actively processing changes.
-
-This function does not modify any data but may block for an extended period
-depending on replication lag and network conditions.
-
-### ARGUMENTS
-
-slotname
-
-    The name of the replication slot to monitor.
-
-target
-
-    The target Log Sequence Number to wait for. The function returns
-    when the slot's confirmed flush LSN reaches or exceeds this
-    value.
+Waits until the specified replication slot has confirmed receipt of changes up to the target Log Sequence Number (LSN). If `slotname` is NULL, waits for all logical replication slots. The function will block until the target LSN is reached.
 
 ### EXAMPLE
 
-The following command waits for a slot named spock_local_sync_346_79a to
-confirm that it has received changes to the target LSN (0/3000000):
+`SELECT spock.wait_slot_confirm_lsn('spk_postgres_n1_sub_n2n1', '0/3000000');`
 
-    SELECT spock.wait_slot_confirm_lsn('spock_local_sync_346_79a',
-    '0/3000000');
+### ARGUMENTS
+    slotname
+        The name of the replication slot to monitor. If NULL, waits for all logical slots.
+    target
+        The target LSN to wait for. The function returns when the slot's confirmed flush LSN reaches or exceeds this value.

--- a/docs/spock_functions/functions/spock_xact_timestamp_origin.md
+++ b/docs/spock_functions/functions/spock_xact_timestamp_origin.md
@@ -1,48 +1,19 @@
 ## NAME
 
-spock.xact_commit_timestamp_origin()
+`spock.xact_commit_timestamp_origin()`
 
 ### SYNOPSIS
 
-spock.xact_commit_timestamp_origin (xid xid, OUT timestamp timestamptz,
-OUT roident oid)
-
-### RETURNS
-
-A record containing transaction commit information:
-
-  - timestamp is the commit timestamp of the transaction.
-  - roident is the replication origin identifier of the transaction.
+`spock.xact_commit_timestamp_origin (xid xid)`
 
 ### DESCRIPTION
 
-Returns the commit timestamp and replication origin identifier for a given
-transaction ID.
-
-This function queries PostgreSQL's commit timestamp tracking system to
-retrieve when a specific transaction was committed and which replication
-origin it came from. The replication origin identifies the source node in a
-multi-node replication topology, allowing you to trace where changes
-originated.
-
-The commit timestamp tracking feature (track_commit_timestamp) must be
-enabled in PostgreSQL for this function to return meaningful results. If
-commit timestamp tracking is disabled, the function may return NULL or
-raise an error.
-
-The replication origin identifier (roident) will be 0 for locally-committed
-transactions that did not come through replication. For replicated
-transactions, it identifies the origin node from which the changes were
-received.
-
-This is a read-only query function that does not modify any data.
-
-### ARGUMENTS
-
-xid
-
-    The transaction ID to query.
+Returns the commit timestamp and replication origin identifier for a given transaction ID. The `track_commit_timestamp` setting must be enabled for this function to return results. The replication origin identifier (`roident`) is 0 for locally-committed transactions.
 
 ### EXAMPLE
 
-    SELECT * FROM spock.xact_commit_timestamp_origin('12345'::xid);
+`SELECT * FROM spock.xact_commit_timestamp_origin('12345'::xid);`
+
+### ARGUMENTS
+    xid
+        The transaction ID to query.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,11 +54,11 @@ nav:
   - Creating a Two-Node Cluster: two_node_cluster.md
   - Using Advanced Configuration Options: configuring.md
   - Upgrading a Spock Installation: upgrading_spock.md
-  - Conflict Types and Resolution: conflict_types.md
-  - Conflict Avoidance and Delta-Apply Columns: conflicts.md
+  - Spock's Conflict Avoidance Options: conflicts.md
   - Spock's Management Features:
     - Managing a Spock Installation: managing/index.md
     - Replicating Partitioned Tables: managing/partition_mgmt.md
+    - Using Batch Inserts: managing/batch_inserts.md
     - Filtering Data: managing/filtering.md
     - Using Spock in Read-Only Mode: managing/read_only.md
     - Using a Trigger to Manage Replication Set Membership: managing/repset_trigger.md
@@ -72,6 +72,11 @@ nav:
       - Using Zodan Scripts and Workflows: modify/zodan/zodan_readme.md
       - Adding a Node with Zero Downtime: modify/zodan/zodan_tutorial.md
     - Adding a Node with Minimal Downtime with pgBackRest: modify/add_node_pgbackrest.md
+    - Using Spockctrl:
+      - Modifying your Cluster with Spockctrl: modify/spockctrl/index.md
+      - Using Spockctrl Functions: modify/spockctrl/spockctrl_functions.md
+      - Populating the spockctrl.json File: modify/spockctrl/spockctrl_json.md
+      - Using a Workflow File to Modify a Cluster: modify/spockctrl/spockctrl_workflow.md
   - Monitoring a Cluster:
     - Monitoring the Configuration and Health of a Cluster: monitoring/index.md
     - Finding Cluster Information: monitoring/spock_info.md
@@ -102,6 +107,7 @@ nav:
       - spock.repset_alter(): spock_functions/functions/spock_repset_alter.md
       - spock.repset_create(): spock_functions/functions/spock_repset_create.md
       - spock.repset_drop(): spock_functions/functions/spock_repset_drop.md
+      - spock.repset_list_tables(): spock_functions/functions/spock_repset_list_tables.md
       - spock.repset_remove_partition(): spock_functions/functions/spock_repset_remove_partition.md
       - spock.repset_remove_seq(): spock_functions/functions/spock_repset_remove_seq.md
       - spock.repset_remove_table(): spock_functions/functions/spock_repset_remove_table.md
@@ -119,15 +125,17 @@ nav:
       - spock.sub_resync_table(): spock_functions/functions/spock_sub_resync_table.md
       - spock.sub_show_status(): spock_functions/functions/spock_sub_show_status.md
       - spock.sub_show_table(): spock_functions/functions/spock_sub_show_table.md
+      - spock.sub_sync(): spock_functions/functions/spock_sub_sync.md
       - spock.sync_event(): spock_functions/functions/spock_sync_event.md
       - spock.sub_wait_for_sync(): spock_functions/functions/spock_sub_wait_for_sync.md
       - spock.version(): spock_functions/functions/spock_version.md
       - spock.version_num(): spock_functions/functions/spock_version_num.md
       - spock.wait_slot_confirm_lsn(): spock_functions/functions/spock_wait_slot_confirm_lsn.md
+      - spock.xact_timestamp_origin(): spock_functions/functions/spock_xact_timestamp_origin.md
   - Limitations: limitations.md
   - FAQ: FAQ.md
   - Release Notes: spock_release_notes.md
   - Internals:
     - Design: internals-doc/DESIGN.md
     - Output Plugin: internals-doc/OUTPUT.md
-    - Protocol: internals-doc/protocol.txt
+    - Protocol: internals-doc/protocol.md


### PR DESCRIPTION
Add configuring.md, protocol.md, and 12 function reference pages. Update install_spock.md, limitations.md, and mkdocs.yml navigation. All content verified against v5_STABLE codebase for compatibility.