### PR TITLE
zodan: fix Phase 3 catchup wait; parameterise spock.sync_event()

### DIFF
--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -1338,7 +1338,8 @@ DECLARE
     dbname             text;
     slot_name          text;
 	sub_name           text;
-    _commit_lsn        pg_lsn;
+    _slot_lsn          pg_lsn;
+    _catchup_lsn       pg_lsn;
 BEGIN
     RAISE NOTICE 'Phase 3: Creating disabled subscriptions and slots';
 
@@ -1349,7 +1350,7 @@ BEGIN
     CREATE TEMP TABLE IF NOT EXISTS temp_sync_lsns (
         origin_node text PRIMARY KEY,
         sync_lsn text NOT NULL,
-        commit_lsn pg_lsn
+        slot_lsn pg_lsn
     );
 
     -- Check if there are any "other" nodes (not source, not new)
@@ -1379,23 +1380,6 @@ BEGIN
     FOR rec IN SELECT * FROM temp_spock_nodes
 	           WHERE node_name != src_node_name AND node_name != new_node_name
 	LOOP
-        -- Trigger sync event on origin node and store LSN
-        BEGIN
-            RAISE NOTICE '    - 3+ node scenario: sync event stored, skipping disabled subscriptions';
-            SELECT * INTO remotesql
-            FROM dblink(rec.dsn, 'SELECT spock.sync_event()') AS t(sync_lsn text);
-
-            -- Store the sync LSN for later use when enabling subscriptions
-            INSERT INTO temp_sync_lsns (origin_node, sync_lsn)
-            VALUES (rec.node_name, remotesql)
-            ON CONFLICT (origin_node) DO UPDATE SET sync_lsn = EXCLUDED.sync_lsn;
-
-            RAISE NOTICE '    OK: %', rpad('Triggering sync event on node ' || rec.node_name || ' (LSN: ' || remotesql || ')', 120, ' ');
-        EXCEPTION
-            WHEN OTHERS THEN
-                RAISE EXCEPTION '    ✗ %', rpad('Triggering sync event on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
-        END;
-
         -- Create replication slot on the "other" node
         BEGIN
             -- Extract dbname and handle both quoted and unquoted values
@@ -1421,73 +1405,104 @@ BEGIN
                 RAISE NOTICE '    Remote SQL for slot creation: %', remotesql;
             END IF;
 
-            SELECT lsn INTO _commit_lsn
+            SELECT lsn INTO _slot_lsn
                 FROM dblink(rec.dsn, remotesql) AS t(slot_name text, lsn pg_lsn);
-            UPDATE temp_sync_lsns SET commit_lsn = _commit_lsn
-                WHERE origin_node = rec.node_name;
-            RAISE NOTICE '    OK: %', rpad('Creating replication slot ' || slot_name || ' (LSN: ' || _commit_lsn || ')' || ' on node ' || rec.node_name, 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Creating replication slot ' || slot_name || ' (LSN: ' || _slot_lsn || ')' || ' on node ' || rec.node_name, 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
                 RAISE EXCEPTION '    ✗ %', rpad('Creating replication slot ' || slot_name || ' on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
         END;
 
-        -- Wait for the source node to have committed all changes from this
-        -- "other" node up to L_slot, ensuring resume_lsn >= L_slot when Phase 5
-        -- takes the snapshot (prevents data loss in the [resume_lsn, L_slot) gap).
+        -- Trigger a sync event on rec *after* slot creation. This anchors a
+        -- real commit at LSN > _slot_lsn, which gives the catchup wait below
+        -- a reachable target even when rec is otherwise idle (the slot's
+        -- consistent_point typically lands on a RUNNING_XACTS record, not on
+        -- a commit, so remote_lsn alone may never reach _slot_lsn).
+        -- The same LSN is reused by Phase 8 wait_for_sync_event on new.
         BEGIN
-            DECLARE
-                src_progress_lsn         pg_lsn;
-                wait_started             timestamptz := clock_timestamp();
-                wait_timeout             interval := interval '3 minutes';
-                progress_sql             text;
-                v_prev_statement_timeout text;
-            BEGIN
-                progress_sql := format(
-                    'SELECT p.remote_lsn '
-                    'FROM spock.progress p '
-                    'JOIN spock.node n ON n.node_id = p.remote_node_id '
-                    'WHERE p.node_id = (SELECT node_id FROM spock.node_info()) '
-                    '  AND n.node_name = %L',
-                    rec.node_name);
+            SELECT t.sync_lsn::pg_lsn INTO _catchup_lsn
+            FROM dblink(rec.dsn, 'SELECT spock.sync_event(true)') AS t(sync_lsn text);
 
-                RAISE NOTICE '    - Waiting for source node % to commit % changes up to slot LSN %...',
-                             src_node_name, rec.node_name, _commit_lsn;
+            INSERT INTO temp_sync_lsns (origin_node, sync_lsn, slot_lsn)
+            VALUES (rec.node_name, _catchup_lsn::text, _slot_lsn)
+            ON CONFLICT (origin_node) DO UPDATE
+                SET sync_lsn = EXCLUDED.sync_lsn,
+                    slot_lsn = EXCLUDED.slot_lsn;
 
-                LOOP
-                    BEGIN
-                        -- Bound each remote probe so dblink calls cannot hang forever.
-                        v_prev_statement_timeout := current_setting('statement_timeout', true);
-                        PERFORM set_config('statement_timeout', '5s', true);
-
-                        SELECT * FROM dblink(src_dsn, progress_sql)
-                            AS t(lsn pg_lsn) INTO src_progress_lsn;
-
-                        PERFORM set_config('statement_timeout', coalesce(v_prev_statement_timeout, '0'), true);
-                    EXCEPTION
-                        WHEN OTHERS THEN
-                            PERFORM set_config('statement_timeout', coalesce(v_prev_statement_timeout, '0'), true);
-                            src_progress_lsn := NULL;
-                    END;
-
-                    EXIT WHEN src_progress_lsn IS NOT NULL
-                              AND src_progress_lsn >= _commit_lsn;
-
-                    IF clock_timestamp() - wait_started > wait_timeout THEN
-                        RAISE WARNING '    Timeout waiting for source node commit catchup (last seen: %)', src_progress_lsn;
-                        EXIT;
-                    END IF;
-
-                    PERFORM pg_sleep(0.5);
-                END LOOP;
-
-                RAISE NOTICE '    OK: %', rpad(
-                    'Source node ' || src_node_name || ' committed ' || rec.node_name
-                    || ' changes up to ' || COALESCE(src_progress_lsn::text, 'unknown')
-                    || ' (needed >= ' || _commit_lsn || ')', 120, ' ');
-            END;
+            RAISE NOTICE '    OK: %', rpad('Triggering sync event on node ' || rec.node_name || ' (LSN: ' || _catchup_lsn || ')', 120, ' ');
         EXCEPTION
             WHEN OTHERS THEN
-                RAISE WARNING '    Could not verify source commit catchup for %: %', rec.node_name, SQLERRM;
+                RAISE EXCEPTION '    ✗ %', rpad('Triggering sync event on node ' || rec.node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+        END;
+
+        -- Wait until src has applied rec changes through _catchup_lsn. Since
+        -- _catchup_lsn > _slot_lsn and apply is in commit order, reaching it
+        -- proves every rec commit with commit_lsn <= _slot_lsn is committed
+        -- on src and visible to the Phase 5 src->new COPY snapshot.
+        --
+        -- We must use remote_lsn (apply progress at last applied
+        -- commit). received_lsn is unsafe here: it advances on keepalive
+        -- messages reporting the remote walsender position even when no rec
+        -- changes have been applied on src yet.
+        DECLARE
+            src_progress_lsn         pg_lsn;
+            wait_started             timestamptz := clock_timestamp();
+            wait_timeout             interval := interval '3 minutes';
+            progress_sql             text;
+            v_prev_statement_timeout text;
+        BEGIN
+            progress_sql := format(
+                'SELECT p.remote_lsn '
+                'FROM spock.progress p '
+                'JOIN spock.node n ON n.node_id = p.remote_node_id '
+                'WHERE p.node_id = (SELECT node_id FROM spock.node_info()) '
+                '  AND n.node_name = %L',
+                rec.node_name);
+
+            RAISE NOTICE '    - Waiting for source node % to apply % changes up to sync LSN %...',
+                         src_node_name, rec.node_name, _catchup_lsn;
+
+            LOOP
+                BEGIN
+                    -- Bound each remote probe so dblink calls cannot hang forever.
+                    v_prev_statement_timeout := current_setting('statement_timeout', true);
+                    PERFORM set_config('statement_timeout', '5s', true);
+
+                    SELECT * FROM dblink(src_dsn, progress_sql)
+                        AS t(lsn pg_lsn) INTO src_progress_lsn;
+
+                    PERFORM set_config('statement_timeout', coalesce(v_prev_statement_timeout, '0'), true);
+                EXCEPTION
+                    WHEN OTHERS THEN
+					    -- Let user know if something wrong happens
+						IF verb THEN
+					      RAISE NOTICE 'An error happened: %', SQLERRM;
+						END IF;
+                        -- Transient probe failure; restore timeout and retry.
+                        PERFORM set_config('statement_timeout', coalesce(v_prev_statement_timeout, '0'), true);
+                        src_progress_lsn := NULL;
+                END;
+
+                EXIT WHEN src_progress_lsn IS NOT NULL
+                          AND src_progress_lsn >= _catchup_lsn;
+
+                IF clock_timestamp() - wait_started > wait_timeout THEN
+                    -- Hard failure: a post-slot sync_event commit was emitted
+                    -- on rec, so this LSN must reach src unless replication
+                    -- is broken. Proceeding would risk losing rec rows in
+                    -- (src_progress_lsn, _slot_lsn] from the src->new COPY.
+                    RAISE EXCEPTION 'Timed out waiting for source node % to apply % changes through sync LSN % (last seen: %)',
+                                    src_node_name, rec.node_name, _catchup_lsn,
+                                    COALESCE(src_progress_lsn::text, 'none');
+                END IF;
+
+                PERFORM pg_sleep(0.5);
+            END LOOP;
+
+            RAISE NOTICE '    OK: %', rpad(
+                'Source node ' || src_node_name || ' applied ' || rec.node_name
+                || ' changes up to ' || COALESCE(src_progress_lsn::text, 'unknown')
+                || ' (needed >= ' || _catchup_lsn || ')', 120, ' ');
         END;
 
         -- Create disabled subscription on new node from "other" node
@@ -1914,7 +1929,7 @@ CREATE OR REPLACE PROCEDURE spock.check_commit_timestamp_and_advance_slot(
 ) LANGUAGE plpgsql AS $$
 DECLARE
     rec RECORD;
-    commit_lsn pg_lsn;
+    slot_lsn pg_lsn;
     slot_name text;
     dbname text;
     remotesql text;
@@ -1980,22 +1995,22 @@ BEGIN
     -- Check src->new slot; only advance if it is NOT active (defensive).
     BEGIN
         RAISE NOTICE '    - Checking source-to-new subscription slot...';
-        
+
         -- Get source node info and extract dbname
         FOR src_rec IN SELECT * FROM temp_spock_nodes WHERE node_name = src_node_name LOOP
             SELECT spock.extract_dbname_from_dsn(src_rec.dsn) INTO src_dbname;
             IF src_dbname IS NOT NULL THEN
                 src_dbname := TRIM(BOTH '''' FROM src_dbname);
             END IF;
-            IF src_dbname IS NULL THEN 
-                src_dbname := 'pgedge'; 
+            IF src_dbname IS NULL THEN
+                src_dbname := 'pgedge';
             END IF;
 
             -- Generate slot name: spk_<dbname>_<src>_sub_<src>_<new>
             src_slot_name := spock.spock_gen_slot_name(
-                src_dbname, src_node_name, 
+                src_dbname, src_node_name,
                 spock.gen_sub_name(src_node_name, new_node_name));
-            
+
             RAISE NOTICE '    Looking for slot % on source node', src_slot_name;
 
             -- Check if slot exists on source node and whether it is active
@@ -2058,23 +2073,23 @@ BEGIN
     FOR rec IN SELECT * FROM temp_spock_nodes WHERE node_name != src_node_name AND node_name != new_node_name LOOP
         BEGIN
             IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'temp_sync_lsns' AND relpersistence = 't') THEN
-                -- Get the stored sync LSN from when subscription was created
-                SELECT tsl.commit_lsn INTO commit_lsn
+                -- Get the stored slot LSN from when the slot was created
+                SELECT tsl.slot_lsn INTO slot_lsn
                 FROM temp_sync_lsns tsl
                 WHERE tsl.origin_node = rec.node_name;
 
-                IF commit_lsn IS NOT NULL THEN
-                    RAISE NOTICE '    OK: %', rpad('Found commit LSN for ' || rec.node_name || ' (LSN: ' || commit_lsn || ')...', 120, ' ');
+                IF slot_lsn IS NOT NULL THEN
+                    RAISE NOTICE '    OK: %', rpad('Found slot LSN for ' || rec.node_name || ' (LSN: ' || slot_lsn || ')...', 120, ' ');
                 ELSE
-                    RAISE NOTICE '    - %', rpad('No commit LSN found for ' || rec.node_name || '->' || new_node_name, 120, ' ');
+                    RAISE NOTICE '    - %', rpad('No slot LSN found for ' || rec.node_name || '->' || new_node_name, 120, ' ');
                     CONTINUE;
                 END IF;
             END IF;
         EXCEPTION
             WHEN OTHERS THEN
-                -- Can't continue the process because commit_lsn is needed
+                -- Can't continue the process because slot_lsn is needed
                 -- to advance LR slot properly.
-                RAISE EXCEPTION '    ✗ %', rpad('Checking commit LSN for ' || rec.node_name || '->' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
+                RAISE EXCEPTION '    ✗ %', rpad('Checking slot LSN for ' || rec.node_name || '->' || new_node_name || ' (error: ' || SQLERRM || ')', 120, ' ');
         END;
 
         -- Advance replication slot based on commit timestamp
@@ -2154,7 +2169,7 @@ BEGIN
             WHEN OTHERS THEN
                 -- Can't continue the process because of an error during the
                 -- slot advancement operation
-                RAISE EXCEPTION '    ✗ %', rpad('Advancing slot ' || slot_name || ' to LSN ' || commit_lsn || ' (error: ' || SQLERRM || ')', 120, ' ');
+                RAISE EXCEPTION '    ✗ %', rpad('Advancing slot ' || slot_name || ' to LSN ' || slot_lsn || ' (error: ' || SQLERRM || ')', 120, ' ');
         END;
     END LOOP;
 END;

--- a/sql/spock--5.0.6--5.0.7.sql
+++ b/sql/spock--5.0.6--5.0.7.sql
@@ -113,3 +113,13 @@ BEGIN
 	CALL spock.wait_for_sync_event(result, origin_id, lsn, timeout, wait_if_disabled);
 END;
 $$ LANGUAGE plpgsql;
+
+-- spock.sync_event() gained an optional 'transactional' boolean argument
+-- (default false). Drop the old zero-arg signature first so the upgrade
+-- doesn't leave behind two overloads with overlapping zero-arg resolution.
+DROP FUNCTION IF EXISTS spock.sync_event();
+CREATE FUNCTION spock.sync_event(transactional boolean DEFAULT false)
+RETURNS pg_lsn RETURNS NULL ON NULL INPUT
+AS 'MODULE_PATHNAME', 'spock_create_sync_event'
+LANGUAGE C VOLATILE;
+

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -3085,24 +3085,41 @@ spock_repair_mode(PG_FUNCTION_ARGS)
 /*
  * spock_create_sync_event
  *
- * This function creates a synchronization event on the provider. It leverages
- * the LogLogicalMessage API to log a custom message within the logical
- * replication framework. By doing so, it generates a unique Log Sequence Number
- * (LSN) that serves as a marker for synchronization purposes.
+ * Emit a SPOCK_SYNC_EVENT_MSG marker into the WAL via LogLogicalMessage and
+ * return the LSN of the message record. The LSN is intended for use with
+ * spock.wait_for_sync_event() on the subscriber side, which blocks until the
+ * marker has been decoded and applied.
  *
- * The generated LSN is returned to the caller and can be used by the
- * spock_wait_for_sync_event procedure on the subscriber side. Subscribers can
- * block and wait for this LSN to arrive, ensuring that all changes up to and
- * including the event have been replicated.
+ * The single boolean argument selects the transactional mode of the marker:
  *
- * an LSN is returned to caller.
+ *   transactional = false (default)
+ *       The message is written non-transactionally with an explicit WAL
+ *       flush, so the walsender wakes immediately and the apply worker on
+ *       the subscriber explicitly advances pg_replication_origin_status to
+ *       the marker's LSN as soon as it is applied. The marker is durable
+ *       regardless of the calling transaction's outcome - waiters cannot
+ *       hang because of a caller-side rollback. This is the right choice
+ *       when the LSN is used as a polling target (e.g. zodan add_node Phase
+ *       3 catchup wait against spock.progress.remote_commit_lsn).
+ *
+ *   transactional = true
+ *       The message is buffered with the surrounding transaction and
+ *       emitted at commit time, preserving order with the caller's DML.
+ *       wait_for_sync_event therefore implies that all DML committed
+ *       before the marker has also been applied. The trade-off: if the
+ *       calling transaction rolls back, the marker is discarded and any
+ *       waiter will hang until its own timeout fires.
+ *
+ * In both modes, an explicit WAL flush is performed so the walsender does
+ * not stall waiting for unrelated traffic.
  */
 Datum
 spock_create_sync_event(PG_FUNCTION_ARGS)
 {
-	SpockLocalNode		   *node;
-	SpockSyncEventMessage	message;
-	XLogRecPtr				lsn;
+	SpockLocalNode *node;
+	SpockSyncEventMessage message;
+	XLogRecPtr	lsn;
+	bool		transactional = PG_GETARG_BOOL(0);
 
 	node = check_local_node(true);
 	message.mtype = SPOCK_SYNC_EVENT_MSG;
@@ -3110,24 +3127,22 @@ spock_create_sync_event(PG_FUNCTION_ARGS)
 	memset(NameStr(message.ename), 0, NAMEDATALEN);
 
 	/*
-	 * Use a non-transactional message with flush. This bypasses the reorder
-	 * buffer so the walsender delivers it immediately, and the explicit WAL
-	 * flush wakes the walsender via WalSndWakeupProcessRequests.
-	 *
-	 * PG17+ has a 5th flush parameter; on PG15/16 we call XLogFlush manually.
-	 * Parentheses around the function name bypass the 4-arg compat macro on
-	 * PG17/18 so we can pass the 5th parameter directly.
+	 * PG17+ has a 5th flush parameter on LogLogicalMessage; on PG15/16 we
+	 * call XLogFlush manually. Parentheses around the function name bypass
+	 * the 4-arg compat macro on PG17/18 so we can pass the 5th parameter
+	 * directly.
 	 */
 #if PG_VERSION_NUM >= 170000
 	lsn = (LogLogicalMessage)(SPOCK_MESSAGE_PREFIX, (char *) &message,
-							  sizeof(message), false, true);
+							  sizeof(message), transactional, true);
 #else
 	lsn = LogLogicalMessage(SPOCK_MESSAGE_PREFIX, (char *) &message,
-							sizeof(message), false);
+							sizeof(message), transactional);
 	XLogFlush(lsn);
 #endif
 
-	elog(DEBUG1, "SPOCK sync_event: emitted non-transactional message at %X/%X",
+	elog(DEBUG1, "SPOCK sync_event: emitted %s message at %X/%X",
+		 transactional ? "transactional" : "non-transactional",
 		 LSN_FORMAT_ARGS(lsn));
 
 	PG_RETURN_LSN(lsn);


### PR DESCRIPTION
Phase 3 of zodan add_node must ensure the source node has applied every change from each "other" rec up to the new slot's consistent_point before the Phase 5 src->new COPY runs.  Otherwise rows in the interval (src_apply_progress, slot_consistent_point] are missing from the COPY and the disabled rec->new slot picks up from slot_consistent_point forward, so those rows silently never reach new.

The prior wait compared spock.progress.remote_commit_lsn (or, more recently, received_lsn) on src against the slot's consistent_point. Neither worked.  The slot LSN typically lands on a RUNNING_XACTS record well past the last actual commit on rec, so on a quiet cluster remote_commit_lsn never converges and the wait times out.  Switching to received_lsn made the wait converge fast but silently broke the invariant: received_lsn is bumped by keepalive messages reporting the remote walsender's flush position, so it can race past the slot LSN while zero rec changes have been applied on src.

Fix by emitting spock.sync_event() on rec *after* slot creation.  Its commit LSN is provably greater than the slot's consistent_point by WAL ordering, which gives remote_commit_lsn a reachable target.  Reaching it proves, by apply commit-order monotonicity, that every rec commit with commit_lsn <= slot_consistent_point is applied on src and visible to the COPY snapshot.  The same LSN replaces the pre-slot sync_event that Phase 8 wait_for_sync_event consumed on new -- a later sync target is strictly safer than an earlier one.

(cherry picked from commit b7fc7022482e7d2caa732fcc0505d342e8e7eaa6)