### PR TITLE
Spock 5.0.7 UPDATE - fix a bug and let future delta apply feature update be smoother

### DIFF
--- a/include/spock.h
+++ b/include/spock.h
@@ -28,6 +28,7 @@
 #define SPOCK_VERSION_NUM 50007
 
 #define EXTENSION_NAME "spock"
+#define SPOCK_SECLABEL_PROVIDER "spock"
 
 #define REPLICATION_ORIGIN_ALL	"all"
 

--- a/sql/spock--5.0.6--5.0.7.sql
+++ b/sql/spock--5.0.6--5.0.7.sql
@@ -123,3 +123,41 @@ RETURNS pg_lsn RETURNS NULL ON NULL INPUT
 AS 'MODULE_PATHNAME', 'spock_create_sync_event'
 LANGUAGE C VOLATILE;
 
+/*
+ * Correct the declared type of spock.subscription.sub_skip_schema.
+ *
+ * The column was added as text in the 5.0.1--5.0.2 upgrade, but the C code
+ * has always treated it as text[] on both read and write paths
+ * (strlist_to_textarray on write, DatumGetArrayTypeP on read).  The bytes
+ * already on disk are therefore a valid ArrayType; only the catalog's type
+ * label is wrong.  ALTER TABLE ... ALTER COLUMN TYPE text[] USING ... is
+ * not viable here: there is no SQL expression that converts "varlena bytes
+ * the planner believes are text but are in fact ArrayType internal format"
+ * back into an ArrayType Datum.  Relabel the column in place so SQL-level
+ * access (SELECT, unnest, etc.) works as users expect, without rewriting
+ * data.
+ */
+LOCK TABLE spock.subscription IN ACCESS EXCLUSIVE MODE;
+
+UPDATE pg_catalog.pg_attribute
+   SET atttypid  = 'text[]'::regtype,
+       attndims  = 1
+ WHERE attrelid  = 'spock.subscription'::regclass
+   AND attname   = 'sub_skip_schema'
+   AND atttypid  = 'text'::regtype;
+
+/*
+ * Drop any pg_statistic rows for the column.  Stats sampled when the
+ * column was labelled text encode varlena bytes with text semantics;
+ * after the relabel the planner would interpret the same stavalues
+ * arrays as text[], producing nonsense selectivities (and possibly
+ * crashing on operators that validate ArrayType structure).  ANALYZE
+ * will repopulate as needed.
+ */
+DELETE FROM pg_catalog.pg_statistic
+ WHERE starelid  = 'spock.subscription'::regclass
+   AND staattnum = (
+       SELECT attnum
+       FROM   pg_catalog.pg_attribute
+       WHERE  attrelid = 'spock.subscription'::regclass
+         AND  attname  = 'sub_skip_schema');

--- a/src/spock.c
+++ b/src/spock.c
@@ -21,10 +21,12 @@
 #include "catalog/pg_extension.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_class.h"
 #include "catalog/pg_database.h"
 #include "catalog/pg_type.h"
 
 #include "commands/extension.h"
+#include "commands/seclabel.h"
 
 #include "executor/executor.h"
 
@@ -917,6 +919,39 @@ log_message_filter(ErrorData *edata)
 }
 
 /*
+ * Spock security label hook.
+ *
+ * Stub provider: stores any well-shaped label and does nothing else.
+ * It exists so v5 servers can persist the labels that the upcoming
+ * delta_apply rework will read on v6 (and on a later v5 release).
+ *
+ * We do NOT remove this stub when the real provider lands: register_label_provider()
+ * registers exactly one callback per provider name, and the real version will
+ * replace this body in place.  Until then, constrain the contract to "column on
+ * an existing relation" so users cannot persist labels on objects the real
+ * provider will refuse, leaving them stuck with rows in pg_seclabel that no
+ * subsequent code path will accept.
+ */
+static void
+spock_object_relabel(const ObjectAddress *object, const char *seclabel)
+{
+	/*
+	 * classId must be pg_class, the object must be a column (objectSubId > 0),
+	 * and the relation must still exist.  The syscache lookup catches the
+	 * race where the relation is dropped concurrently, in which case we let
+	 * the caller see an explicit error rather than silently storing a
+	 * dangling label.
+	 */
+	if (object->classId != RelationRelationId ||
+		object->objectSubId <= 0 ||
+		!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(object->objectId)))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("spock provider does not support labels on %s",
+						getObjectTypeDescription(object, false))));
+}
+
+/*
  * Entry point for this module.
  */
 void
@@ -1236,5 +1271,8 @@ _PG_init(void)
 	/* General-purpose message filter */
 	prev_emit_log_hook = emit_log_hook;
 	emit_log_hook = log_message_filter;
+
+	/* Security label provider hook */
+	register_label_provider(SPOCK_SECLABEL_PROVIDER, spock_object_relabel);
 }
 


### PR DESCRIPTION
## Summary

Two additions to the 5.0.7 upgrade path on `v5_STABLE`:

### 1. Register a `spock` security-label provider (stub)

`src/spock.c` now calls `register_label_provider("spock", spock_object_relabel)` from `_PG_init`. The provider is intentionally a stub for now — it accepts a label only when the object is a column (`classId == pg_class`, `objectSubId > 0`) on a relation that still exists, and rejects anything else with a clear `ERRCODE_FEATURE_NOT_SUPPORTED`.

The stub exists so v5 servers can persist labels that the upcoming delta-apply rework will read on v6 (and on a later v5 release). Constraining the contract up front keeps users from writing `pg_seclabel` rows that the real provider will later refuse, which would otherwise leave them with dangling rows and no clean migration. The body will be replaced in place when the real provider lands — `register_label_provider` registers exactly one callback per provider name, so the stub does not need to be removed.

`SPOCK_SECLABEL_PROVIDER` is added to `include/spock.h`, so the provider name is shared between this site and the future caller.

### 2. Fix `spock.subscription.sub_skip_schema` type label

The 5.0.1→5.0.2 upgrade added `sub_skip_schema` as `text`, but the C code has always written it via `strlist_to_textarray()` and read it back via `DatumGetArrayTypeP()`. The on-disk bytes are a valid `ArrayType` serialisation — only the catalogue type is wrong. SQL-level access (`SELECT`, `unnest`, etc.) has been broken since 5.0.2: the text I/O path walks the bytes as a string and returns garbage or fails UTF-8 validation.

`ALTER TABLE ... ALTER COLUMN TYPE text[] USING ...` is not viable here: there is no SQL expression that converts "varlena bytes the planner believes are text but are in fact ArrayType internal format" back into an `ArrayType` Datum. Instead, the 5.0.6→5.0.7 upgrade script relabels `pg_attribute.atttypid` in place under `ACCESS EXCLUSIVE`, sets `attndims = 1`, and filters on `atttypid = 'text'::regtype` so re-running the upgrade (or running it after a manual fix) is a no-op. `CacheInvalidateHeapTuple` fires automatically when `heap_update` hits `pg_attribute`, so no explicit relcache invalidation is needed.

Stale `pg_statistic` rows are dropped in the same script — stats sampled under text semantics encode the same bytes that `text[]` would interpret as `ArrayType` internals, producing nonsense selectivities and risking validator crashes on operators that check array structure. `ANALYZE` will repopulate.

## Why now

Both changes are prerequisites for the v6 delta-apply rework: the seclabel stub gives that work a stable on-disk format to lean on while v5 is still the supported branch, and the `sub_skip_schema` relabel removes a latent SQL-side breakage on the same upgrade path users will follow to get there.