### PR TITLE
fix: guard replay-queue free against apply_replay_bytes integer overflow

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -3080,6 +3080,7 @@ stream_replay:
 			{
 				ApplyReplayEntry   *entry;
 				bool				queue_append;
+				bool				added_to_queue;
 				StringInfo			msg;
 				int					c;
 
@@ -3180,6 +3181,7 @@ stream_replay:
 					 * Append the entry to the end of the replay queue
 					 * if we read it from the stream but check for overflow.
 					 */
+					added_to_queue = false;
 					if (queue_append)
 					{
 						apply_replay_bytes += msg->len;
@@ -3195,6 +3197,7 @@ stream_replay:
 								apply_replay_tail->next = entry;
 								apply_replay_tail = entry;
 							}
+							added_to_queue = true;
 						}
 						else
 						{
@@ -3204,7 +3207,7 @@ stream_replay:
 
 					replication_handler(msg);
 
-					if (queue_append && apply_replay_overflow)
+					if (queue_append && apply_replay_overflow && !added_to_queue)
 					{
 						apply_replay_entry_free(entry);
 					}


### PR DESCRIPTION
apply_replay_bytes is a 32-bit signed int that accumulates WAL message sizes continuously throughout a large transaction, even after apply_replay_overflow is set.  Once it wraps past INT_MAX (~2.1 GB into overflow mode) it becomes negative, so the size check

    apply_replay_bytes < spock_replay_queue_size

evaluates true again.  The entry is then appended to the linked list AND freed immediately by the apply_replay_overflow guard, leaving a dangling pointer in the list.  When the transaction commits and apply_replay_queue_reset() iterates the list, it calls PQfreemem() on the already-freed copydata.data buffer, producing the glibc

    free(): double free detected in tcache 2

Fix: introduce added_to_queue, a per-iteration bool that is set only when the entry is actually linked into apply_replay_head/tail.  The free guard becomes `apply_replay_overflow && !added_to_queue`, so the free fires only when the entry is genuinely not in the list, regardless of what apply_replay_bytes does numerically.