### PR TITLE
Use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/src/spock.c
+++ b/src/spock.c
@@ -68,7 +68,14 @@
 #include "spock_shmem.h"
 #include "spock.h"
 
+#if PG_VERSION_NUM >= 180000
+PG_MODULE_MAGIC_EXT(
+	.name = "spock",
+	.version = SPOCK_VERSION
+);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 static const struct config_enum_entry SpockConflictResolvers[] = {
 	/*

--- a/src/spock_output.c
+++ b/src/spock_output.c
@@ -16,7 +16,16 @@
 
 #include "replication/logical.h"
 
+#include "spock.h"
+
+#if PG_VERSION_NUM >= 180000
+PG_MODULE_MAGIC_EXT(
+	.name = "spock_output",
+	.version = SPOCK_VERSION
+);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 extern void _PG_output_plugin_init(OutputPluginCallbacks *cb);
 


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.