### PR TITLE
Skip auto-DDL replication for commands referencing temporary relations

### DIFF
--- a/.github/workflows/installcheck-single-pg18.yml
+++ b/.github/workflows/installcheck-single-pg18.yml
@@ -1,0 +1,80 @@
+#
+# Single-PG18 Spock mesh installcheck (no Docker)
+#
+# Builds PostgreSQL REL_18_STABLE plus the Spock extension once, wires
+# three single-node PG18 clusters into a full Spock mesh
+# (6 subscriptions, exception_behaviour='discard', auto-DDL on),
+# stresses it with `make installcheck` against n1,
+# then asserts that every subscription is still enabled and that
+# spock.sync_event() round-trips on every directed edge.
+#
+# The whole thing is driven by tests/run-single-pg18-installcheck.sh, so
+# it runs identically on a developer laptop.  This workflow's job is
+# just: provision deps, invoke the script, save logs on failure.
+#
+# Dependency footprint is dictated by the script's ./configure flags:
+#
+#   --with-icu       -> libicu-dev
+#   --with-openssl   -> libssl-dev
+#   --with-readline  -> libreadline-dev
+#   --with-zstd      -> libzstd-dev
+#   --with-lz4       -> liblz4-dev
+#   (default zlib)   -> zlib1g-dev
+#   parser/scanner   -> bison, flex
+#   ICU pkg detect   -> pkg-config (preinstalled, listed for clarity)
+#
+# Everything else the script touches -- gcc, make, perl, git, rsync,
+# ca-certificates -- is preinstalled on ubuntu-latest.  If you change
+# the configure command in the script, sync this list with it.
+#
+
+name: Installcheck (single-PG18 mesh)
+run-name: Single-PG18 mesh installcheck + sync_event verification
+
+on:
+  workflow_dispatch:          # manual: "Run workflow" button in the UI
+  push:                       # automatic: every commit on every branch
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  installcheck-single-pg18:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout spock
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            --no-install-recommends \
+              bison flex pkg-config \
+              libicu-dev libssl-dev libreadline-dev \
+              libzstd-dev liblz4-dev zlib1g-dev
+
+      - name: Run single-PG18 installcheck
+        run: |
+          # BASE_DIR defaults to <repo>/single-pg18-installcheck which in CI
+          # is ${GITHUB_WORKSPACE}/single-pg18-installcheck -- exactly the
+          # paths the upload-artifact step below points at.
+          ./tests/run-single-pg18-installcheck.sh --jobs "$(nproc)"
+
+      - name: Collect logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: installcheck-single-pg18-logs
+          path: |
+            single-pg18-installcheck/log/**
+            single-pg18-installcheck/src/pg18/src/test/regress/regression.diffs
+            single-pg18-installcheck/src/pg18/src/test/regress/regression.out
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ spock.control
 tags
 .vscode
 tmp/
+
+# Single-PG18 installcheck test rig (tests/run-single-pg18-installcheck.sh).
+# Contains the PG clone, build, install, PGDATA dirs and logs; can grow to
+# several gigabytes.  Always ignored -- re-create by running the script.
+# Deliberately not dot-prefixed so the directory is visible in Finder / ls
+# and easy to inspect.
+single-pg18-installcheck/

--- a/include/spock.h
+++ b/include/spock.h
@@ -97,7 +97,7 @@ extern int64 sequence_get_last_value(Oid seqoid);
 
 extern bool in_spock_replicate_ddl_command;
 extern bool in_spock_queue_ddl_command;
-extern void spock_auto_replicate_ddl(const char *query, List *replication_sets,
+extern bool spock_auto_replicate_ddl(const char *query, List *replication_sets,
 									 Oid roleoid, Node *stmt);
 
 /* spock_readonly.c */

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1970,6 +1970,19 @@ handle_truncate(StringInfo s)
 				 * restore ApplyOperationContext for the code below.
 				 */
 				MemoryContextSwitchTo(ApplyOperationContext);
+
+				/*
+				 * apply_truncate() opens its target relations inside the
+				 * subtransaction we just rolled back -- unlike
+				 * handle_insert/update/delete, which open the relation in the
+				 * parent transaction.  The abort released those relation
+				 * references, but the Spock relation cache still holds the
+				 * now-stale ->rel handles (the spock_relation_close() calls at
+				 * the tail of apply_truncate() never ran).  Invalidate the
+				 * cache so the next open re-resolves the relation instead of
+				 * returning a dangling Relation pointer.
+				 */
+				spock_relation_cache_reset();
 			}
 			PG_END_TRY();
 

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -94,11 +94,18 @@ spock_autoddl_process(PlannedStmt *pstmt,
 	queryString = CleanQuerytext(queryString, &loc, &len);
 	curr_qry = pnstrdup(queryString, len);
 
-	spock_auto_replicate_ddl(curr_qry,
-							 list_make1(DEFAULT_INSONLY_REPSET_NAME),
-							 GetUserId(),
-							 parsetree);
-	add_ddl_to_repset(parsetree);
+	/*
+	 * Only track the affected relation in the replication set if the command
+	 * was actually queued for replication.  If replication was skipped (for
+	 * example because the statement references a temporary relation), adding
+	 * the table here would let its later DML replicate to subscribers that
+	 * never received the CREATE, stalling the apply worker.
+	 */
+	if (spock_auto_replicate_ddl(curr_qry,
+								 list_make1(DEFAULT_INSONLY_REPSET_NAME),
+								 GetUserId(),
+								 parsetree))
+		add_ddl_to_repset(parsetree);
 
 end:
 	/* Restore previous session privileges */

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2351,13 +2351,81 @@ spock_replicate_ddl_command(PG_FUNCTION_ARGS)
 }
 
 /*
+ * query_temp_like_source
+ *
+ * Auto-DDL ships the raw text of a command to be re-parsed and executed on the
+ * subscriber.  A CREATE TABLE may copy the definition of another relation with
+ * a LIKE clause; if that source relation is temporary, the shipped command
+ * would fail on the subscriber, where the temporary relation does not exist.
+ *
+ * We cannot inspect the executed parse tree for this: by the time auto-DDL runs
+ * (post-execution) transformCreateStmt() has already expanded the LIKE clause
+ * out of CreateStmt->tableElts, so the TableLikeClause is gone.  Instead we
+ * re-parse the raw command text -- the exact text we are about to ship and the
+ * subscriber will re-parse -- which still carries the LIKE clause untouched.
+ *
+ * The parse tree's relpersistence flag is only meaningful for the object being
+ * declared -- referenced RangeVars default to RELPERSISTENCE_PERMANENT
+ * regardless of what they actually resolve to -- so we resolve each LIKE source
+ * against the catalogue and inspect its real persistence.  Name resolution uses
+ * the current search_path (where pg_temp is normally first), matching what the
+ * executor did on the origin.
+ *
+ * Returns the offending RangeVar (for a useful error message) or NULL if no
+ * temporary relation is referenced.  Note that this detects only relations
+ * named directly in the statement; a temporary relation reached indirectly
+ * (e.g. through a function body) is not visible here.
+ */
+static RangeVar *
+query_temp_like_source(const char *query)
+{
+	ListCell   *rawlc;
+
+	foreach(rawlc, pg_parse_query(query))
+	{
+		RawStmt    *raw = lfirst_node(RawStmt, rawlc);
+		CreateStmt *cstmt;
+		ListCell   *cell;
+
+		if (!IsA(raw->stmt, CreateStmt))
+			continue;
+
+		cstmt = (CreateStmt *) raw->stmt;
+		foreach(cell, cstmt->tableElts)
+		{
+			TableLikeClause *like;
+			Oid			relid;
+
+			if (!IsA(lfirst(cell), TableLikeClause))
+				continue;
+
+			like = (TableLikeClause *) lfirst(cell);
+			relid = RangeVarGetRelid(like->relation, AccessShareLock, true);
+
+			if (OidIsValid(relid) &&
+				get_rel_persistence(relid) == RELPERSISTENCE_TEMP)
+				return like->relation;
+		}
+	}
+
+	return NULL;
+}
+
+/*
  * spock_auto_replicate_ddl
  *
  * Add the DDL statement to the spock.queue table so it can
  * be replicated to connected nodes. It also sends the current
  * search_path along with the query.
+ *
+ * Returns true if the statement was queued for replication, or false if it was
+ * skipped (e.g. a purely local command, or one that references a temporary
+ * relation that does not exist on other nodes).  The caller uses this to decide
+ * whether the affected relation should be added to the replication set: a table
+ * whose creation was not replicated must not be tracked, or its later DML would
+ * fail to apply on the subscriber.
  */
-void
+bool
 spock_auto_replicate_ddl(const char *query, List *replication_sets,
 						 Oid roleoid, Node *stmt)
 {
@@ -2441,13 +2509,50 @@ spock_auto_replicate_ddl(const char *query, List *replication_sets,
 				if (castNode(Query, ctas->query)->commandType == CMD_UTILITY &&
 					IsA(castNode(Query, ctas->query)->utilityStmt, ExecuteStmt))
 					goto skip_ddl;
+
+				/*
+				 * The defining query is re-executed verbatim on the subscriber.
+				 * If it reads a temporary relation -- at any nesting level --
+				 * it would fail there, so let the local command stand but skip
+				 * replication and say why.  isQueryUsingTempRelation() walks the
+				 * whole analysed query tree.
+				 */
+				if (isQueryUsingTempRelation(castNode(Query, ctas->query)))
+				{
+					ereport(spock_enable_quiet_mode ? LOG : WARNING,
+							(errmsg("CREATE TABLE AS reads a temporary relation"),
+							 errdetail("Temporary relations are session-private and do not exist on other nodes.")));
+					goto skip_ddl;
+				}
 				warn = true;
 			}
 			break;
 
 		case T_CreateStmt:
-			if (castNode(CreateStmt, stmt)->relation->relpersistence == RELPERSISTENCE_TEMP)
-				goto skip_ddl;
+			{
+				CreateStmt *cstmt = castNode(CreateStmt, stmt);
+				RangeVar   *tmpsrc;
+
+				if (cstmt->relation->relpersistence == RELPERSISTENCE_TEMP)
+					goto skip_ddl;
+
+				/*
+				 * A permanent table whose definition is copied from a
+				 * temporary one via LIKE cannot be replicated: the shipped
+				 * command text would fail on the subscriber, where the
+				 * temporary source relation does not exist.  Let the local
+				 * command stand, but skip replication and say why.
+				 */
+				tmpsrc = query_temp_like_source(query);
+				if (tmpsrc != NULL)
+				{
+					ereport(spock_enable_quiet_mode ? LOG : WARNING,
+							(errmsg("CREATE TABLE copies the definition of temporary relation \"%s\"",
+									tmpsrc->relname),
+							 errdetail("Temporary relations are session-private and do not exist on other nodes.")));
+					goto skip_ddl;
+				}
+			}
 			break;
 
 		case T_CreateSeqStmt:
@@ -2557,12 +2662,11 @@ spock_auto_replicate_ddl(const char *query, List *replication_sets,
 
 				if (analyze &&
 					castNode(Query, estmt->query)->commandType == CMD_UTILITY)
-				{
-					spock_auto_replicate_ddl(query, replication_sets, roleoid,
-											 castNode(Query, estmt->query)->utilityStmt);
-				}
+					return spock_auto_replicate_ddl(query, replication_sets,
+													roleoid,
+													castNode(Query, estmt->query)->utilityStmt);
 
-				return;			/* nothing more to do. */
+				return false;	/* EXPLAIN without ANALYZE: nothing replicated. */
 			}
 			break;
 
@@ -2598,10 +2702,11 @@ spock_auto_replicate_ddl(const char *query, List *replication_sets,
 	/* Queue the query for replication. */
 	queue_message(replication_sets, roleoid, QUEUE_COMMAND_TYPE_DDL, cmd.data);
 
-	return;
+	return true;
 
 skip_ddl:
 	elog(spock_enable_quiet_mode ? LOG : WARNING, "This DDL statement will not be replicated.");
+	return false;
 }
 
 

--- a/tests/regress/expected/autoddl.out
+++ b/tests/regress/expected/autoddl.out
@@ -138,6 +138,44 @@ SELECT count(*) FROM test_ns_schema_1.abc;
      1
 (1 row)
 
+-- A temporary relation is never replicated, so a permanent table that copies
+-- its definition (LIKE) or its data (CREATE TABLE AS) cannot be auto-replicated:
+-- the shipped command text would fail on the subscriber, where the temporary
+-- relation does not exist.  Auto-DDL creates the table locally but skips
+-- replication and explains why.
+\c :provider_dsn
+CREATE TEMP TABLE autoddl_temp_src (a int primary key, b text);
+WARNING:  This DDL statement will not be replicated.
+-- CREATE TABLE ... (LIKE temp): created locally, replication skipped with a reason
+CREATE TABLE autoddl_perm_like (LIKE autoddl_temp_src);
+WARNING:  CREATE TABLE copies the definition of temporary relation "autoddl_temp_src"
+DETAIL:  Temporary relations are session-private and do not exist on other nodes.
+WARNING:  This DDL statement will not be replicated.
+-- CREATE TABLE AS reading a temp relation: created locally, replication skipped
+CREATE TABLE autoddl_perm_ctas AS SELECT * FROM autoddl_temp_src;
+WARNING:  CREATE TABLE AS reads a temporary relation
+DETAIL:  Temporary relations are session-private and do not exist on other nodes.
+WARNING:  This DDL statement will not be replicated.
+-- A temp relation nested in a subquery is still detected
+CREATE TABLE autoddl_perm_ctas2 AS
+    SELECT * FROM (SELECT a FROM autoddl_temp_src) s;
+WARNING:  CREATE TABLE AS reads a temporary relation
+DETAIL:  Temporary relations are session-private and do not exist on other nodes.
+WARNING:  This DDL statement will not be replicated.
+-- Sanity: copying a permanent relation with LIKE still replicates normally
+CREATE TABLE autoddl_perm_src (a int primary key, b text);
+INFO:  DDL statement replicated.
+CREATE TABLE autoddl_perm_like_ok (LIKE autoddl_perm_src);
+INFO:  DDL statement replicated.
+-- Clean up (IF EXISTS: the temp-derived tables were never created on the subscriber)
+DROP TABLE IF EXISTS autoddl_perm_like, autoddl_perm_ctas, autoddl_perm_ctas2;
+INFO:  DDL statement replicated.
+DROP TABLE IF EXISTS autoddl_perm_like_ok, autoddl_perm_src;
+NOTICE:  drop cascades to table autoddl_perm_like_ok membership in replication set default_insert_only
+NOTICE:  drop cascades to table autoddl_perm_src membership in replication set default
+INFO:  DDL statement replicated.
+DROP TABLE autoddl_temp_src;
+INFO:  DDL statement replicated.
 -- Reset the configuration to the default value
 \c :provider_dsn
 ALTER SYSTEM SET spock.enable_ddl_replication = 'off';

--- a/tests/regress/sql/autoddl.sql
+++ b/tests/regress/sql/autoddl.sql
@@ -86,6 +86,33 @@ CALL spock.wait_for_sync_event(true, 'test_provider', :'sync_event');
 SELECT count(*) FROM spock.tables where nspname = 'test_ns_schema_1' AND set_name IS NOT NULL;
 SELECT count(*) FROM test_ns_schema_1.abc;
 
+-- A temporary relation is never replicated, so a permanent table that copies
+-- its definition (LIKE) or its data (CREATE TABLE AS) cannot be auto-replicated:
+-- the shipped command text would fail on the subscriber, where the temporary
+-- relation does not exist.  Auto-DDL creates the table locally but skips
+-- replication and explains why.
+\c :provider_dsn
+CREATE TEMP TABLE autoddl_temp_src (a int primary key, b text);
+
+-- CREATE TABLE ... (LIKE temp): created locally, replication skipped with a reason
+CREATE TABLE autoddl_perm_like (LIKE autoddl_temp_src);
+
+-- CREATE TABLE AS reading a temp relation: created locally, replication skipped
+CREATE TABLE autoddl_perm_ctas AS SELECT * FROM autoddl_temp_src;
+
+-- A temp relation nested in a subquery is still detected
+CREATE TABLE autoddl_perm_ctas2 AS
+    SELECT * FROM (SELECT a FROM autoddl_temp_src) s;
+
+-- Sanity: copying a permanent relation with LIKE still replicates normally
+CREATE TABLE autoddl_perm_src (a int primary key, b text);
+CREATE TABLE autoddl_perm_like_ok (LIKE autoddl_perm_src);
+
+-- Clean up (IF EXISTS: the temp-derived tables were never created on the subscriber)
+DROP TABLE IF EXISTS autoddl_perm_like, autoddl_perm_ctas, autoddl_perm_ctas2;
+DROP TABLE IF EXISTS autoddl_perm_like_ok, autoddl_perm_src;
+DROP TABLE autoddl_temp_src;
+
 -- Reset the configuration to the default value
 \c :provider_dsn
 ALTER SYSTEM SET spock.enable_ddl_replication = 'off';

--- a/tests/run-single-pg18-installcheck.sh
+++ b/tests/run-single-pg18-installcheck.sh
@@ -1,0 +1,802 @@
+#!/usr/bin/env bash
+#
+# tests/run-single-pg18-installcheck.sh
+#
+# Build PostgreSQL REL_18_STABLE once, build the Spock extension against
+# it once, then start THREE single-node clusters (n1..n3, all PG18,
+# sharing the same install) wired into a full Spock mesh (6
+# subscriptions, exception_behaviour='discard', auto-DDL on), run
+# `make installcheck` against node n1, and verify every subscription is
+# still enabled afterwards and that spock.sync_event() round-trips on
+# every edge.
+#
+# Compatible with bash 3.2 (macOS /bin/bash) -- no associative arrays.
+#
+# There is only ONE build pipeline (clone PG, build PG, build Spock), so
+# it runs in the foreground; only the three initdb+start steps are
+# per-node.
+#
+# Layout (under BASE_DIR, default <spock-repo>/single-pg18-installcheck):
+#   src/pg18               PG source clone
+#   bin/pg18               PG install (configure --prefix)
+#   spock-build/pg18       Spock source copy + build artefacts
+#   pgdata/n1..n3          PGDATA per node
+#   log/                   per-instance log files (build phases are logged
+#                          under the pseudo-node name 'pg18')
+#   sock/                  unix-socket dir shared by all nodes
+#
+# Node mapping (all PG18):
+#   n1 -> port 57601
+#   n2 -> port 57602
+#   n3 -> port 57603
+#
+# Subscription naming:
+#   sub_<provider>_<subscriber>; e.g. sub_n1_n2 lives on n2 and pulls from n1.
+#
+# Usage:
+#   tests/run-single-pg18-installcheck.sh [--base-dir DIR] [--keep] \
+#                                         [--force] [--jobs N]
+#
+# Existing PG installs (bin/postgres present) and Spock installs
+# (extension/spock.control present) are reused by default to speed up
+# re-runs.  Pass --force to rebuild everything from scratch.
+#
+# Exit status:
+#   0  every Spock subscription on every node is still enabled
+#      (sub_enabled = true)  AND  a spock.sync_event() fired on each
+#      provider was applied on every other node within
+#      SYNC_EVENT_TIMEOUT seconds.  Regression-suite pass/fail is
+#      logged but does NOT influence the exit code -- the installcheck
+#      workload is used as stress; the only success signal is the
+#      surviving mesh.
+#   2  one or more subscriptions ended up disabled, OR sync_event
+#      failed to propagate on at least one edge within
+#      SYNC_EVENT_TIMEOUT seconds.
+#   >2 build / setup error.
+#
+
+# Deliberately NOT using `-E` (errtrace): with -E the ERR trap leaks into
+# command substitutions and a single transient psql failure could shut
+# everything down.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPOCK_SRC="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Default base dir lives inside the spock repo so all artefacts are
+# contained next to the source.  Distinct from the multi-version rig's
+# directory so the two can coexist.  Overridden by --base-dir.
+BASE_DIR="${SPOCK_SRC}/single-pg18-installcheck"
+KEEP_RUNNING=1
+FORCE_REBUILD=0
+JOBS_TOTAL="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+PG_VER=18
+NODES="n1 n2 n3"
+
+DBNAME=regression
+DBUSER=regression
+TARGET_NODE=n1   # node we run `make installcheck` against
+
+PG_GIT_REMOTES="https://git.postgresql.org/git/postgresql.git https://github.com/postgres/postgres.git"
+
+# ---------------------------------------------------------------------------
+# Bash-3-safe lookup helpers (no `declare -A`)
+# ---------------------------------------------------------------------------
+
+# Ports deliberately differ from the multi-version rig (57516..57518)
+# so both rigs can run simultaneously.
+node_to_port() {
+	case "$1" in
+		n1) echo 57601 ;;
+		n2) echo 57602 ;;
+		n3) echo 57603 ;;
+		*)  return 1 ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# Logging / error trap
+# ---------------------------------------------------------------------------
+
+# log() writes only to disk -- the terminal stays clean.  Output goes to
+# the caller's $NODE_LOG when set, otherwise to $MAIN_LOG.
+log() {
+	local msg
+	msg="[$(date +%H:%M:%S)] $*"
+	if [ -n "${NODE_LOG:-}" ]; then
+		printf '%s\n' "${msg}" >>"${NODE_LOG}"
+	elif [ -n "${MAIN_LOG:-}" ]; then
+		printf '%s\n' "${msg}" >>"${MAIN_LOG}"
+	fi
+}
+
+# say() is for the few things the user must see on the terminal.
+say() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+
+fail() { say "FATAL: $1"; log "FATAL: $1"; exit "${2:-3}"; }
+
+# run_phase LABEL PHASE CMD ARGS...
+#   Runs CMD with stdout+stderr captured to ${LOG_DIR}/<label>-<phase>.log
+#   and emits a single end-of-phase OK/FAILED line on the terminal.
+run_phase() {
+	local label="$1" phase="$2"
+	shift 2
+	local logf="${LOG_DIR}/${label}-${phase}.log"
+	log "${label}: [${phase}] start  -> ${logf}"
+	local rc=0
+	"$@" >"${logf}" 2>&1 || rc=$?
+	if [ "${rc}" -ne 0 ]; then
+		log "${label}: [${phase}] FAILED rc=${rc}  (see ${logf})"
+		say "${label}: ${phase} FAILED rc=${rc}  (see ${logf})"
+		return "${rc}"
+	fi
+	log "${label}: [${phase}] ok"
+	say "${label}: ${phase} ok"
+}
+
+trap 'on_err $? $LINENO' ERR
+
+on_err() {
+	local rc=$1 line=$2
+	log "Aborted: exit ${rc} at line ${line}"
+	say "see ${LOG_DIR}/ for per-instance log files"
+	exit "${rc}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+usage() {
+	awk 'NR>1 { if ($0 !~ /^#/) exit; print }' "$0"
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--base-dir)         BASE_DIR="$2"; shift 2 ;;
+		--keep)             KEEP_RUNNING=1; shift ;;
+		--force)            FORCE_REBUILD=1; shift ;;
+		--jobs)             JOBS_TOTAL="$2"; shift 2 ;;
+		-h|--help)          usage; exit 0 ;;
+		*)                  fail "unknown argument: $1" 4 ;;
+	esac
+done
+
+mkdir -p "${BASE_DIR}/src"          \
+         "${BASE_DIR}/bin"          \
+         "${BASE_DIR}/spock-build"  \
+         "${BASE_DIR}/pgdata"       \
+         "${BASE_DIR}/log"          \
+         "${BASE_DIR}/sock"
+BASE_DIR="$(cd "${BASE_DIR}" && pwd)"
+SOCK_DIR="${BASE_DIR}/sock"
+LOG_DIR="${BASE_DIR}/log"
+
+# Fresh log directory per run; src/, bin/, spock-build/, and pgdata/
+# are preserved so reuse-on-rerun still works.
+rm -rf "${LOG_DIR}"
+mkdir -p "${LOG_DIR}"
+
+MAIN_LOG="${LOG_DIR}/main.log"
+: >"${MAIN_LOG}"
+
+log "BASE_DIR   = ${BASE_DIR}"
+log "SPOCK_SRC  = ${SPOCK_SRC}"
+log "JOBS_TOTAL = ${JOBS_TOTAL}"
+log "PG_VER     = ${PG_VER}"
+log "NODES      = ${NODES}"
+
+# ---------------------------------------------------------------------------
+# Path helpers (single shared install)
+# ---------------------------------------------------------------------------
+
+PREFIX="${BASE_DIR}/bin/pg${PG_VER}"
+SRC="${BASE_DIR}/src/pg${PG_VER}"
+SPOCK_BUILD="${BASE_DIR}/spock-build/pg${PG_VER}"
+PG_CONFIG="${PREFIX}/bin/pg_config"
+
+data_for() { echo "${BASE_DIR}/pgdata/$1"; }
+
+# DSN that talks over the shared Unix socket directory.
+dsn_for_node() {
+	local node="$1"
+	local port; port="$(node_to_port "${node}")"
+	echo "host=${SOCK_DIR} port=${port} dbname=${DBNAME} user=${DBUSER}"
+}
+
+# Run psql against a node (all nodes share the same client binaries).
+psql_on() {
+	local node="$1"; shift
+	local port; port="$(node_to_port "${node}")"
+	PGPASSWORD="" "${PREFIX}/bin/psql" \
+		-X -v ON_ERROR_STOP=1 \
+		-h "${SOCK_DIR}" -p "${port}" \
+		-U "${DBUSER}" -d "${DBNAME}" \
+		"$@"
+}
+
+# ---------------------------------------------------------------------------
+# Build pipeline: clone + build PG + build Spock (once, shared by all nodes)
+# ---------------------------------------------------------------------------
+
+pick_pg_remote() {
+	local r
+	for r in ${PG_GIT_REMOTES}; do
+		if git ls-remote --exit-code --heads "${r}" "REL_${PG_VER}_STABLE" \
+				>/dev/null 2>&1; then
+			echo "${r}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+_do_clone_pg() {
+	local remote="$1"
+	local branch="REL_${PG_VER}_STABLE"
+	rm -rf "${SRC}"
+	git clone --depth=1 --single-branch --branch "${branch}" \
+		"${remote}" "${SRC}"
+}
+
+clone_pg() {
+	local branch="REL_${PG_VER}_STABLE"
+
+	if [ -d "${SRC}/.git" ] \
+		&& [ -f "${SRC}/src/test/regress/parallel_schedule" ]; then
+		log "pg${PG_VER}: [pg-clone] source already present, skipping"
+		return 0
+	fi
+
+	local remote
+	remote="$(pick_pg_remote)" \
+		|| fail "PG${PG_VER}: no reachable git remote for ${branch}" 5
+
+	log "pg${PG_VER}: [pg-clone] ${branch} from ${remote}"
+	run_phase "pg${PG_VER}" pg-clone _do_clone_pg "${remote}"
+}
+
+# Spock needs Postgres with per-version patches applied; patches live
+# in patches/<ver>/ in the spock tree, applied in lexical order via
+# `git apply`.  A marker file makes the phase idempotent.
+_do_patch_pg() {
+	local patch_dir="$1"
+	if [ ! -d "${patch_dir}" ]; then
+		echo "no patch directory ${patch_dir} -- nothing to do"
+		return 0
+	fi
+	local p any=0
+	for p in "${patch_dir}"/*.diff "${patch_dir}"/*.patch; do
+		[ -f "${p}" ] || continue
+		any=1
+		echo "----- applying $(basename "${p}") -----"
+		( cd "${SRC}" && git apply --whitespace=nowarn -p1 "${p}" )
+	done
+	if [ "${any}" -eq 0 ]; then
+		echo "no .diff/.patch files in ${patch_dir}"
+	fi
+	touch "${SRC}/.spock-patches-applied"
+}
+
+patch_pg() {
+	local patch_dir="${SPOCK_SRC}/patches/${PG_VER}"
+
+	if [ -f "${SRC}/.spock-patches-applied" ]; then
+		log "pg${PG_VER}: [pg-patch] patches already applied (marker present), skipping"
+		return 0
+	fi
+	run_phase "pg${PG_VER}" pg-patch _do_patch_pg "${patch_dir}"
+}
+
+_do_configure_pg() {
+	cd "${SRC}"
+	./configure --prefix="${PREFIX}" --enable-debug --enable-cassert \
+		--with-icu --with-openssl --with-readline --with-zstd --with-lz4
+}
+
+_do_build_pg() {
+	local jobs="$1"
+	make -C "${SRC}" -s -j"${jobs}"
+	make -C "${SRC}" -s -j"${jobs}" install
+	# Install pg_regress so `make installcheck` later can find it via $bindir.
+	make -C "${SRC}/src/test/regress" -s install
+}
+
+build_pg() {
+	if [ "${FORCE_REBUILD}" -eq 0 ] && [ -x "${PREFIX}/bin/postgres" ]; then
+		log "pg${PG_VER}: [pg-build] reusing existing install at ${PREFIX}"
+		return 0
+	fi
+
+	run_phase "pg${PG_VER}" pg-configure _do_configure_pg
+	run_phase "pg${PG_VER}" pg-build     _do_build_pg "${JOBS_TOTAL}"
+}
+
+# Spock builds in its own copy of the source tree.  `make clean` after
+# the rsync evicts any build artefacts a manual `make` in the repo root
+# may have left behind (objects compiled against the wrong PG headers
+# would otherwise be installed verbatim).
+_do_build_spock() {
+	local jobs="$1"
+	rm -rf "${SPOCK_BUILD}"
+	mkdir -p "${SPOCK_BUILD}"
+	rsync -a \
+		--exclude='/single-pg18-installcheck' \
+		--exclude='/.git' \
+		--exclude='.DS_Store' \
+		"${SPOCK_SRC}/" "${SPOCK_BUILD}/"
+	make -C "${SPOCK_BUILD}" PG_CONFIG="${PG_CONFIG}" clean
+	make -C "${SPOCK_BUILD}" PG_CONFIG="${PG_CONFIG}" -j"${jobs}"
+	make -C "${SPOCK_BUILD}" PG_CONFIG="${PG_CONFIG}" install
+}
+
+build_spock() {
+	if [ "${FORCE_REBUILD}" -eq 0 ] \
+		&& [ -f "$("${PG_CONFIG}" --sharedir)/extension/spock.control" ]; then
+		log "pg${PG_VER}: [spock-build] reusing existing install"
+		return 0
+	fi
+
+	run_phase "pg${PG_VER}" spock-build _do_build_spock "${JOBS_TOTAL}"
+}
+
+# ---------------------------------------------------------------------------
+# Per-node initdb + start
+# ---------------------------------------------------------------------------
+
+_do_initdb() {
+	local data="$1"
+	"${PREFIX}/bin/initdb" -D "${data}" -U "${DBUSER}" \
+		--encoding=UTF8 --locale=C
+}
+
+init_node() {
+	local node="$1"
+	local data; data="$(data_for "${node}")"
+	local port; port="$(node_to_port "${node}")"
+
+	if [ -d "${data}" ]; then
+		log "${node}: [initdb] clearing existing data dir"
+		rm -rf "${data}"
+	fi
+	run_phase "${node}" initdb _do_initdb "${data}"
+
+	cat >>"${data}/postgresql.conf" <<-EOF
+		# --- single-PG18 installcheck test rig ---
+		listen_addresses = ''
+		unix_socket_directories = '${SOCK_DIR}'
+		port = ${port}
+		max_connections = 200
+
+		wal_level = logical
+		track_commit_timestamp = on
+		max_worker_processes = 32
+		max_replication_slots = 32
+		max_wal_senders = 32
+
+		log_min_messages = 'log'
+		log_statement = 'none'
+		logging_collector = off
+
+		shared_preload_libraries = 'spock'
+		spock.conflict_resolution = 'last_update_wins'
+		spock.exception_behaviour = 'discard'
+		spock.save_resolutions = on
+
+		# Replicate DDL automatically across the mesh, and add any tables
+		# created by that DDL to the default replication set.
+		spock.enable_ddl_replication = on
+		spock.include_ddl_repset    = on
+		spock.allow_ddl_from_functions = on
+	EOF
+
+	# Trust on the shared Unix socket; no TCP listener so this is local-only.
+	cat >>"${data}/pg_hba.conf" <<-EOF
+		local all all trust
+		local replication all trust
+	EOF
+}
+
+_do_pg_ctl_start() {
+	local data="$1" server_log="$2"
+	"${PREFIX}/bin/pg_ctl" -D "${data}" -l "${server_log}" -w -t 60 start
+}
+
+start_node() {
+	local node="$1"
+	local data; data="$(data_for "${node}")"
+	run_phase "${node}" pg-start _do_pg_ctl_start \
+		"${data}" "${LOG_DIR}/${node}-server.log"
+}
+
+stop_node() {
+	local node="$1"
+	local data; data="$(data_for "${node}")"
+	if [ -f "${data}/postmaster.pid" ]; then
+		log "${node}: pg_ctl stop"
+		"${PREFIX}/bin/pg_ctl" -D "${data}" -m fast -w -t 60 stop || true
+	fi
+}
+
+stop_all_nodes() {
+	local node
+	for node in ${NODES}; do stop_node "${node}"; done
+}
+
+# ---------------------------------------------------------------------------
+# pg_isready probe for each node
+# ---------------------------------------------------------------------------
+
+wait_for_ready() {
+	local node="$1"
+	local port; port="$(node_to_port "${node}")"
+	local deadline=$(( $(date +%s) + 60 ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		if "${PREFIX}/bin/pg_isready" -q \
+				-h "${SOCK_DIR}" -p "${port}" -d "${DBNAME}" -U "${DBUSER}"; then
+			log "${node}: pg_isready OK"
+			return 0
+		fi
+		sleep 1
+	done
+	log "${node}: pg_isready did not become ready within 60s"
+	return 1
+}
+
+wait_for_all_ready() {
+	local node rc=0
+	for node in ${NODES}; do
+		wait_for_ready "${node}" || rc=1
+	done
+	return ${rc}
+}
+
+# ---------------------------------------------------------------------------
+# DB + Spock bootstrap (after all servers are up)
+# ---------------------------------------------------------------------------
+
+_do_createdb() {
+	local port="$1"
+	"${PREFIX}/bin/createdb" -h "${SOCK_DIR}" -p "${port}" \
+		-U "${DBUSER}" -O "${DBUSER}" "${DBNAME}"
+}
+
+create_db_for_node() {
+	local node="$1"
+	local port; port="$(node_to_port "${node}")"
+	run_phase "${node}" createdb _do_createdb "${port}"
+}
+
+setup_spock_node() {
+	local node="$1"
+	local logf="${LOG_DIR}/${node}-spock-bootstrap.log"
+	log "${node}: [spock-bootstrap] CREATE EXTENSION + node_create  -> ${logf}"
+	{
+		psql_on "${node}" -c "CREATE EXTENSION IF NOT EXISTS spock;"
+		psql_on "${node}" <<-SQL
+			SELECT spock.node_create(
+				node_name := '${node}',
+				dsn       := '$(dsn_for_node "${node}")'
+			);
+		SQL
+	} >>"${logf}" 2>&1
+}
+
+create_subscription() {
+	local provider="$1" subscriber="$2"
+	local subname="sub_${provider}_${subscriber}"
+	local provider_dsn; provider_dsn="$(dsn_for_node "${provider}")"
+	local logf="${LOG_DIR}/${subscriber}-spock-bootstrap.log"
+
+	log "${subscriber}: [spock-bootstrap] sub_create ${subname} <- ${provider}"
+	psql_on "${subscriber}" >>"${logf}" 2>&1 <<-SQL
+		SELECT spock.sub_create(
+			subscription_name     := '${subname}',
+			provider_dsn          := '${provider_dsn}',
+			synchronize_structure := false,
+			synchronize_data      := false,
+			forward_origins       := '{}'::text[],
+			enabled               := true
+		);
+	SQL
+}
+
+wire_full_mesh() {
+	local subscriber provider
+	for subscriber in ${NODES}; do
+		for provider in ${NODES}; do
+			[ "${provider}" = "${subscriber}" ] && continue
+			create_subscription "${provider}" "${subscriber}"
+		done
+	done
+}
+
+# ---------------------------------------------------------------------------
+# Run `make installcheck` against the target node
+# ---------------------------------------------------------------------------
+
+run_installcheck() {
+	local node="${TARGET_NODE}"
+	local port; port="$(node_to_port "${node}")"
+
+	log "${node} (PG${PG_VER}): make installcheck-parallel"
+
+	# --use-existing is critical: without it pg_regress tries DROP DATABASE
+	# regression, which fails while Spock holds live replication slots into
+	# that database.
+	set +e
+	(
+		cd "${SRC}/src/test/regress"
+		PATH="${PREFIX}/bin:${PATH}" \
+		PGHOST="${SOCK_DIR}" PGPORT="${port}" \
+		PGUSER="${DBUSER}" PGDATABASE="${DBNAME}" \
+		make -k installcheck-parallel \
+			USE_INSTALLED=1 \
+			EXTRA_REGRESS_OPTS="--use-existing --host=${SOCK_DIR} --port=${port} --user=${DBUSER}"
+	) >"${LOG_DIR}/installcheck.log" 2>&1
+	local rc=$?
+	set -e
+
+	# Regression-suite failures are expected -- Spock's auto-DDL
+	# replication will mangle the test fixtures.  Logged for diagnostics
+	# only; the verdict comes from the surviving mesh.
+	if [ ${rc} -ne 0 ]; then
+		log "installcheck completed with regression failures (exit ${rc})"
+		log "  see ${LOG_DIR}/installcheck.log and ${SRC}/src/test/regress/regression.diffs"
+	else
+		log "installcheck completed cleanly (no regression diffs)"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Wait for every sub to report status='replicating'
+# ---------------------------------------------------------------------------
+
+WAIT_REPLICATING_TIMEOUT_PRE=60
+WAIT_REPLICATING_TIMEOUT_POST=30
+
+wait_for_mesh_replicating() {
+	local timeout="${1:-${WAIT_REPLICATING_TIMEOUT_PRE}}"
+	local deadline node not_replicating
+	deadline=$(( $(date +%s) + timeout ))
+	while [ "$(date +%s)" -lt "${deadline}" ]; do
+		not_replicating=0
+		for node in ${NODES}; do
+			local n
+			n="$(psql_on "${node}" -At -c \
+				"SELECT count(*) FROM spock.sub_show_status() \
+				 WHERE status IS DISTINCT FROM 'replicating';" \
+				2>/dev/null)" || n=999
+			if [ "${n}" -ne 0 ]; then
+				not_replicating=1
+				break
+			fi
+		done
+		if [ "${not_replicating}" -eq 0 ]; then
+			log "all 6 subscriptions reached status='replicating' (within ${timeout}s)"
+			return 0
+		fi
+		sleep 1
+	done
+	log "timed out after ${timeout}s waiting for subs to reach 'replicating'"
+	return 1
+}
+
+print_subscription_state() {
+	local label="$1"
+	local node
+	for node in ${NODES}; do
+		local nlog="${LOG_DIR}/${node}.log"
+		{
+			printf '\n--- subscription state (%s) on %s ---\n' "${label}" "${node}"
+			psql_on "${node}" -P null='(null)' \
+				-c "SELECT sub_name, sub_enabled FROM spock.subscription
+				    ORDER BY sub_name;" \
+				-c "SELECT subscription_name, status, provider_node, slot_name
+				    FROM spock.sub_show_status()
+				    ORDER BY subscription_name;"
+		} >>"${nlog}" 2>&1 || true
+	done
+}
+
+print_connection_params() {
+	local node port
+	printf '\n=== Connection parameters ===\n' >&2
+	if [ "${KEEP_RUNNING}" -eq 1 ]; then
+		printf '(servers are left running -- you can attach right now)\n' >&2
+	else
+		printf '(servers will be stopped on script exit; re-run with --keep to keep them up)\n' >&2
+	fi
+	for node in ${NODES}; do
+		port="$(node_to_port "${node}")"
+		printf '\n  %s  (PG%s)\n' "${node}" "${PG_VER}" >&2
+		printf '    host    = %s\n' "${SOCK_DIR}" >&2
+		printf '    port    = %s\n' "${port}"     >&2
+		printf '    user    = %s\n' "${DBUSER}"   >&2
+		printf '    dbname  = %s\n' "${DBNAME}"   >&2
+		printf '    psql    = %s/bin/psql -h %s -p %s -U %s -d %s\n' \
+			"${PREFIX}" "${SOCK_DIR}" "${port}" "${DBUSER}" "${DBNAME}" >&2
+	done
+	printf '\n' >&2
+}
+
+print_subscription_state_to_screen() {
+	local node
+	for node in ${NODES}; do
+		printf '\n=== %s (PG%s) ===\n' "${node}" "${PG_VER}" >&2
+		if ! psql_on "${node}" -At -c 'SELECT 1' >/dev/null 2>&1; then
+			printf '  (not reachable -- server is stopped or socket is gone)\n' >&2
+			continue
+		fi
+		psql_on "${node}" -P null='(null)' \
+			-c "SELECT sub_name, sub_enabled
+			    FROM spock.subscription
+			    ORDER BY sub_name;" \
+			-c "SELECT subscription_name, status, provider_node, slot_name
+			    FROM spock.sub_show_status()
+			    ORDER BY subscription_name;" \
+			1>&2 2>&1 || true
+	done
+	printf '\n' >&2
+}
+
+# ---------------------------------------------------------------------------
+# End-to-end propagation check using spock.sync_event / wait_for_sync_event
+# ---------------------------------------------------------------------------
+
+SYNC_EVENT_TIMEOUT=10
+
+_wait_one_sync_event() {
+	local provider="$1" subscriber="$2" lsn="$3"
+	psql_on "${subscriber}" -q -c "
+		DO \$check\$
+		DECLARE
+			r bool;
+		BEGIN
+			CALL spock.wait_for_sync_event(
+				r, '${provider}'::name, '${lsn}'::pg_lsn,
+				${SYNC_EVENT_TIMEOUT});
+			IF NOT r THEN
+				RAISE EXCEPTION
+					'sync_event from ${provider} did not arrive on ${subscriber} within ${SYNC_EVENT_TIMEOUT}s';
+			END IF;
+		END
+		\$check\$;
+	"
+}
+
+check_sync_event_propagation() {
+	local fail=0 provider subscriber lsn
+	local logf="${LOG_DIR}/sync-event-check.log"
+	: >"${logf}"
+
+	for provider in ${NODES}; do
+		lsn="$(psql_on "${provider}" -At \
+			-c "SELECT spock.sync_event();" 2>/dev/null)" \
+			|| lsn=
+		if [ -z "${lsn}" ]; then
+			log "${provider}: spock.sync_event() emit failed"
+			fail=1
+			continue
+		fi
+		log "${provider}: emitted sync_event @ ${lsn}"
+
+		for subscriber in ${NODES}; do
+			[ "${subscriber}" = "${provider}" ] && continue
+			if _wait_one_sync_event "${provider}" "${subscriber}" "${lsn}" \
+					>>"${logf}" 2>&1; then
+				log "${provider} -> ${subscriber}: sync_event delivered"
+			else
+				log "${provider} -> ${subscriber}: sync_event NOT delivered within ${SYNC_EVENT_TIMEOUT}s"
+				fail=1
+			fi
+		done
+	done
+	return ${fail}
+}
+
+# ---------------------------------------------------------------------------
+# Verify every subscription is still enabled
+# ---------------------------------------------------------------------------
+
+verify_subs_enabled() {
+	local node out any_bad=0
+	for node in ${NODES}; do
+		out="$(psql_on "${node}" -At -c \
+			"SELECT sub_name FROM spock.subscription WHERE NOT sub_enabled ORDER BY sub_name;" \
+			2>/dev/null)" \
+			|| { any_bad=1; log "${node}: NOT reachable -- treating as failure"; continue; }
+		if [ -n "${out}" ]; then
+			any_bad=1
+			log "${node}: DISABLED subscriptions: $(echo ${out} | tr '\n' ' ')"
+		else
+			log "${node}: all subscriptions still enabled"
+		fi
+	done
+	return "${any_bad}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	# Single shared build pipeline -- no parallel builders needed.
+	clone_pg
+	patch_pg
+	build_pg
+	build_spock
+
+	# Per-node initdb + start (cheap; sequential keeps the logs tidy).
+	local node
+	for node in ${NODES}; do
+		init_node  "${node}"
+		start_node "${node}"
+	done
+
+	wait_for_all_ready || fail "one or more nodes never became ready" 6
+
+	for node in ${NODES}; do create_db_for_node   "${node}"; done
+	for node in ${NODES}; do setup_spock_node     "${node}"; done
+
+	wire_full_mesh
+
+	local wait_rc=0
+	wait_for_mesh_replicating "${WAIT_REPLICATING_TIMEOUT_PRE}" || wait_rc=$?
+
+	print_subscription_state "before installcheck"
+
+	if [ "${wait_rc}" -ne 0 ]; then
+		say "WARNING: not all subscriptions reached 'replicating' before installcheck (see ${LOG_DIR}/<node>.log)"
+	fi
+
+	# Always run installcheck; its own pass/fail is logged but irrelevant
+	# to the exit code -- the workload is stress, the mesh is the test.
+	run_installcheck
+
+	print_subscription_state "after installcheck"
+
+	local post_wait_rc=0
+	wait_for_mesh_replicating "${WAIT_REPLICATING_TIMEOUT_POST}" \
+		|| post_wait_rc=$?
+	if [ "${post_wait_rc}" -ne 0 ]; then
+		log "diagnostic: status!='replicating' on some subs after ${WAIT_REPLICATING_TIMEOUT_POST}s (sync_event below is the authority)"
+	fi
+
+	local sync_rc=0
+	check_sync_event_propagation || sync_rc=$?
+
+	local verify_rc=0
+	verify_subs_enabled || verify_rc=$?
+
+	print_subscription_state_to_screen
+	print_connection_params
+
+	if [ "${KEEP_RUNNING}" -eq 0 ]; then
+		stop_all_nodes
+	else
+		log "--keep set: leaving nodes running. Sockets under ${SOCK_DIR}"
+	fi
+
+	if [ "${verify_rc}" -ne 0 ] || [ "${sync_rc}" -ne 0 ]; then
+		local reason=
+		[ "${verify_rc}" -ne 0 ] \
+			&& reason="some subscriptions disabled"
+		[ "${sync_rc}" -ne 0 ] \
+			&& reason="${reason:+${reason}; }sync_event did not propagate on some edges (see ${LOG_DIR}/sync-event-check.log)"
+		log "RESULT: ${reason}"
+		say "RESULT: FAIL -- ${reason} (see output above)"
+		return 2
+	fi
+	log "RESULT: every sub enabled, sync_event round-trips on every edge"
+	say "RESULT: PASS -- mesh healthy after installcheck (sub_enabled + sync_event)"
+	return 0
+}
+
+main "$@"

--- a/tests/run-single-pg18-installcheck.sh
+++ b/tests/run-single-pg18-installcheck.sh
@@ -71,7 +71,8 @@ SPOCK_SRC="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # contained next to the source.  Distinct from the multi-version rig's
 # directory so the two can coexist.  Overridden by --base-dir.
 BASE_DIR="${SPOCK_SRC}/single-pg18-installcheck"
-KEEP_RUNNING=1
+# Default: stop every node we started on exit.  --keep flips this on.
+KEEP_RUNNING=0
 FORCE_REBUILD=0
 JOBS_TOTAL="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
 
@@ -158,10 +159,12 @@ usage() {
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
-		--base-dir)         BASE_DIR="$2"; shift 2 ;;
+		--base-dir)         [ "$#" -ge 2 ] || fail "--base-dir requires a value" 4
+		                    BASE_DIR="$2"; shift 2 ;;
 		--keep)             KEEP_RUNNING=1; shift ;;
 		--force)            FORCE_REBUILD=1; shift ;;
-		--jobs)             JOBS_TOTAL="$2"; shift 2 ;;
+		--jobs)             [ "$#" -ge 2 ] || fail "--jobs requires a value" 4
+		                    JOBS_TOTAL="$2"; shift 2 ;;
 		-h|--help)          usage; exit 0 ;;
 		*)                  fail "unknown argument: $1" 4 ;;
 	esac
@@ -247,7 +250,8 @@ _do_clone_pg() {
 clone_pg() {
 	local branch="REL_${PG_VER}_STABLE"
 
-	if [ -d "${SRC}/.git" ] \
+	if [ "${FORCE_REBUILD}" -eq 0 ] \
+		&& [ -d "${SRC}/.git" ] \
 		&& [ -f "${SRC}/src/test/regress/parallel_schedule" ]; then
 		log "pg${PG_VER}: [pg-clone] source already present, skipping"
 		return 0
@@ -427,6 +431,19 @@ stop_all_nodes() {
 	local node
 	for node in ${NODES}; do stop_node "${node}"; done
 }
+
+# Bound to EXIT so node shutdown runs on normal completion AND on every
+# failure path -- including the ERR trap, which exit()s before main()'s tail
+# is reached.  Skipped only when the user passed --keep.  stop_node is a
+# no-op for nodes that never started, so this is safe at any exit point.
+cleanup_nodes() {
+	if [ "${KEEP_RUNNING}" -eq 0 ]; then
+		stop_all_nodes
+	else
+		log "--keep set: leaving nodes running. Sockets under ${SOCK_DIR}"
+	fi
+}
+trap cleanup_nodes EXIT
 
 # ---------------------------------------------------------------------------
 # pg_isready probe for each node
@@ -650,7 +667,11 @@ print_subscription_state_to_screen() {
 # End-to-end propagation check using spock.sync_event / wait_for_sync_event
 # ---------------------------------------------------------------------------
 
-SYNC_EVENT_TIMEOUT=10
+# Seconds to wait for a sync_event to propagate across the mesh.  This is the
+# test's authoritative success signal and runs after run_installcheck, when the
+# replication backlog is heaviest, so the default is generous (matching the
+# pre-installcheck replicating wait).  Override via the environment on slow CI.
+SYNC_EVENT_TIMEOUT="${SYNC_EVENT_TIMEOUT:-60}"
 
 _wait_one_sync_event() {
 	local provider="$1" subscriber="$2" lsn="$3"
@@ -714,7 +735,7 @@ verify_subs_enabled() {
 			|| { any_bad=1; log "${node}: NOT reachable -- treating as failure"; continue; }
 		if [ -n "${out}" ]; then
 			any_bad=1
-			log "${node}: DISABLED subscriptions: $(echo ${out} | tr '\n' ' ')"
+			log "${node}: DISABLED subscriptions: $(echo "${out}" | tr '\n' ' ')"
 		else
 			log "${node}: all subscriptions still enabled"
 		fi
@@ -778,11 +799,7 @@ main() {
 	print_subscription_state_to_screen
 	print_connection_params
 
-	if [ "${KEEP_RUNNING}" -eq 0 ]; then
-		stop_all_nodes
-	else
-		log "--keep set: leaving nodes running. Sockets under ${SOCK_DIR}"
-	fi
+	# node shutdown is handled by the cleanup_nodes EXIT trap
 
 	if [ "${verify_rc}" -ne 0 ] || [ "${sync_rc}" -ne 0 ]; then
 		local reason=


### PR DESCRIPTION
## Problem

Spock's automatic DDL replication ships the raw command text to be re-parsed and executed on every subscriber. When a *permanent* table is created from a *temporary* one, the shipped command is valid on the origin but cannot run on the subscriber, where the temporary relation does not exist:

- `CREATE TABLE foo (LIKE some_temp_table)`
- `CREATE TABLE foo AS SELECT ... FROM some_temp_table`

The replicated command fails on the subscriber with `relation "..." does not exist`, and because queued changes apply in order, the apply worker stalls — every later change from that origin (including `spock.sync_event()`) is blocked behind the un-appliable command. The existing temp-relation guard only checked the *target* of the CREATE, not relations it copies from.

## Root cause

By the time auto-DDL runs (post-execution, in the ProcessUtility hook) `transformCreateStmt()` has already expanded the `LIKE` clause out of `CreateStmt->tableElts`, so the executed parse tree no longer shows the source relation. Inspecting that tree finds nothing. The information only survives in the raw command text — the exact text we would ship and the subscriber would re-parse.

## Solution

In `spock_auto_replicate_ddl()`, detect temporary-relation references and skip replication with an explanatory message instead of shipping a command that cannot apply:

- **`CREATE TABLE ... (LIKE ...)`** — re-parse the raw command text (which still carries the `LIKE` clause), resolve each source relation against the catalogue, and check its persistence. Name resolution uses the live `search_path`, matching what the executor did on the origin.
- **`CREATE TABLE AS`** — walk the analysed defining query with the existing `isQueryUsingTempRelation()`, which catches references at any nesting level (e.g. inside a subquery).

`spock_auto_replicate_ddl()` now returns whether the statement was queued. `spock_autoddl_process()` adds the relation to the replication set only when it was — otherwise a table whose `CREATE` was not replicated would have its later DML fail to apply downstream, reintroducing the same stall.

## Limitations

Detection covers only relations named directly in the statement. A temporary relation reached indirectly — through a function body or dynamic SQL — cannot be detected statically; that is a separate, fundamentally undecidable case.

## Also in this branch

Replaces the multi-PG mesh installcheck rig with a single-PG18 one (`tests/run-single-pg18-installcheck.sh` + GitHub Actions workflow). The multi-version rig conflated genuine bugs with inherent cross-version DDL-shipping fragility (e.g. a PG16-built `regress.dylib` failing to load on a PG18 subscriber), which is expected and out of scope for the regression mesh. The single-PG18 rig builds PostgreSQL REL_18_STABLE and Spock once, wires three PG18 nodes into a full mesh, stresses it with `make installcheck`, and asserts every subscription stays enabled and `spock.sync_event()` round-trips on every edge.
