### PR TITLE
Change apply_replay_bytes from int to uint64

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -159,7 +159,7 @@ static MemoryContext		ApplyReplayContext = NULL;
 static ApplyReplayEntry	   *apply_replay_head = NULL;
 static ApplyReplayEntry	   *apply_replay_tail = NULL;
 static ApplyReplayEntry	   *apply_replay_next = NULL;
-static int					apply_replay_bytes = 0;
+static uint64				apply_replay_bytes = 0;
 static bool					apply_replay_overflow = false;
 
 typedef struct SpockApplyFunctions


### PR DESCRIPTION
apply_replay_bytes is a 32-bit signed int that accumulates WAL message sizes continuously throughout a large transaction, even after apply_replay_overflow is set. Once it wraps past INT_MAX (~2.1 GB into overflow mode) it becomes negative, so the size check

apply_replay_bytes < spock_replay_queue_size

evaluates true again. The entry is then appended to the linked list AND freed immediately by the apply_replay_overflow guard, leaving a dangling pointer in the list. When the transaction commits and apply_replay_queue_reset() iterates the list, it calls PQfreemem() on the already-freed copydata.data buffer, producing the glibc

`free(): double free detected in tcache 2`

Fix: Make `apply_replay_bytes` a uint64.

Found by @rasifr 