### PR TITLE
Prepare v5.0.8 release.

### DIFF
--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -1,5 +1,13 @@
 # Spock Release Notes
 
+## Spock 5.0.8
+
+### Bug Fixes
+* Fix subscriber crash on transactions larger than 2 GB. `apply_replay_bytes`
+  was declared as `int`, causing signed-integer overflow and a crash when a
+  single replicated transaction exceeded 2 GB of WAL data. Changed to
+  `uint64`.
+
 ## Spock 5.0.7
 
 ### New Features

--- a/include/spock.h
+++ b/include/spock.h
@@ -24,8 +24,8 @@
 #include "spock_fe.h"
 #include "spock_node.h"
 
-#define SPOCK_VERSION "5.0.7"
-#define SPOCK_VERSION_NUM 50007
+#define SPOCK_VERSION "5.0.8"
+#define SPOCK_VERSION_NUM 50008
 
 #define EXTENSION_NAME "spock"
 #define SPOCK_SECLABEL_PROVIDER "spock"

--- a/sql/spock--5.0.7--5.0.8.sql
+++ b/sql/spock--5.0.7--5.0.8.sql
@@ -1,0 +1,6 @@
+/* spock--5.0.7--5.0.8.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION spock UPDATE TO '5.0.8'" to load this file. \quit
+
+-- No schema changes in 5.0.8.

--- a/tests/regress/expected/init.out
+++ b/tests/regress/expected/init.out
@@ -49,7 +49,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
                List of installed extensions
  Name  | Version | Schema |          Description           
 -------+---------+--------+--------------------------------
- spock | 5.0.7   | spock  | PostgreSQL Logical Replication
+ spock | 5.0.8   | spock  | PostgreSQL Logical Replication
 (1 row)
 
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super');

--- a/tests/regress/expected/init_1.out
+++ b/tests/regress/expected/init_1.out
@@ -49,7 +49,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
                         List of installed extensions
  Name  | Version | Default version | Schema |          Description           
 -------+---------+-----------------+--------+--------------------------------
- spock | 5.0.7   | 5.0.7           | spock  | PostgreSQL Logical Replication
+ spock | 5.0.8   | 5.0.8           | spock  | PostgreSQL Logical Replication
 (1 row)
 
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super');


### PR DESCRIPTION
Bump SPOCK_VERSION/SPOCK_VERSION_NUM to 5.0.8, add no-op spock--5.0.7--5.0.8.sql migration script, and add 5.0.8 release notes entry for the apply_replay_bytes int→uint64 crash fix.