### PR TITLE
Backport to v5_STABLE: Fix memory leak and assertion bug

### DIFF
--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -1210,7 +1210,8 @@ spock_apply_heap_delete(SpockRelation *rel, SpockTupleData *oldtup)
 							  rel, NULL, oldtup,
 							  remotetuple, NULL, SpockResolution_Skip,
 							  InvalidTransactionId, false, InvalidRepOriginId,
-							  (TimestampTz)0, edata->targetRel->idxoid);
+							  (TimestampTz) 0, edata->targetRel->idxoid);
+		heap_freetuple(remotetuple);
 	}
 
 	/* Cleanup. */

--- a/src/spock_worker.c
+++ b/src/spock_worker.c
@@ -415,7 +415,7 @@ spock_worker_detach(bool crash)
 
 	LWLockAcquire(SpockCtx->lock, LW_EXCLUSIVE);
 
-	Assert(MySpockWorker->proc = MyProc);
+	Assert(MySpockWorker->proc == MyProc);
 	Assert(MySpockWorker->generation == MySpockWorkerGeneration);
 	MySpockWorker->proc = NULL;
 


### PR DESCRIPTION
- Fix assertion in spock_worker.c Changed 'Assert(MySpockWorker->proc = MyProc)' to use '=='

- Fix memory leak in spock_apply_heap.c Free remotetuple after reporting conflict

(cherry picked from commit 0698eae00e2a43fd40607cf0ab304a4d55ecf910)