### PR TITLE
reject structure synchronization from an incompatible upstream version

### DIFF
--- a/include/spock_sync.h
+++ b/include/spock_sync.h
@@ -66,6 +66,7 @@ typedef struct SpockSyncStatus
 extern void spock_sync_worker_finish(void);
 
 extern void spock_sync_subscription(SpockSubscription *sub);
+extern bool upstream_version_supports_structure_sync(PGconn *origin_conn);
 extern char spock_sync_table(SpockSubscription *sub, RangeVar *table, XLogRecPtr *status_lsn);
 
 extern void create_local_sync_status(SpockSyncStatus *sync);

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -494,6 +494,27 @@ spock_create_subscription(PG_FUNCTION_ARGS)
 
 	/* Now, fetch info about remote node. */
 	conn = spock_connect(provider_dsn, sub_name, "create");
+
+	/*
+	 * If we will dump the provider's schema, our pg_dump/pg_restore must be
+	 * able to read it.  Reject an incompatible major version now, at CREATE
+	 * SUBSCRIPTION, rather than failing later in the sync worker.
+	 */
+	if (sync_structure && !upstream_version_supports_structure_sync(conn))
+	{
+		const char *v = PQparameterStatus(conn, "server_version");
+		char	   *provider_version = pstrdup(v ? v : "unknown");
+
+		PQfinish(conn);
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("cannot synchronize structure from provider running PostgreSQL %s",
+						provider_version),
+				 errdetail("The subscriber's pg_dump/pg_restore (version %s) cannot dump from a newer major version.",
+						   PG_VERSION),
+				 errhint("Synchronize the schema separately and create the subscription with synchronize_structure = false, or match the major versions.")));
+	}
+
 	origin = spock_remote_node_info(conn, NULL, NULL, NULL);
 	PQfinish(conn);
 

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -331,6 +331,31 @@ restore_structure(SpockSubscription *sub, const char *srcfile,
 }
 
 /*
+ * upstream_version_supports_structure_sync
+ *		True if our pg_dump/pg_restore can read this upstream.
+ *
+ * The subscriber's pg_dump (its own, per get_pg_executable()) cannot read a
+ * provider of a newer major version than itself; cf. _check_database_version()
+ * in src/bin/pg_dump/connectdb.c.
+ */
+bool
+upstream_version_supports_structure_sync(PGconn *origin_conn)
+{
+	int			remoteversion;
+
+	Assert(origin_conn != NULL && PQstatus(origin_conn) == CONNECTION_OK);
+
+	remoteversion = PQserverVersion(origin_conn);
+
+	/*
+	 * Treat an unknown version (0 -- a dead connection or a non-PostgreSQL
+	 * endpoint) as unsupported, and reject a newer major version that our
+	 * pg_dump could not read.
+	 */
+	return remoteversion != 0 && remoteversion / 100 <= PG_VERSION_NUM / 100;
+}
+
+/*
  * Create slot and get the exported snapshot.
  *
  * This will try to recreate slot if already exists and not active.
@@ -1448,6 +1473,38 @@ spock_sync_subscription(SpockSubscription *sub)
 
 		origin_conn = spock_connect(sub->origin_if->dsn,
 									sub->name, "snap");
+
+		/*
+		 * An incompatible upstream is permanent, so disable the subscription
+		 * rather than let the worker crash-loop on every restart.  Checked
+		 * before the replication connection and slot are created.  No
+		 * transaction is open (the switch above committed its own), so
+		 * spock_disable_subscription() commits its own and the disable survives
+		 * the FATAL; origin_conn is left open to keep remoteversion_str valid.
+		 */
+		if (SyncKindStructure(sync->kind) &&
+			!upstream_version_supports_structure_sync(origin_conn))
+		{
+			const char *remoteversion_str = PQparameterStatus(origin_conn,
+															  "server_version");
+
+			Assert(!IsTransactionState());
+
+			exception_behaviour = SUB_DISABLE;
+			spock_disable_subscription(sub, InvalidRepOriginId,
+									   InvalidTransactionId,
+									   InvalidXLogRecPtr, 0);
+
+			ereport(FATAL,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("SPOCK %s: cannot synchronize structure from upstream server version %s",
+							sub->name,
+							remoteversion_str ? remoteversion_str : "unknown"),
+					 errdetail("The subscriber's pg_dump/pg_restore (version %s) cannot dump from a newer major version.",
+							   PG_VERSION),
+					 errhint("Synchronize the schema another way and recreate the subscription with synchronize_structure = false, then re-enable the subscription.")));
+		}
+
 		origin_conn_repl = spock_connect_replica(sub->origin_if->dsn,
 												 sub->name, "snap");
 

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -335,13 +335,17 @@ restore_structure(SpockSubscription *sub, const char *srcfile,
  *		True if our pg_dump/pg_restore can read this upstream.
  *
  * The subscriber's pg_dump (its own, per get_pg_executable()) cannot read a
- * provider of a newer major version than itself; cf. _check_database_version()
- * in src/bin/pg_dump/connectdb.c.
+ * provider whose server version falls outside the inclusive
+ * [minRemoteVersion, maxRemoteVersion] window that pg_dump itself enforces in
+ * _check_database_version() (src/bin/pg_dump/pg_backup_db.c).  The bounds
+ * mirror those set in main() of src/bin/pg_dump/pg_dump.c.
  */
 bool
 upstream_version_supports_structure_sync(PGconn *origin_conn)
 {
 	int			remoteversion;
+	const int	minRemoteVersion = 90200;
+	const int	maxRemoteVersion = (PG_VERSION_NUM / 100) * 100 + 99;
 
 	Assert(origin_conn != NULL && PQstatus(origin_conn) == CONNECTION_OK);
 
@@ -349,10 +353,12 @@ upstream_version_supports_structure_sync(PGconn *origin_conn)
 
 	/*
 	 * Treat an unknown version (0 -- a dead connection or a non-PostgreSQL
-	 * endpoint) as unsupported, and reject a newer major version that our
-	 * pg_dump could not read.
+	 * endpoint) as unsupported, and reject upstreams below minRemoteVersion
+	 * or above maxRemoteVersion, matching pg_dump's own bounds check.
 	 */
-	return remoteversion != 0 && remoteversion / 100 <= PG_VERSION_NUM / 100;
+	return remoteversion != 0
+		&& remoteversion >= minRemoteVersion
+		&& remoteversion <= maxRemoteVersion;
 }
 
 /*

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -359,9 +359,8 @@ retry:
 	 * sync_replication_slots = on.  PG17+ uses parenthesised option syntax:
 	 *   CREATE_REPLICATION_SLOT "name" LOGICAL plugin (FAILOVER)
 	 *
-	 * We key off the regular SQL connection (sql_conn) for version detection.
-	 * Replication protocol connections (repl_conn) return 0 from PQserverVersion()
-	 * so they cannot be used for this check.
+	 * Detect the version on the SQL connection (sql_conn), which we hold open
+	 * anyway for the slot-reclaim queries below.
 	 */
 	if (PQserverVersion(sql_conn) >= 170000)
 		appendStringInfo(&query, " (FAILOVER)");
@@ -616,8 +615,7 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	 * consistent with the slot's WAL position — the correct snapshot for COPY.
 	 *
 	 * Mark the slot with (FAILOVER) when the remote provider is PG17+.
-	 * Use the regular SQL connection (conn) for version detection — replication
-	 * protocol connections (repl_conn) return 0 from PQserverVersion().
+	 * Detect the version on the SQL connection (conn), held open anyway.
 	 */
 	appendStringInfo(&query, "CREATE_REPLICATION_SLOT \"%s\" LOGICAL %s",
 					 slot_name, "spock_output");


### PR DESCRIPTION
## Problem

When a subscription is created with `synchronize_structure = true`, spock copies the provider's schema by shelling out to `pg_dump`/`pg_restore`. Those binaries are pinned to the *subscriber's* own major version (via `get_pg_executable()`), and `pg_dump` cannot read a server of a newer major version than itself — it aborts with `"aborting because of server version mismatch"`.

With other words, the subscriber's major version of Postgres must be the same or newer as that of the provider/publisher if syncing the structure of the table.

Until now that incompatibility surfaced badly:

- At sync time it appeared only as an opaque `pg_dump` exit code wrapped in `"could not execute pg_dump"`, and only *after* spock had already created a replication slot and exported a snapshot on the provider.
- Because the condition is permanent, the apply worker would `ERROR`, die, and be restarted by the launcher — reconnecting to the publisher and failing again on every cycle, indefinitely.

## What this PR does

Detects the version mismatch up front by mirroring `pg_dump`'s own `_check_database_version()` test against the live connection, and enforces it at two points:

- **`sub_create` (foreground):** rejects the operation immediately with a clear `ERROR` naming the provider's PostgreSQL version, before any slot/snapshot is created. This is the path most users hit.
- **Apply worker (backstop):** for subscriptions that reach init another way, the worker disables the subscription (rather than `ERROR`-ing into a restart loop) and exits `FATAL` with an actionable hint. Disabling is what actually breaks the loop — the severity keyword alone would not.

Both call sites share a single predicate, `upstream_version_supports_structure_sync()`, so the "must track `pg_dump`'s rule" logic lives in one place. An unknown (zero) version — a dead connection or a non-PostgreSQL endpoint — is treated as unsupported (fail closed).

Data-only syncs use `COPY`, which has no such version restriction, and are deliberately left untouched: the check is scoped to structure-bearing sync kinds only.
