### PR TITLE
Fix missing schema name in spock_version and spock_version_num docs

### DIFF
--- a/docs/spock_functions/functions/spock_version.md
+++ b/docs/spock_functions/functions/spock_version.md
@@ -1,10 +1,10 @@
 ## NAME
 
-`spock_version()`
+`spock.spock_version()`
 
 ### SYNOPSIS
 
-`spock_version ()`
+`spock.spock_version ()`
 
 ### DESCRIPTION
 
@@ -13,7 +13,7 @@ Returns the Spock version in a human-readable major/minor form (for example, `5.
 ### EXAMPLE
 
 ```sql
-postgres=# SELECT spock_version();
+postgres=# SELECT spock.spock_version();
  spock_version
 ---------------
  5.0.5

--- a/docs/spock_functions/functions/spock_version_num.md
+++ b/docs/spock_functions/functions/spock_version_num.md
@@ -1,10 +1,10 @@
 ## NAME
 
-spock_version_num()
+spock.spock_version_num()
 
 ### SYNOPSIS
 
-spock_version_num ()
+spock.spock_version_num ()
 
 ### RETURNS
 
@@ -33,6 +33,6 @@ This function takes no arguments.
 The following command returns the current Spock extension version as an
 integer:
 
-    postgres=# SELECT spock_version_num();
+    postgres=# SELECT spock.spock_version_num();
     -[ RECORD 1 ]-----+------
     spock_version_num | 50005


### PR DESCRIPTION
Fix missing schema name in spock_version and spock_version_num docs