### PR TITLE
Re-add delta apply via security label commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ ifdef SPOCK_RANDOM_DELAYS
 PG_CPPFLAGS += -DSPOCK_RANDOM_DELAYS
 endif
 SHLIB_LINK += $(libpq) $(filter -lintl, $(LIBS))
-ifdef NO_LOG_OLD_VALUE
-PG_CPPFLAGS += -DNO_LOG_OLD_VALUE
-endif
 
 REGRESS := __placeholder__
 EXTRA_CLEAN += $(control_path) spock_compat.bc \

--- a/include/spock.h
+++ b/include/spock.h
@@ -28,6 +28,7 @@
 #define SPOCK_VERSION_NUM 60000
 
 #define EXTENSION_NAME "spock"
+#define spock_SECLABEL_PROVIDER "spock"
 
 #define REPLICATION_ORIGIN_ALL	"all"
 

--- a/include/spock.h
+++ b/include/spock.h
@@ -28,7 +28,7 @@
 #define SPOCK_VERSION_NUM 60000
 
 #define EXTENSION_NAME "spock"
-#define spock_SECLABEL_PROVIDER "spock"
+#define SPOCK_SECLABEL_PROVIDER "spock"
 
 #define REPLICATION_ORIGIN_ALL	"all"
 

--- a/include/spock_relcache.h
+++ b/include/spock_relcache.h
@@ -49,6 +49,9 @@ typedef struct SpockRelation
 
 	/* Additional cache, only valid as long as relation mapping is. */
 	bool		hasTriggers;
+
+	Oid		   *delta_functions;
+	bool		has_delta_apply;
 } SpockRelation;
 
 extern void spock_relation_cache_update(uint32 remoteid,

--- a/include/spock_relcache.h
+++ b/include/spock_relcache.h
@@ -44,8 +44,6 @@ typedef struct SpockRelation
 	Oid			idxoid;
 	Relation	rel;
 	int		   *attmap;
-	bool		has_delta_columns;
-	Oid		   *delta_apply_functions;
 
 	/* Additional cache, only valid as long as relation mapping is. */
 	bool		hasTriggers;

--- a/include/spock_relcache.h
+++ b/include/spock_relcache.h
@@ -48,8 +48,8 @@ typedef struct SpockRelation
 	/* Additional cache, only valid as long as relation mapping is. */
 	bool		hasTriggers;
 
-	Oid		   *delta_functions;
-	bool		has_delta_apply;
+	Oid		   *delta_apply_functions;
+	bool		has_delta_columns;
 } SpockRelation;
 
 extern void spock_relation_cache_update(uint32 remoteid,

--- a/include/spock_relcache.h
+++ b/include/spock_relcache.h
@@ -69,6 +69,8 @@ extern void spock_relation_cache_reset(void);
 
 extern Oid	spock_lookup_delta_function(char *fname, Oid typeoid);
 
+extern Oid get_replication_identity(Relation rel);
+
 struct SpockTupleData;
 
 #endif							/* SPOCK_RELCACHE_H */

--- a/sql/spock--5.0.8--6.0.0.sql
+++ b/sql/spock--5.0.8--6.0.0.sql
@@ -302,7 +302,12 @@ BEGIN
    */
   SELECT pg_catalog.current_setting('spock.enable_ddl_replication') INTO status;
   IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
-    raise WARNING 'delta_apply setting has not been propagated to other spock nodes';
+    raise WARNING 'delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)';
+  END IF;
+
+  SELECT pg_catalog.current_setting('spock.allow_ddl_from_functions') INTO status;
+  IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
+    raise WARNING 'delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)';
   END IF;
 
   IF EXISTS (SELECT 1 FROM pg_catalog.pg_seclabel

--- a/sql/spock--5.0.8--6.0.0.sql
+++ b/sql/spock--5.0.8--6.0.0.sql
@@ -215,106 +215,103 @@ RETURNS void
 AS 'MODULE_PATHNAME', 'spock_reset_subscription_stats'
 LANGUAGE C CALLED ON NULL INPUT VOLATILE;
 
-DROP PROCEDURE IF EXISTS spock.wait_for_sync_event(OUT bool, oid, pg_lsn, int);
-DROP PROCEDURE IF EXISTS spock.wait_for_sync_event(OUT bool, oid, pg_lsn, int, bool);
-DROP PROCEDURE IF EXISTS spock.wait_for_sync_event(OUT bool, name, pg_lsn, int);
-DROP PROCEDURE IF EXISTS spock.wait_for_sync_event(OUT bool, name, pg_lsn, int, bool);
-CREATE PROCEDURE spock.wait_for_sync_event(
-	OUT result          bool,
-	origin_id           oid,
-	lsn                 pg_lsn,
-	timeout             int  DEFAULT 0,
-	wait_if_disabled    bool DEFAULT false
-) AS $$
+-- Set delta_apply security label on specific column
+CREATE FUNCTION spock.delta_apply(
+  rel regclass,
+  att_name name,
+  to_drop boolean DEFAULT false
+) RETURNS boolean AS $$
 DECLARE
-	target_id		oid;
-	start_time		timestamptz := clock_timestamp();
-	progress_lsn	pg_lsn;
-	sub_is_enabled	bool;
-	sub_slot		name;
+  label     text;
+  atttype   name;
+  attdata   record;
+  sqlstring text;
+  status    boolean;
+  relreplident char (1);
+  ctypname  name;
 BEGIN
-	IF origin_id IS NULL THEN
-		RAISE EXCEPTION 'Invalid NULL origin_id';
-	END IF;
-	target_id := node_id FROM spock.node_info();
 
-	-- Upfront existence check is skipped when wait_if_disabled is true because
-	-- the subscription may not yet exist (e.g. a newly added node whose
-	-- subscriptions are still initializing).  The loop below handles both the
-	-- not-found and disabled cases gracefully in that mode.
-	IF NOT wait_if_disabled THEN
-		SELECT sub_enabled, sub_slot_name INTO sub_is_enabled, sub_slot
-			FROM spock.subscription
-			WHERE sub_origin = origin_id AND sub_target = target_id;
+  /*
+   * regclass input type guarantees we see this table, no 'not found' check
+   * is needed.
+   */
+  SELECT c.relreplident FROM pg_class c WHERE oid = rel INTO relreplident;
+  /*
+   * Allow only DEFAULT type of replica identity. FULL type means we have
+   * already requested delta_apply feature on this table.
+   * Avoid INDEX type because indexes may have different names on the nodes and
+   * it would be better to stay paranoid than afraid of consequences.
+   */
+  IF (relreplident <> 'd' AND relreplident <> 'f')
+  THEN
+    RAISE EXCEPTION 'spock can apply delta_apply feature to the DEFAULT replica identity type only. This table holds "%" idenity', relreplident;
+  END IF;
 
-		IF NOT FOUND THEN
-			RAISE EXCEPTION 'No subscription found for replication % => %',
-							origin_id, target_id;
-		END IF;
-	END IF;
+  /*
+   * Find proper delta_apply function for the column type or ERROR
+   */
 
-	WHILE true LOOP
-		-- Re-check subscription state each iteration.  Also re-fetches
-		-- sub_slot_name so the loop is self-contained when wait_if_disabled
-		-- is true and the pre-loop check was skipped.
-		SELECT sub_enabled, sub_slot_name INTO sub_is_enabled, sub_slot
-			FROM spock.subscription
-			WHERE sub_origin = origin_id AND sub_target = target_id;
+  SELECT t.typname,t.typinput,t.typoutput
+  FROM pg_catalog.pg_attribute a, pg_type t
+  WHERE a.attrelid = rel AND a.attname = att_name AND (a.atttypid = t.oid)
+  INTO attdata;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'column % does not exist in the table %', att_name, rel;
+  END IF;
 
-		IF NOT FOUND THEN
-			IF NOT wait_if_disabled THEN
-				RAISE EXCEPTION 'No subscription found for replication % => %',
-								origin_id, target_id;
-			END IF;
-			-- Subscription not yet created; fall through to sleep.
-		ELSIF NOT sub_is_enabled THEN
-			IF NOT wait_if_disabled THEN
-				RAISE EXCEPTION 'Subscription % => % has been disabled',
-								origin_id, target_id;
-			END IF;
-			-- Subscription still initializing; fall through to sleep.
-		ELSE
-			-- Subscription is enabled; check LSN progress.
-			-- Uses PostgreSQL's native origin tracking rather than spock.progress
-			SELECT remote_lsn INTO progress_lsn
-				FROM pg_replication_origin_status
-				WHERE external_id = sub_slot;
+  SELECT typname FROM pg_type WHERE
+    typname IN ('int2','int4','int8','float4','float8','numeric','money') AND
+    typinput = attdata.typinput AND typoutput = attdata.typoutput
+  INTO ctypname;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'type "%" can not be used in delta_apply conflict resolution',
+          attdata.typname;
+  END IF;
 
-			IF progress_lsn IS NOT NULL AND progress_lsn >= lsn THEN
-				result = true;
-				RETURN;
-			END IF;
-		END IF;
+  --
+  -- Create security label on the column
+  --
+  IF (to_drop = true) THEN
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS NULL;' ,
+                        rel, att_name);
+  ELSE
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L;' ,
+                        rel, att_name, 'spock.delta_apply');
+  END IF;
 
-		IF timeout <> 0 AND
-		   EXTRACT(EPOCH FROM (clock_timestamp() - start_time)) >= timeout THEN
-			result := false;
-			RETURN;
-		END IF;
+  EXECUTE sqlstring;
 
-		ROLLBACK;
-		PERFORM pg_sleep(0.2);
-	END LOOP;
+  /*
+   * Auto replication will propagate security label if needed. Just warn if it's
+   * not - the structure sync pg_dump call would copy security labels, isn't it?
+   */
+  SELECT pg_catalog.current_setting('spock.enable_ddl_replication') INTO status;
+  IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
+    raise WARNING 'delta_apply setting has not been propagated to other spock nodes';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_seclabel
+			 WHERE objoid = rel AND classoid = 'pg_class'::regclass AND
+			       provider = 'spock') THEN
+    /*
+     * Call it each time to trigger relcache invalidation callback that causes
+     * refresh of the SpockRelation entry and guarantees actual state of the
+     * delta_apply columns.
+     */
+    EXECUTE format('ALTER TABLE %I REPLICA IDENTITY FULL', rel);
+  ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_class c
+			 WHERE c.oid = rel AND c.relreplident = 'f') THEN
+    /*
+	 * Have removed he last security label. Revert this spock hack change,
+	 * if needed.
+	 */
+	EXECUTE format('ALTER TABLE %I REPLICA IDENTITY DEFAULT', rel);
+  END IF;
+
+  RETURN true;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STRICT VOLATILE;
 
-CREATE PROCEDURE spock.wait_for_sync_event(
-	OUT result          bool,
-	origin              name,
-	lsn                 pg_lsn,
-	timeout             int  DEFAULT 0,
-	wait_if_disabled    bool DEFAULT false
-) AS $$
-DECLARE
-	origin_id  oid;
-BEGIN
-	origin_id := node_id FROM spock.node WHERE node_name = origin;
-	IF origin_id IS NULL THEN
-		RAISE EXCEPTION 'Origin node ''%'' not found', origin;
-	END IF;
-	CALL spock.wait_for_sync_event(result, origin_id, lsn, timeout, wait_if_disabled);
-END;
-$$ LANGUAGE plpgsql;
 
 CREATE FUNCTION spock.sub_alter_options(
   subscription_name name,

--- a/sql/spock--5.0.8--6.0.0.sql
+++ b/sql/spock--5.0.8--6.0.0.sql
@@ -287,10 +287,10 @@ BEGIN
   -- Create security label on the column
   --
   IF (to_drop = true) THEN
-    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS NULL;' ,
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %s.%I IS NULL;' ,
                         rel, att_name);
   ELSE
-    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L;' ,
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %s.%I IS %L;' ,
                         rel, att_name, 'spock.delta_apply');
   END IF;
 
@@ -313,14 +313,13 @@ BEGIN
      * refresh of the SpockRelation entry and guarantees actual state of the
      * delta_apply columns.
      */
-    EXECUTE format('ALTER TABLE %I REPLICA IDENTITY FULL', rel);
+    EXECUTE format('ALTER TABLE %s REPLICA IDENTITY FULL', rel);
   ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_class c
 			 WHERE c.oid = rel AND c.relreplident = 'f') THEN
     /*
-	 * Have removed he last security label. Revert this spock hack change,
-	 * if needed.
+	 * Removed the last security label. Revert the replica identity spock set.
 	 */
-	EXECUTE format('ALTER TABLE %I REPLICA IDENTITY DEFAULT', rel);
+	EXECUTE format('ALTER TABLE %s REPLICA IDENTITY DEFAULT', rel);
   END IF;
 
   RETURN true;

--- a/sql/spock--5.0.8--6.0.0.sql
+++ b/sql/spock--5.0.8--6.0.0.sql
@@ -251,12 +251,27 @@ BEGIN
    * Find proper delta_apply function for the column type or ERROR
    */
 
-  SELECT t.typname,t.typinput,t.typoutput
+ SELECT t.typname,t.typinput,t.typoutput, a.attnotnull
   FROM pg_catalog.pg_attribute a, pg_type t
   WHERE a.attrelid = rel AND a.attname = att_name AND (a.atttypid = t.oid)
   INTO attdata;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'column % does not exist in the table %', att_name, rel;
+  END IF;
+
+  IF (attdata.attnotnull = false) THEN
+    /*
+	 * TODO: Here is a case where the table has different constraints on nodes.
+	 * Using prepared transactions, we might be sure this operation will finish
+	 * if only each node satisfies the rule. But we need to add support for 2PC
+	 * commit beforehand.
+	 */
+    RAISE NOTICE USING
+	  MESSAGE = format('delta_apply feature can not be applied to nullable column %L of the table %I',
+						att_name, rel),
+	  HINT = 'Set NOT NULL constraint on the column',
+	  ERRCODE = 'object_not_in_prerequisite_state';
+	RETURN false;
   END IF;
 
   SELECT typname FROM pg_type WHERE

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -933,10 +933,10 @@ BEGIN
   -- Create security label on the column
   --
   IF (to_drop = true) THEN
-    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS NULL;' ,
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %s.%I IS NULL;' ,
                         rel, att_name);
   ELSE
-    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L;' ,
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %s.%I IS %L;' ,
                         rel, att_name, 'spock.delta_apply');
   END IF;
 
@@ -959,14 +959,13 @@ BEGIN
      * refresh of the SpockRelation entry and guarantees actual state of the
      * delta_apply columns.
      */
-    EXECUTE format('ALTER TABLE %I REPLICA IDENTITY FULL', rel);
+    EXECUTE format('ALTER TABLE %s REPLICA IDENTITY FULL', rel);
   ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_class c
 			 WHERE c.oid = rel AND c.relreplident = 'f') THEN
     /*
-	 * Have removed he last security label. Revert this spock hack change,
-	 * if needed.
+	 * Removed the last security label. Revert the replica identity spock set.
 	 */
-	EXECUTE format('ALTER TABLE %I REPLICA IDENTITY DEFAULT', rel);
+	EXECUTE format('ALTER TABLE %s REPLICA IDENTITY DEFAULT', rel);
   END IF;
 
   RETURN true;

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -854,22 +854,13 @@ CREATE FUNCTION spock.delta_apply(
   to_drop  boolean DEFAULT false
 ) RETURNS boolean AS $$
 DECLARE
-  label    text;
-  atttype  name;
-  attdata  record;
-  ctypname name;
+  label     text;
+  atttype   name;
+  attdata   record;
+  ctypname  name;
+  sqlstring text;
+  status    boolean;
 BEGIN
-  IF (to_drop = true) THEN
-    DELETE FROM pg_seclabel WHERE objoid = rel AND
-	                              classoid = 'pg_class'::regclass AND
-								  objsubid > 0 AND provider = 'spock';
-	IF NOT FOUND THEN
-      RETURN false;
-    END IF;
-
-    RETURN true;
-  END IF;
-
   --
   -- Find proper delta_apply function for the column type or ERROR
   --
@@ -894,8 +885,24 @@ BEGIN
   --
   -- Create security label on the column
   --
-  EXECUTE format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L' ,
-                 rel, att_name, 'delta_apply');
+  IF (to_drop = true) THEN
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS NULL;' ,
+                        rel, att_name);
+  ELSE
+  sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L;' ,
+                      rel, att_name, 'delta_apply');
+  END IF;
+
+  EXECUTE sqlstring;
+
+  /*
+   * Auto replication will propagate security label if needed. Just warn if it's
+   * not - the structure sync pg_dump call would copy security labels, isn't it?
+   */
+  SELECT pg_catalog.current_setting('spock.enable_ddl_replication') INTO status;
+  IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
+    raise WARNING 'delta_apply setting has not been propagated to other spock nodes';
+  END IF;
 
   RETURN true;
 END;

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -948,7 +948,12 @@ BEGIN
    */
   SELECT pg_catalog.current_setting('spock.enable_ddl_replication') INTO status;
   IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
-    raise WARNING 'delta_apply setting has not been propagated to other spock nodes';
+    raise WARNING 'delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)';
+  END IF;
+
+  SELECT pg_catalog.current_setting('spock.allow_ddl_from_functions') INTO status;
+  IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
+    raise WARNING 'delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)';
   END IF;
 
   IF EXISTS (SELECT 1 FROM pg_catalog.pg_seclabel

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -846,3 +846,57 @@ CREATE FUNCTION spock.reset_subscription_stats(subid oid DEFAULT NULL)
 RETURNS void
 AS 'MODULE_PATHNAME', 'spock_reset_subscription_stats'
 LANGUAGE C CALLED ON NULL INPUT VOLATILE;
+
+-- Set delta_apply security label on specific column
+CREATE FUNCTION spock.delta_apply(
+  rel      regclass,
+  att_name name,
+  to_drop  boolean DEFAULT false
+) RETURNS boolean AS $$
+DECLARE
+  label    text;
+  atttype  name;
+  attdata  record;
+  ctypname name;
+BEGIN
+  IF (to_drop = true) THEN
+    DELETE FROM pg_seclabel WHERE objoid = rel AND
+	                              classoid = 'pg_class'::regclass AND
+								  objsubid > 0 AND provider = 'spock';
+	IF NOT FOUND THEN
+      RETURN false;
+    END IF;
+
+    RETURN true;
+  END IF;
+
+  --
+  -- Find proper delta_apply function for the column type or ERROR
+  --
+
+  SELECT t.typname,t.typinput,t.typoutput
+  FROM pg_catalog.pg_attribute a, pg_type t
+  WHERE a.attrelid = rel AND a.attname = att_name AND (a.atttypid = t.oid)
+  INTO attdata;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'column % does not exist in the table %', att_name, rel;
+  END IF;
+
+  SELECT typname FROM pg_type WHERE
+    typname IN ('int2','int4','int8','float4','float8','numeric','money') AND
+    typinput = attdata.typinput AND typoutput = attdata.typoutput
+  INTO ctypname;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'type "%" can not be used in delta_apply conflict resolution',
+          attdata.typname;
+  END IF;
+
+  --
+  -- Create security label on the column
+  --
+  EXECUTE format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L' ,
+                 rel, att_name, 'delta_apply');
+
+  RETURN true;
+END;
+$$ LANGUAGE plpgsql STRICT VOLATILE;

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -750,19 +750,33 @@ CREATE FUNCTION spock.terminate_active_transactions() RETURNS bool
 -- Generic delta apply functions for all numeric data types
 -- ----
 CREATE FUNCTION spock.delta_apply(int2, int2, int2)
-RETURNS int2 LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_int2';
+RETURNS int2
+AS 'MODULE_PATHNAME', 'delta_apply_int2'
+LANGUAGE C;
 CREATE FUNCTION spock.delta_apply(int4, int4, int4)
-RETURNS int4 LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_int4';
+RETURNS int4
+AS 'MODULE_PATHNAME', 'delta_apply_int4'
+LANGUAGE C;
 CREATE FUNCTION spock.delta_apply(int8, int8, int8)
-RETURNS int8 LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_int8';
+RETURNS int8
+AS 'MODULE_PATHNAME', 'delta_apply_int8'
+LANGUAGE C;
 CREATE FUNCTION spock.delta_apply(float4, float4, float4)
-RETURNS float4 LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_float4';
+RETURNS float4
+AS 'MODULE_PATHNAME', 'delta_apply_float4'
+LANGUAGE C;
 CREATE FUNCTION spock.delta_apply(float8, float8, float8)
-RETURNS float8 LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_float8';
+RETURNS float8
+AS 'MODULE_PATHNAME', 'delta_apply_float8'
+LANGUAGE C;
 CREATE FUNCTION spock.delta_apply(numeric, numeric, numeric)
-RETURNS numeric LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_numeric';
+RETURNS numeric
+AS 'MODULE_PATHNAME', 'delta_apply_numeric'
+LANGUAGE C;
 CREATE FUNCTION spock.delta_apply(money, money, money)
-RETURNS money LANGUAGE c AS 'MODULE_PATHNAME', 'delta_apply_money';
+RETURNS money
+AS 'MODULE_PATHNAME', 'delta_apply_money'
+LANGUAGE C;
 
 -- ----
 -- Function to control REPAIR mode
@@ -857,13 +871,31 @@ DECLARE
   label     text;
   atttype   name;
   attdata   record;
-  ctypname  name;
   sqlstring text;
   status    boolean;
+  relreplident char (1);
+  ctypname  name;
 BEGIN
-  --
-  -- Find proper delta_apply function for the column type or ERROR
-  --
+
+  /*
+   * regclass input type guarantees we see this table, no 'not found' check
+   * is needed.
+   */
+  SELECT c.relreplident FROM pg_class c WHERE oid = rel INTO relreplident;
+  /*
+   * Allow only DEFAULT type of replica identity. FULL type means we have
+   * already requested delta_apply feature on this table.
+   * Avoid INDEX type because indexes may have different names on the nodes and
+   * it would be better to stay paranoid than afraid of consequences.
+   */
+  IF (relreplident <> 'd' AND relreplident <> 'f')
+  THEN
+    RAISE EXCEPTION 'spock can apply delta_apply feature to the DEFAULT replica identity type only. This table holds "%" idenity', relreplident;
+  END IF;
+
+  /*
+   * Find proper delta_apply function for the column type or ERROR
+   */
 
   SELECT t.typname,t.typinput,t.typoutput
   FROM pg_catalog.pg_attribute a, pg_type t
@@ -889,8 +921,8 @@ BEGIN
     sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS NULL;' ,
                         rel, att_name);
   ELSE
-  sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L;' ,
-                      rel, att_name, 'delta_apply');
+    sqlstring := format('SECURITY LABEL FOR spock ON COLUMN %I.%I IS %L;' ,
+                        rel, att_name, 'spock.delta_apply');
   END IF;
 
   EXECUTE sqlstring;
@@ -902,6 +934,24 @@ BEGIN
   SELECT pg_catalog.current_setting('spock.enable_ddl_replication') INTO status;
   IF EXISTS (SELECT 1 FROM spock.local_node) AND status = false THEN
     raise WARNING 'delta_apply setting has not been propagated to other spock nodes';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_catalog.pg_seclabel
+			 WHERE objoid = rel AND classoid = 'pg_class'::regclass AND
+			       provider = 'spock') THEN
+    /*
+     * Call it each time to trigger relcache invalidation callback that causes
+     * refresh of the SpockRelation entry and guarantees actual state of the
+     * delta_apply columns.
+     */
+    EXECUTE format('ALTER TABLE %I REPLICA IDENTITY FULL', rel);
+  ELSIF EXISTS (SELECT 1 FROM pg_catalog.pg_class c
+			 WHERE c.oid = rel AND c.relreplident = 'f') THEN
+    /*
+	 * Have removed he last security label. Revert this spock hack change,
+	 * if needed.
+	 */
+	EXECUTE format('ALTER TABLE %I REPLICA IDENTITY DEFAULT', rel);
   END IF;
 
   RETURN true;

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -897,12 +897,27 @@ BEGIN
    * Find proper delta_apply function for the column type or ERROR
    */
 
-  SELECT t.typname,t.typinput,t.typoutput
+  SELECT t.typname,t.typinput,t.typoutput, a.attnotnull
   FROM pg_catalog.pg_attribute a, pg_type t
   WHERE a.attrelid = rel AND a.attname = att_name AND (a.atttypid = t.oid)
   INTO attdata;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'column % does not exist in the table %', att_name, rel;
+  END IF;
+
+  IF (attdata.attnotnull = false) THEN
+    /*
+	 * TODO: Here is a case where the table has different constraints on nodes.
+	 * Using prepared transactions, we might be sure this operation will finish
+	 * if only each node satisfies the rule. But we need to add support for 2PC
+	 * commit beforehand.
+	 */
+    RAISE NOTICE USING
+	  MESSAGE = format('delta_apply feature can not be applied to nullable column %L of the table %I',
+						att_name, rel),
+	  HINT = 'Set NOT NULL constraint on the column',
+	  ERRCODE = 'object_not_in_prerequisite_state';
+	RETURN false;
   END IF;
 
   SELECT typname FROM pg_type WHERE

--- a/src/spock.c
+++ b/src/spock.c
@@ -1353,7 +1353,7 @@ _PG_init(void)
 	emit_log_hook = log_message_filter;
 
 	/* Security label provider hook */
-	register_label_provider(spock_SECLABEL_PROVIDER, spock_object_relabel);
+	register_label_provider(SPOCK_SECLABEL_PROVIDER, spock_object_relabel);
 
 #if PG_VERSION_NUM >= 180000
 	/* Spock replication conflict statistics */

--- a/src/spock.c
+++ b/src/spock.c
@@ -990,11 +990,13 @@ spock_object_relabel(const ObjectAddress *object, const char *seclabel)
 		elog(ERROR, "spock extension is not created yet");
 
 	/*
-	 * Check: classId must be pg_class, objectId should an existing table and
-	 * attnum must be more than 0.
+	 * Check: classId must be pg_class, the object must be an existing plain
+	 * table, and attnum must be greater than 0. delta_apply reads heap tuples,
+	 * so reject views, matviews, sequences, indexes, foreign/partitioned
+	 * tables, composite types, etc.
 	 */
 	if (object->classId != RelationRelationId || object->objectSubId <= 0 ||
-		!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(object->objectId)))
+		get_rel_relkind(object->objectId) != RELKIND_RELATION)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("spock provider does not support labels on %s",

--- a/src/spock.c
+++ b/src/spock.c
@@ -25,6 +25,7 @@
 #include "catalog/pg_type.h"
 
 #include "commands/extension.h"
+#include "commands/seclabel.h"
 
 #include "executor/executor.h"
 
@@ -975,6 +976,32 @@ log_message_filter(ErrorData *edata)
 }
 
 /*
+ * Spock security label hook.
+ *
+ * Just to be sure user adds a proper label: only table columns may be applied.
+ */
+static void
+spock_object_relabel(const ObjectAddress *object, const char *seclabel)
+{
+	Oid				extoid;
+
+	extoid = get_extension_oid(EXTENSION_NAME, true);
+	if (!OidIsValid(extoid))
+		elog(ERROR, "spock extension is not created yet");
+
+	/*
+	 * Check: classId must be pg_class, objectId should an existing table and
+	 * attnum must be more than 0.
+	 */
+	if (object->classId != RelationRelationId || object->objectSubId <= 0 ||
+		!SearchSysCacheExists1(RELOID, ObjectIdGetDatum(object->objectId)))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("spock provider does not support labels on %s",
+						getObjectTypeDescription(object, false))));
+}
+
+/*
  * Entry point for this module.
  */
 void
@@ -1324,6 +1351,9 @@ _PG_init(void)
 	/* General-purpose message filter */
 	prev_emit_log_hook = emit_log_hook;
 	emit_log_hook = log_message_filter;
+
+	/* Security label provider hook */
+	register_label_provider(spock_SECLABEL_PROVIDER, spock_object_relabel);
 
 #if PG_VERSION_NUM >= 180000
 	/* Spock replication conflict statistics */

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -3782,9 +3782,12 @@ spock_execute_sql_command(char *cmdstr, char *role, bool isTopLevel)
 		/*
 		 * check if it's a DDL statement. we only do this for
 		 * in_spock_replicate_ddl_command
+		 * SECURITY LABEL command is not a DDL, just an utility one. Hence, let
+		 * spock execute this command.
 		 */
 		if (in_spock_replicate_ddl_command &&
-			GetCommandLogLevel(command->stmt) != LOGSTMT_DDL)
+			GetCommandLogLevel(command->stmt) != LOGSTMT_DDL &&
+			!IsA(command->stmt, SecLabelStmt))
 		{
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -536,7 +536,7 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 		int			remoteattnum = rel->attmap[attidx];
 
 		Assert(remoteattnum < tupdesc->natts);
-		if (rel->delta_functions[remoteattnum] == InvalidOid)
+		if (rel->delta_apply_functions[remoteattnum] == InvalidOid)
 		{
 			deltatup->values[remoteattnum] = 0xdeadbeef;
 			deltatup->nulls[remoteattnum] = true;
@@ -564,7 +564,7 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 								 &loc_isnull);
 		Assert(!loc_isnull);
 
-		result = OidFunctionCall3Coll(rel->delta_functions[remoteattnum],
+		result = OidFunctionCall3Coll(rel->delta_apply_functions[remoteattnum],
 									  InvalidOid, oldtup->values[remoteattnum],
 									  newtup->values[remoteattnum], loc_value);
 		deltatup->values[remoteattnum] = result;
@@ -642,7 +642,7 @@ spock_handle_conflict_and_apply(SpockRelation *rel, EState *estate,
 						  xmin, local_origin_found, local_origin,
 						  local_ts, idxused);
 
-	if (rel->has_delta_apply)
+	if (rel->has_delta_columns)
 	{
 		SpockTupleData deltatup;
 		HeapTuple	currenttuple;

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -102,11 +102,9 @@ typedef struct ApplyExecState
 
 #define TTS_TUP(slot) (((HeapTupleTableSlot *)slot)->tuple)
 
-#ifndef NO_LOG_OLD_VALUE
 static void build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 							  SpockTupleData *newtup, SpockTupleData *deltatup,
 							  TupleTableSlot *localslot);
-#endif
 static bool physatt_in_attmap(SpockRelation *rel, int attid);
 
 /*
@@ -517,8 +515,6 @@ physatt_in_attmap(SpockRelation *rel, int attid)
 }
 
 
-#ifndef NO_LOG_OLD_VALUE
-
 static void
 build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 				  SpockTupleData *newtup,
@@ -540,8 +536,7 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 		int			remoteattnum = rel->attmap[attidx];
 
 		Assert(remoteattnum < tupdesc->natts);
-		if (rel->delta_apply_functions[remoteattnum] == InvalidOid &&
-			rel->delta_functions[remoteattnum] == InvalidOid)
+		if (rel->delta_functions[remoteattnum] == InvalidOid)
 		{
 			deltatup->values[remoteattnum] = 0xdeadbeef;
 			deltatup->nulls[remoteattnum] = true;
@@ -568,8 +563,7 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 		{
 			/*
 			 * This is a special case. Columns for delta apply need to be
-			 * marked NOT NULL and LOG_OLD_VALUE=true. During this remote
-			 * UPDATE LOG_OLD_VALUE setting was false. We use this as a flag
+			 * marked NOT NULL. We use this as a flag
 			 * to force plain NEW value application. This is useful in case a
 			 * server ever gets out of sync.
 			 */
@@ -577,7 +571,7 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 			deltatup->nulls[remoteattnum] = false;
 			deltatup->changed[remoteattnum] = true;
 		}
-		else if (rel->delta_functions[remoteattnum] != InvalidOid)
+		else
 		{
 			loc_value = heap_getattr(TTS_TUP(localslot), remoteattnum + 1, tupdesc,
 									 &loc_isnull);
@@ -589,21 +583,8 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 			deltatup->nulls[remoteattnum] = false;
 			deltatup->changed[remoteattnum] = true;
 		}
-		else
-		{
-			loc_value = heap_getattr(TTS_TUP(localslot), remoteattnum + 1, tupdesc,
-									 &loc_isnull);
-
-			result = OidFunctionCall3Coll(rel->delta_apply_functions[remoteattnum],
-										  InvalidOid, oldtup->values[remoteattnum],
-										  newtup->values[remoteattnum], loc_value);
-			deltatup->values[remoteattnum] = result;
-			deltatup->nulls[remoteattnum] = false;
-			deltatup->changed[remoteattnum] = true;
-		}
 	}
 }
-#endif							/* NO_LOG_OLD_VALUE */
 
 
 /**
@@ -674,7 +655,7 @@ spock_handle_conflict_and_apply(SpockRelation *rel, EState *estate,
 						  xmin, local_origin_found, local_origin,
 						  local_ts, idxused);
 
-	if (rel->has_delta_columns || rel->has_delta_apply)
+	if (rel->has_delta_apply)
 	{
 		SpockTupleData deltatup;
 		HeapTuple	currenttuple;

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -562,7 +562,21 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 
 		loc_value = heap_getattr(TTS_TUP(localslot), remoteattnum + 1, tupdesc,
 								 &loc_isnull);
-		Assert(!loc_isnull);
+
+		/*
+		 * The local base value is required to compute the delta. It must not be
+		 * NULL (delta_apply columns are required to be NOT NULL), but constraints
+		 * can drift across nodes or predate the constraint, so guard at runtime
+		 * rather than only via Assert - otherwise a non-assert build would call
+		 * the delta function with an invalid Datum.
+		 */
+		if (loc_isnull)
+			ereport(ERROR,
+					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					errmsg("delta apply column can't operate NULL values"),
+					errdetail("attribute \"%s\" (%d) of the local tuple is NULL",
+							  NameStr(TupleDescAttr(tupdesc, remoteattnum)->attname),
+							  remoteattnum + 1)));
 
 		result = OidFunctionCall3Coll(rel->delta_apply_functions[remoteattnum],
 									  InvalidOid, oldtup->values[remoteattnum],

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -545,44 +545,31 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 		}
 
 		/*
-		 * Column is marked LOG_OLD_VALUE=true. We use that as flag to apply
-		 * the delta between the remote old and new instead of the plain new
-		 * value.
-		 *
-		 * To perform the actual delta math we need the functions behind the
-		 * '+' and '-' operators for the data type.
-		 *
-		 * XXX: This is currently hardcoded for the builtin data types we
-		 * support. Ideally we would lookup those operators in the system
-		 * cache, but that isn't straight forward and we get into all sorts of
-		 * trouble when it comes to user defined data types and the search
-		 * path.
+		 * This shouldn't happen: creating delta_apply column we must check that
+		 * NOT NULL constraint is set on this column or reject. But just to
+		 * survive in case of a bug we complain and send the apply worker to
+		 * exception behavior path way.
 		 */
+		if (oldtup->nulls[remoteattnum] || newtup->nulls[remoteattnum])
+			ereport(ERROR,
+					(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+					errmsg("delta apply column can't operate NULL values"),
+					errdetail("attribute %d for remote tuple is %s, and for the local tuple is %s",
+							  remoteattnum + 1,
+							  newtup->nulls[remoteattnum] ? "NULL" : "NOT NULL",
+							  oldtup->nulls[remoteattnum] ? "NULL" : "NOT NULL"
+							  )));
 
-		if (oldtup->nulls[remoteattnum])
-		{
-			/*
-			 * This is a special case. Columns for delta apply need to be
-			 * marked NOT NULL. We use this as a flag
-			 * to force plain NEW value application. This is useful in case a
-			 * server ever gets out of sync.
-			 */
-			deltatup->values[remoteattnum] = newtup->values[remoteattnum];
-			deltatup->nulls[remoteattnum] = false;
-			deltatup->changed[remoteattnum] = true;
-		}
-		else
-		{
-			loc_value = heap_getattr(TTS_TUP(localslot), remoteattnum + 1, tupdesc,
-									 &loc_isnull);
+		loc_value = heap_getattr(TTS_TUP(localslot), remoteattnum + 1, tupdesc,
+								 &loc_isnull);
+		Assert(!loc_isnull);
 
-			result = OidFunctionCall3Coll(rel->delta_functions[remoteattnum],
-										  InvalidOid, oldtup->values[remoteattnum],
-										  newtup->values[remoteattnum], loc_value);
-			deltatup->values[remoteattnum] = result;
-			deltatup->nulls[remoteattnum] = false;
-			deltatup->changed[remoteattnum] = true;
-		}
+		result = OidFunctionCall3Coll(rel->delta_functions[remoteattnum],
+									  InvalidOid, oldtup->values[remoteattnum],
+									  newtup->values[remoteattnum], loc_value);
+		deltatup->values[remoteattnum] = result;
+		deltatup->nulls[remoteattnum] = false;
+		deltatup->changed[remoteattnum] = true;
 	}
 }
 

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -540,7 +540,8 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 		int			remoteattnum = rel->attmap[attidx];
 
 		Assert(remoteattnum < tupdesc->natts);
-		if (rel->delta_apply_functions[remoteattnum] == InvalidOid)
+		if (rel->delta_apply_functions[remoteattnum] == InvalidOid &&
+			rel->delta_functions[remoteattnum] == InvalidOid)
 		{
 			deltatup->values[remoteattnum] = 0xdeadbeef;
 			deltatup->nulls[remoteattnum] = true;
@@ -573,6 +574,18 @@ build_delta_tuple(SpockRelation *rel, SpockTupleData *oldtup,
 			 * server ever gets out of sync.
 			 */
 			deltatup->values[remoteattnum] = newtup->values[remoteattnum];
+			deltatup->nulls[remoteattnum] = false;
+			deltatup->changed[remoteattnum] = true;
+		}
+		else if (rel->delta_functions[remoteattnum] != InvalidOid)
+		{
+			loc_value = heap_getattr(TTS_TUP(localslot), remoteattnum + 1, tupdesc,
+									 &loc_isnull);
+
+			result = OidFunctionCall3Coll(rel->delta_functions[remoteattnum],
+										  InvalidOid, oldtup->values[remoteattnum],
+										  newtup->values[remoteattnum], loc_value);
+			deltatup->values[remoteattnum] = result;
 			deltatup->nulls[remoteattnum] = false;
 			deltatup->changed[remoteattnum] = true;
 		}
@@ -661,7 +674,7 @@ spock_handle_conflict_and_apply(SpockRelation *rel, EState *estate,
 						  xmin, local_origin_found, local_origin,
 						  local_ts, idxused);
 
-	if (rel->has_delta_columns)
+	if (rel->has_delta_columns || rel->has_delta_apply)
 	{
 		SpockTupleData deltatup;
 		HeapTuple	currenttuple;

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -342,8 +342,9 @@ autoddl_can_proceed(Node *parsetree, ProcessUtilityContext context,
 		 */
 		return false;
 
-	/* Only process DDL statements */
-	if (GetCommandLogLevel(parsetree) != LOGSTMT_DDL)
+	/* Only process DDL statements and SECURITY LABEL's */
+	if (GetCommandLogLevel(parsetree) != LOGSTMT_DDL &&
+		!IsA(parsetree, SecLabelStmt))
 		return false;
 
 	/* If DDL replication is disabled, do nothing */

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -344,7 +344,10 @@ autoddl_can_proceed(Node *parsetree, ProcessUtilityContext context,
 		 */
 		return false;
 
-	/* Only process DDL statements and SECURITY LABEL's */
+	/*
+	 * Process DDL and all SECURITY LABELs (every provider, not just spock) -
+	 * participating nodes must therefore have the same label providers loaded.
+	 */
 	if (GetCommandLogLevel(parsetree) != LOGSTMT_DDL &&
 		!IsA(parsetree, SecLabelStmt))
 		return false;

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -21,7 +21,7 @@
 
 #include "commands/defrem.h"
 #include "commands/extension.h"
-
+#include "commands/seclabel.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -30,6 +30,7 @@
 #include "spock_autoddl.h"
 #include "spock_executor.h"
 #include "spock_queue.h"
+#include "spock_relcache.h"
 #include "spock_repset.h"
 #include "spock_node.h"
 #include "spock_output_plugin.h"
@@ -281,7 +282,8 @@ add_ddl_to_repset(Node *parsetree)
 		}
 
 		if (!OidIsValid(targetrel->rd_replidindex) &&
-			(repset->replicate_update || repset->replicate_delete))
+			(repset->replicate_update || repset->replicate_delete) &&
+			!OidIsValid(get_replication_identity(targetrel)))
 		{
 			table_close(targetrel, NoLock);
 			return;

--- a/src/spock_executor.c
+++ b/src/spock_executor.c
@@ -215,7 +215,7 @@ DeleteSecurityLabels(const char *provider)
 		Assert(!isnull);
 		provider = TextDatumGetCString(datum);
 
-		if (strcmp(provider, spock_SECLABEL_PROVIDER) != 0)
+		if (strcmp(provider, SPOCK_SECLABEL_PROVIDER) != 0)
 			continue;
 
 		CatalogTupleDelete(pg_seclabel, &htup->t_self);
@@ -280,7 +280,7 @@ spock_object_access(ObjectAccessType access,
 		if (dropping_spock_obj)
 		{
 			/* Need to drop any security labels created by the extension */
-			DeleteSecurityLabels(spock_SECLABEL_PROVIDER);
+			DeleteSecurityLabels(SPOCK_SECLABEL_PROVIDER);
 			return;
 		}
 

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -453,3 +453,44 @@ spock_lookup_delta_function(char *fname, Oid typeoid)
 
 	return funcoid;
 }
+
+/*
+ * Detect if the FULL identity is just covering delta_apply
+ * feature underpinned by PK.
+ * This is quite a rare case. Don't afraid overhead.
+ */
+Oid
+get_replication_identity(Relation rel)
+{
+	TupleDesc	tupDesc = RelationGetDescr(rel);
+	int			i = 0;
+
+	if (OidIsValid(rel->rd_replidindex))
+		return rel->rd_replidindex;
+
+	if (rel->rd_rel->relreplident != REPLICA_IDENTITY_FULL ||
+		!OidIsValid(rel->rd_pkindex))
+		return InvalidOid;
+
+	for (i = 0; i < tupDesc->natts; i++)
+	{
+		char		   *seclabel;
+		ObjectAddress	object;
+
+		ObjectAddressSubSet(object, RelationRelationId,
+							RelationGetRelid(rel), i + 1);
+		seclabel = GetSecurityLabel(&object, spock_SECLABEL_PROVIDER);
+
+		if (seclabel != NULL)
+		{
+			/*
+			 * Relation has at least on security label on it. Treat it as a
+			 * delta_apply feature.
+			 */
+			pfree(seclabel);
+			return rel->rd_pkindex;
+		}
+	}
+
+	return InvalidOid;
+}

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -55,15 +55,12 @@ relcache_free_entry(SpockRelation *entry)
 
 	if (entry->attmap)
 		pfree(entry->attmap);
-	if (entry->delta_apply_functions)
-		pfree(entry->delta_apply_functions);
 	if (entry->delta_functions)
 		pfree(entry->delta_functions);
 
 	entry->natts = 0;
 	entry->reloid = InvalidOid;
 	entry->rel = NULL;
-	entry->has_delta_columns = false;
 	entry->has_delta_apply = false;
 }
 
@@ -104,9 +101,9 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 		/*
 		 * Reset delta-apply metadata before rescanning. A relcache
 		 * invalidation only resets entry->reloid; the function-Oid array
-		 * and has_delta_columns flag carry over from the prior state.
-		 * Without this reset, dropping a delta_apply_function attoption
-		 * would leave a stale Oid behind and has_delta_columns stuck at
+		 * and has_delta_apply flag carry over from the prior state.
+		 * Without this reset, dropping a delta_apply security label
+		 * would leave a stale Oid behind and has_delta_apply stuck at
 		 * true.
 		 *
 		 * Also resize the array to the local TupleDesc width. The
@@ -114,17 +111,17 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 		 * below indexes by attmap[i] (a local position), which can exceed
 		 * remote natts when local has columns the remote does not.
 		 */
-		if (entry->delta_apply_functions != NULL)
-			pfree(entry->delta_apply_functions);
+		if (entry->delta_functions != NULL)
+			pfree(entry->delta_functions);
 		{
 			MemoryContext oldcontext;
 
 			oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
-			entry->delta_apply_functions =
+			entry->delta_functions =
 				palloc0(desc->natts * sizeof(Oid));
 			MemoryContextSwitchTo(oldcontext);
 		}
-		entry->has_delta_columns = false;
+		entry->has_delta_apply = false;
 
 		for (i = 0; i < entry->natts; i++)
 		{
@@ -132,36 +129,6 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 			char			   *seclabel;
 
 			entry->attmap[i] = tupdesc_get_att_by_name(desc, entry->attnames[i]);
-
-			/*
-			 * If we find attribute options for this column and the
-			 * delta_apply_function is set, lookup the oid for it.
-			 */
-			att = TupleDescAttr(desc, entry->attmap[i]);
-			aopt = get_attribute_options(entry->rel->rd_id,
-										 entry->attmap[i] + 1);
-			if (aopt != NULL && aopt->delta_apply_function != 0)
-			{
-				char			   *fname;
-				Form_pg_attribute	att;
-				Oid					dfunc;
-
-				fname = pstrdup(GET_STRING_RELOPTION(aopt,
-													 delta_apply_function));
-				dfunc = spock_lookup_delta_function(fname, att->atttypid);
-				pfree(fname);
-
-				if (dfunc == InvalidOid)
-					elog(ERROR, "SPOCK: column %s.%s.%s is configured for "
-						 "delta_apply_function %s - function not found",
-						 entry->nspname, entry->relname,
-						 entry->attnames[i],
-						 GET_STRING_RELOPTION(aopt, delta_apply_function));
-
-
-				entry->has_delta_columns = true;
-				entry->delta_apply_functions[entry->attmap[i]] = dfunc;
-			}
 
 			if (entry->rel->rd_rel->relreplident != REPLICA_IDENTITY_FULL)
 				continue;
@@ -172,16 +139,27 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 			 *
 			 * XXX: What about non-existing columns on remote side?
 			 */
-			object.classId = RelationRelationId;
-			object.objectId = RelationGetRelid(entry->rel);
-			object.objectSubId = entry->attmap[i] + 1;
+			ObjectAddressSubSet(object, RelationRelationId,
+								RelationGetRelid(entry->rel),
+								entry->attmap[i] + 1);
 			seclabel = GetSecurityLabel(&object, spock_SECLABEL_PROVIDER);
 			if (seclabel != NULL)
 			{
-				entry->has_delta_apply = true;
-				entry->delta_functions[entry->attmap[i]] =
-						spock_lookup_delta_function(seclabel, att->atttypid);
+				Form_pg_attribute	att;
+				Oid					dfunc;
+
+				att = TupleDescAttr(desc, entry->attmap[i]);
+				dfunc = spock_lookup_delta_function(seclabel, att->atttypid);
+
+				if (dfunc == InvalidOid)
+					elog(ERROR, "SPOCK: column %s.%s.%s is configured for "
+						 "delta_apply function %s - function not found",
+						 entry->nspname, entry->relname,
+						 entry->attnames[i], seclabel);
+
+				entry->delta_functions[entry->attmap[i]] = dfunc;
 				Assert(entry->delta_functions[entry->attmap[i]] != InvalidOid);
+				entry->has_delta_apply = true;
 			}
 			else
 			{
@@ -279,8 +257,6 @@ spock_relation_cache_update(uint32 remoteid, char *schemaname,
 		entry->attrtypmods[i] = attrtypmods[i];
 	}
 	entry->attmap = palloc(natts * sizeof(int));
-	entry->has_delta_columns = false;
-	entry->delta_apply_functions = palloc0(natts * sizeof(Oid));
 	entry->has_delta_apply = false;
 	entry->delta_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
 	MemoryContextSwitchTo(oldcontext);
@@ -319,8 +295,6 @@ spock_relation_cache_updater(SpockRemoteRel *remoterel)
 	for (i = 0; i < remoterel->natts; i++)
 		entry->attnames[i] = pstrdup(remoterel->attnames[i]);
 	entry->attmap = palloc(remoterel->natts * sizeof(int));
-	entry->has_delta_columns = false;
-	entry->delta_apply_functions = palloc0(remoterel->natts * sizeof(Oid));
 	entry->has_delta_apply = false;
 	entry->delta_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
 	MemoryContextSwitchTo(oldcontext);

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -16,7 +16,7 @@
 
 #include "catalog/namespace.h"
 #include "catalog/pg_trigger.h"
-
+#include "commands/seclabel.h"
 #include "utils/attoptcache.h"
 #include "utils/builtins.h"
 #include "utils/catcache.h"
@@ -57,11 +57,14 @@ relcache_free_entry(SpockRelation *entry)
 		pfree(entry->attmap);
 	if (entry->delta_apply_functions)
 		pfree(entry->delta_apply_functions);
+	if (entry->delta_functions)
+		pfree(entry->delta_functions);
 
 	entry->natts = 0;
 	entry->reloid = InvalidOid;
 	entry->rel = NULL;
 	entry->has_delta_columns = false;
+	entry->has_delta_apply = false;
 }
 
 
@@ -125,7 +128,8 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 
 		for (i = 0; i < entry->natts; i++)
 		{
-			AttributeOpts *aopt;
+			ObjectAddress		object;
+			char			   *seclabel;
 
 			entry->attmap[i] = tupdesc_get_att_by_name(desc, entry->attnames[i]);
 
@@ -133,15 +137,15 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 			 * If we find attribute options for this column and the
 			 * delta_apply_function is set, lookup the oid for it.
 			 */
+			att = TupleDescAttr(desc, entry->attmap[i]);
 			aopt = get_attribute_options(entry->rel->rd_id,
 										 entry->attmap[i] + 1);
 			if (aopt != NULL && aopt->delta_apply_function != 0)
 			{
-				char	   *fname;
-				Form_pg_attribute att;
-				Oid			dfunc;
+				char			   *fname;
+				Form_pg_attribute	att;
+				Oid					dfunc;
 
-				att = TupleDescAttr(desc, entry->attmap[i]);
 				fname = pstrdup(GET_STRING_RELOPTION(aopt,
 													 delta_apply_function));
 				dfunc = spock_lookup_delta_function(fname, att->atttypid);
@@ -158,12 +162,54 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 				entry->has_delta_columns = true;
 				entry->delta_apply_functions[entry->attmap[i]] = dfunc;
 			}
+
+			if (entry->rel->rd_rel->relreplident != REPLICA_IDENTITY_FULL)
+				continue;
+
+			/*
+			 * Read security labels for each attname. For each such an attribute
+			 * choose corresponding delta function.
+			 *
+			 * XXX: What about non-existing columns on remote side?
+			 */
+			object.classId = RelationRelationId;
+			object.objectId = RelationGetRelid(entry->rel);
+			object.objectSubId = entry->attmap[i] + 1;
+			seclabel = GetSecurityLabel(&object, spock_SECLABEL_PROVIDER);
+			if (seclabel != NULL)
+			{
+				entry->has_delta_apply = true;
+				entry->delta_functions[entry->attmap[i]] =
+						spock_lookup_delta_function(seclabel, att->atttypid);
+				Assert(entry->delta_functions[entry->attmap[i]] != InvalidOid);
+			}
+			else
+			{
+				/* Main case */
+				entry->delta_functions[entry->attmap[i]] = InvalidOid;
+			}
 		}
 
 		relinfo = makeNode(ResultRelInfo);
 		InitResultRelInfo(relinfo, entry->rel, 1, NULL, 0);
 		entry->reloid = RelationGetRelid(entry->rel);
-		entry->idxoid = RelationGetReplicaIndex(relinfo->ri_RelationDesc);
+		if (entry->has_delta_apply)
+		{
+			/*
+			 * It looks like a hack — which, in fact, it is.
+			 * We assume that delta_apply may be used for the DEFAULT identity
+			 * only and will be immediately removed after altering the table.
+			 * Also, if an ERROR happens here we will stay with an inconsistent
+			 * value of the relreplident field. But it is just a cache ...
+			 */
+			relinfo->ri_RelationDesc->rd_rel->relreplident = REPLICA_IDENTITY_DEFAULT;
+			relinfo->ri_RelationDesc->rd_indexvalid = false;
+			entry->idxoid = RelationGetReplicaIndex(relinfo->ri_RelationDesc);
+			Assert(entry->idxoid != InvalidOid);
+			relinfo->ri_RelationDesc->rd_rel->relreplident = REPLICA_IDENTITY_FULL;
+		}
+		else
+			entry->idxoid = RelationGetReplicaIndex(relinfo->ri_RelationDesc);
 
 		/* Cache trigger info. */
 		entry->hasTriggers = false;
@@ -235,6 +281,8 @@ spock_relation_cache_update(uint32 remoteid, char *schemaname,
 	entry->attmap = palloc(natts * sizeof(int));
 	entry->has_delta_columns = false;
 	entry->delta_apply_functions = palloc0(natts * sizeof(Oid));
+	entry->has_delta_apply = false;
+	entry->delta_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
 	MemoryContextSwitchTo(oldcontext);
 
 	/* XXX Should we validate the relation against local schema here? */
@@ -273,6 +321,8 @@ spock_relation_cache_updater(SpockRemoteRel *remoterel)
 	entry->attmap = palloc(remoterel->natts * sizeof(int));
 	entry->has_delta_columns = false;
 	entry->delta_apply_functions = palloc0(remoterel->natts * sizeof(Oid));
+	entry->has_delta_apply = false;
+	entry->delta_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
 	MemoryContextSwitchTo(oldcontext);
 
 	/* XXX Should we validate the relation against local schema here? */

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -55,13 +55,13 @@ relcache_free_entry(SpockRelation *entry)
 
 	if (entry->attmap)
 		pfree(entry->attmap);
-	if (entry->delta_functions)
-		pfree(entry->delta_functions);
+	if (entry->delta_apply_functions)
+		pfree(entry->delta_apply_functions);
 
 	entry->natts = 0;
 	entry->reloid = InvalidOid;
 	entry->rel = NULL;
-	entry->has_delta_apply = false;
+	entry->has_delta_columns = false;
 }
 
 
@@ -101,9 +101,9 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 		/*
 		 * Reset delta-apply metadata before rescanning. A relcache
 		 * invalidation only resets entry->reloid; the function-Oid array
-		 * and has_delta_apply flag carry over from the prior state.
+		 * and has_delta_columns flag carry over from the prior state.
 		 * Without this reset, dropping a delta_apply security label
-		 * would leave a stale Oid behind and has_delta_apply stuck at
+		 * would leave a stale Oid behind and has_delta_columns stuck at
 		 * true.
 		 *
 		 * Also resize the array to the local TupleDesc width. The
@@ -111,17 +111,17 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 		 * below indexes by attmap[i] (a local position), which can exceed
 		 * remote natts when local has columns the remote does not.
 		 */
-		if (entry->delta_functions != NULL)
-			pfree(entry->delta_functions);
+		if (entry->delta_apply_functions != NULL)
+			pfree(entry->delta_apply_functions);
 		{
 			MemoryContext oldcontext;
 
 			oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
-			entry->delta_functions =
+			entry->delta_apply_functions =
 				palloc0(desc->natts * sizeof(Oid));
 			MemoryContextSwitchTo(oldcontext);
 		}
-		entry->has_delta_apply = false;
+		entry->has_delta_columns = false;
 
 		for (i = 0; i < entry->natts; i++)
 		{
@@ -142,7 +142,7 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 			ObjectAddressSubSet(object, RelationRelationId,
 								RelationGetRelid(entry->rel),
 								entry->attmap[i] + 1);
-			seclabel = GetSecurityLabel(&object, spock_SECLABEL_PROVIDER);
+			seclabel = GetSecurityLabel(&object, SPOCK_SECLABEL_PROVIDER);
 			if (seclabel != NULL)
 			{
 				Form_pg_attribute	att;
@@ -157,21 +157,21 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 						 entry->nspname, entry->relname,
 						 entry->attnames[i], seclabel);
 
-				entry->delta_functions[entry->attmap[i]] = dfunc;
-				Assert(entry->delta_functions[entry->attmap[i]] != InvalidOid);
-				entry->has_delta_apply = true;
+				entry->delta_apply_functions[entry->attmap[i]] = dfunc;
+				Assert(entry->delta_apply_functions[entry->attmap[i]] != InvalidOid);
+				entry->has_delta_columns = true;
 			}
 			else
 			{
 				/* Main case */
-				entry->delta_functions[entry->attmap[i]] = InvalidOid;
+				entry->delta_apply_functions[entry->attmap[i]] = InvalidOid;
 			}
 		}
 
 		relinfo = makeNode(ResultRelInfo);
 		InitResultRelInfo(relinfo, entry->rel, 1, NULL, 0);
 		entry->reloid = RelationGetRelid(entry->rel);
-		if (entry->has_delta_apply)
+		if (entry->has_delta_columns)
 		{
 			/*
 			 * It looks like a hack — which, in fact, it is.
@@ -257,8 +257,8 @@ spock_relation_cache_update(uint32 remoteid, char *schemaname,
 		entry->attrtypmods[i] = attrtypmods[i];
 	}
 	entry->attmap = palloc(natts * sizeof(int));
-	entry->has_delta_apply = false;
-	entry->delta_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
+	entry->has_delta_columns = false;
+	entry->delta_apply_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
 	MemoryContextSwitchTo(oldcontext);
 
 	/* XXX Should we validate the relation against local schema here? */
@@ -295,8 +295,8 @@ spock_relation_cache_updater(SpockRemoteRel *remoterel)
 	for (i = 0; i < remoterel->natts; i++)
 		entry->attnames[i] = pstrdup(remoterel->attnames[i]);
 	entry->attmap = palloc(remoterel->natts * sizeof(int));
-	entry->has_delta_apply = false;
-	entry->delta_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
+	entry->has_delta_columns = false;
+	entry->delta_apply_functions = (Oid *) palloc0(entry->natts * sizeof(Oid));
 	MemoryContextSwitchTo(oldcontext);
 
 	/* XXX Should we validate the relation against local schema here? */
@@ -479,7 +479,7 @@ get_replication_identity(Relation rel)
 
 		ObjectAddressSubSet(object, RelationRelationId,
 							RelationGetRelid(rel), i + 1);
-		seclabel = GetSecurityLabel(&object, spock_SECLABEL_PROVIDER);
+		seclabel = GetSecurityLabel(&object, SPOCK_SECLABEL_PROVIDER);
 
 		if (seclabel != NULL)
 		{

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -160,6 +160,7 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 				entry->delta_apply_functions[entry->attmap[i]] = dfunc;
 				Assert(entry->delta_apply_functions[entry->attmap[i]] != InvalidOid);
 				entry->has_delta_columns = true;
+				pfree(seclabel);
 			}
 			else
 			{

--- a/src/spock_repset.c
+++ b/src/spock_repset.c
@@ -45,6 +45,7 @@
 #include "spock_dependency.h"
 #include "spock_node.h"
 #include "spock_queue.h"
+#include "spock_relcache.h"
 #include "spock_repset.h"
 #include "spock.h"
 #include "spock_compat.h"
@@ -1130,7 +1131,7 @@ replication_set_add_table(Oid setid, Oid reloid, List *att_list,
 
 	if (targetrel->rd_indexvalid == 0)
 		RelationGetIndexList(targetrel);
-	if (!OidIsValid(targetrel->rd_replidindex) &&
+	if (!OidIsValid(get_replication_identity(targetrel)) &&
 		(repset->replicate_update || repset->replicate_delete))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/src/spock_repset.c
+++ b/src/spock_repset.c
@@ -861,7 +861,7 @@ alter_replication_set(SpockRepSet *repset)
 
 				if (targetrel->rd_indexvalid == 0)
 					RelationGetIndexList(targetrel);
-				if (!OidIsValid(targetrel->rd_replidindex) &&
+				if (!OidIsValid(get_replication_identity(targetrel)) &&
 					(repset->replicate_update || repset->replicate_delete))
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),

--- a/tests/docker/Dockerfile-step-1.el9
+++ b/tests/docker/Dockerfile-step-1.el9
@@ -104,7 +104,7 @@ COPY --chmod=755 tests/docker/*.sh /home/pgedge/
 # Clone spockbench for testing workloads
 # TODO: Pin to specific tag/commit for reproducibility
 RUN set -eux && \
-	git clone --depth 1 \
+	git clone --branch delta-apply-update --depth 1 \
 	https://github.com/pgEdge/spockbench.git /home/pgedge/spockbench && \
 	echo "export SPOCKBENCH_SOURCE_DIR=/home/pgedge/spockbench" >> /home/pgedge/.bashrc
 

--- a/tests/regress/expected/autoddl.out
+++ b/tests/regress/expected/autoddl.out
@@ -103,7 +103,7 @@ INFO:  DDL statement replicated.
 \c :provider_dsn
 \set VERBOSITY terse
 -- Check propagation of security labels
-CREATE TABLE slabel1 (x integer, y text PRIMARY KEY);
+CREATE TABLE slabel1 (x integer NOT NULL, y text PRIMARY KEY);
 INFO:  DDL statement replicated.
 SELECT spock.delta_apply('slabel1', 'x');
 INFO:  DDL statement replicated.

--- a/tests/regress/expected/autoddl.out
+++ b/tests/regress/expected/autoddl.out
@@ -100,9 +100,74 @@ WARNING:  This DDL statement will not be replicated.
 DROP TABLE test_383 CASCADE;
 NOTICE:  drop cascades to table test_383 membership in replication set default_insert_only
 INFO:  DDL statement replicated.
-\c :subscriber_dsn
--- Reset the configuration to the default value
 \c :provider_dsn
+\set VERBOSITY terse
+-- Check propagation of security labels
+CREATE TABLE slabel1 (x integer, y text PRIMARY KEY);
+INFO:  DDL statement replicated.
+SELECT spock.delta_apply('slabel1', 'x');
+INFO:  DDL statement replicated.
+ delta_apply 
+-------------
+ t
+(1 row)
+
+SELECT spock.delta_apply('slabel1', 'y'); -- ERROR
+ERROR:  type "text" can not be used in delta_apply conflict resolution
+SELECT spock.delta_apply('slabel1', 'z'); -- ERROR
+ERROR:  column z does not exist in the table slabel1
+SELECT spock.delta_apply('slabel1', 'x'); -- repeating call do nothing
+INFO:  DDL statement replicated.
+ delta_apply 
+-------------
+ t
+(1 row)
+
+SELECT objname, label FROM pg_seclabels;
+  objname  |    label    
+-----------+-------------
+ slabel1.x | delta_apply
+(1 row)
+
+-- Wait for the apply worker to process the security label before checking.
+SELECT spock.sync_event() AS sync_lsn \gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 60);
+ result 
+--------
+ t
+(1 row)
+
+SELECT objname, label FROM pg_seclabels;
+  objname  |    label    
+-----------+-------------
+ slabel1.x | delta_apply
+(1 row)
+
+\c :provider_dsn
+SELECT spock.delta_apply('slabel1', 'x', true);
+INFO:  DDL statement replicated.
+ delta_apply 
+-------------
+ t
+(1 row)
+
+-- Wait for the apply worker to process the removal before checking.
+SELECT spock.sync_event() AS sync_lsn \gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 60);
+ result 
+--------
+ t
+(1 row)
+
+SELECT objname, label FROM pg_seclabels;
+ objname | label 
+---------+-------
+(0 rows)
+
+\c :provider_dsn
+-- Reset the configuration to the default value
 ALTER SYSTEM SET spock.enable_ddl_replication = 'off';
 WARNING:  This DDL statement will not be replicated.
 ALTER SYSTEM SET spock.include_ddl_repset = 'off';

--- a/tests/regress/expected/autoddl.out
+++ b/tests/regress/expected/autoddl.out
@@ -107,6 +107,7 @@ CREATE TABLE slabel1 (x integer, y text PRIMARY KEY);
 INFO:  DDL statement replicated.
 SELECT spock.delta_apply('slabel1', 'x');
 INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
  delta_apply 
 -------------
  t
@@ -118,15 +119,16 @@ SELECT spock.delta_apply('slabel1', 'z'); -- ERROR
 ERROR:  column z does not exist in the table slabel1
 SELECT spock.delta_apply('slabel1', 'x'); -- repeating call do nothing
 INFO:  DDL statement replicated.
+INFO:  DDL statement replicated.
  delta_apply 
 -------------
  t
 (1 row)
 
 SELECT objname, label FROM pg_seclabels;
-  objname  |    label    
------------+-------------
- slabel1.x | delta_apply
+  objname  |       label       
+-----------+-------------------
+ slabel1.x | spock.delta_apply
 (1 row)
 
 -- Wait for the apply worker to process the security label before checking.
@@ -139,13 +141,14 @@ CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 60);
 (1 row)
 
 SELECT objname, label FROM pg_seclabels;
-  objname  |    label    
------------+-------------
- slabel1.x | delta_apply
+  objname  |       label       
+-----------+-------------------
+ slabel1.x | spock.delta_apply
 (1 row)
 
 \c :provider_dsn
 SELECT spock.delta_apply('slabel1', 'x', true);
+INFO:  DDL statement replicated.
 INFO:  DDL statement replicated.
  delta_apply 
 -------------

--- a/tests/regress/expected/basic.out
+++ b/tests/regress/expected/basic.out
@@ -218,6 +218,9 @@ DROP FUNCTION call_fn;
 --
 -- A label creation checks
 CREATE TABLE slabel (x integer, y text PRIMARY KEY);
+CREATE TABLE slabel_ri (x integer NOT NULL, y text);
+CREATE UNIQUE INDEX slabel_ri_idx ON slabel_ri(x);
+ALTER TABLE slabel_ri REPLICA IDENTITY USING INDEX slabel_ri_idx;
 SELECT spock.delta_apply('slabel', 'x');
 WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 
@@ -236,12 +239,15 @@ WARNING:  delta_apply setting has not been propagated to other spock nodes
  t
 (1 row)
 
+SELECT spock.delta_apply('slabel_ri', 'x'); -- ERROR
+ERROR:  spock can apply delta_apply feature to the DEFAULT replica identity type only. This table holds "i" idenity
 SELECT objname, label FROM pg_seclabels;
- objname  |    label    
-----------+-------------
- slabel.x | delta_apply
+ objname  |       label       
+----------+-------------------
+ slabel.x | spock.delta_apply
 (1 row)
 
+DROP TABLE slabel_ri CASCADE;
 -- Short round trip to check that subscriber has no security labels
 \c :subscriber_dsn
 SELECT objname, label FROM pg_seclabels;
@@ -276,7 +282,7 @@ WARNING:  delta_apply setting has not been propagated to other spock nodes
 (1 row)
 
 ALTER TABLE slabel ALTER COLUMN x TYPE text; -- just warn
-WARNING:  the alter column statement removes spock security label 'delta_apply' on this column
+WARNING:  the alter column statement removes spock security label 'spock.delta_apply' on this column
 SELECT objname, label FROM pg_seclabels;
  objname | label 
 ---------+-------

--- a/tests/regress/expected/basic.out
+++ b/tests/regress/expected/basic.out
@@ -217,8 +217,8 @@ DROP FUNCTION call_fn;
 -- Remember, these tests still check intra-node behaviour.
 --
 -- A label creation checks
-CREATE TABLE slabel (x integer, y text PRIMARY KEY);
-CREATE TABLE slabel_ri (x integer NOT NULL, y text);
+CREATE TABLE slabel (x integer NOT NULL, y text PRIMARY KEY);
+CREATE TABLE slabel_ri (x integer NOT NULL, y text, z text);
 CREATE UNIQUE INDEX slabel_ri_idx ON slabel_ri(x);
 ALTER TABLE slabel_ri REPLICA IDENTITY USING INDEX slabel_ri_idx;
 SELECT spock.delta_apply('slabel', 'x');
@@ -289,7 +289,7 @@ SELECT objname, label FROM pg_seclabels;
 (0 rows)
 
 ALTER TABLE slabel DROP COLUMN x;
-ALTER TABLE slabel ADD COLUMN x numeric;
+ALTER TABLE slabel ADD COLUMN x numeric NOT NULL;
 SELECT spock.delta_apply('slabel', 'x', false);
 WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 

--- a/tests/regress/expected/basic.out
+++ b/tests/regress/expected/basic.out
@@ -211,3 +211,85 @@ CREATE FUNCTION call_fn(creds text) RETURNS void AS $$
 $$ LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
 SELECT call_fn(:fakecreds);
 ERROR:  dsn "dbname=regression passwordXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+DROP FUNCTION call_fn;
+--
+-- Basic SECURITY LABEL tests. Fix limits of acceptable behavior.
+-- Remember, these tests still check intra-node behaviour.
+--
+-- A label creation checks
+CREATE TABLE slabel (x integer, y text PRIMARY KEY);
+SELECT spock.delta_apply('slabel', 'x');
+ delta_apply 
+-------------
+ t
+(1 row)
+
+SELECT spock.delta_apply('slabel', 'y'); -- ERROR
+ERROR:  type "text" can not be used in delta_apply conflict resolution
+SELECT spock.delta_apply('slabel', 'z'); -- ERROR
+ERROR:  column z does not exist in the table slabel
+SELECT spock.delta_apply('slabel', 'x'); -- repeating call do nothing
+ delta_apply 
+-------------
+ t
+(1 row)
+
+SELECT objname, label FROM pg_seclabels;
+ objname  |    label    
+----------+-------------
+ slabel.x | delta_apply
+(1 row)
+
+-- Label drop checks
+SELECT spock.delta_apply('slabel', 'x', true);
+ delta_apply 
+-------------
+ t
+(1 row)
+
+SELECT spock.delta_apply('slabel', 'y', true);
+ delta_apply 
+-------------
+ f
+(1 row)
+
+SELECT spock.delta_apply('slabel', 'z', true);
+ delta_apply 
+-------------
+ f
+(1 row)
+
+SELECT objname, label FROM pg_seclabels;
+ objname | label 
+---------+-------
+(0 rows)
+
+-- Dependencies
+SELECT spock.delta_apply('slabel', 'x', false);
+ delta_apply 
+-------------
+ t
+(1 row)
+
+ALTER TABLE slabel ALTER COLUMN x TYPE text; -- just warn
+WARNING:  the alter column statement removes spock security label 'delta_apply' on this column
+SELECT objname, label FROM pg_seclabels;
+ objname | label 
+---------+-------
+(0 rows)
+
+ALTER TABLE slabel DROP COLUMN x;
+ALTER TABLE slabel ADD COLUMN x numeric;
+SELECT spock.delta_apply('slabel', 'x', false);
+ delta_apply 
+-------------
+ t
+(1 row)
+
+ALTER TABLE slabel DROP COLUMN x;
+SELECT objname, label FROM pg_seclabels;
+ objname | label 
+---------+-------
+(0 rows)
+
+DROP TABLE slabel;

--- a/tests/regress/expected/basic.out
+++ b/tests/regress/expected/basic.out
@@ -219,6 +219,7 @@ DROP FUNCTION call_fn;
 -- A label creation checks
 CREATE TABLE slabel (x integer, y text PRIMARY KEY);
 SELECT spock.delta_apply('slabel', 'x');
+WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 
 -------------
  t
@@ -229,6 +230,7 @@ ERROR:  type "text" can not be used in delta_apply conflict resolution
 SELECT spock.delta_apply('slabel', 'z'); -- ERROR
 ERROR:  column z does not exist in the table slabel
 SELECT spock.delta_apply('slabel', 'x'); -- repeating call do nothing
+WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 
 -------------
  t
@@ -240,25 +242,26 @@ SELECT objname, label FROM pg_seclabels;
  slabel.x | delta_apply
 (1 row)
 
+-- Short round trip to check that subscriber has no security labels
+\c :subscriber_dsn
+SELECT objname, label FROM pg_seclabels;
+ objname | label 
+---------+-------
+(0 rows)
+
+\c :provider_dsn
 -- Label drop checks
 SELECT spock.delta_apply('slabel', 'x', true);
+WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 
 -------------
  t
 (1 row)
 
 SELECT spock.delta_apply('slabel', 'y', true);
- delta_apply 
--------------
- f
-(1 row)
-
+ERROR:  type "text" can not be used in delta_apply conflict resolution
 SELECT spock.delta_apply('slabel', 'z', true);
- delta_apply 
--------------
- f
-(1 row)
-
+ERROR:  column z does not exist in the table slabel
 SELECT objname, label FROM pg_seclabels;
  objname | label 
 ---------+-------
@@ -266,6 +269,7 @@ SELECT objname, label FROM pg_seclabels;
 
 -- Dependencies
 SELECT spock.delta_apply('slabel', 'x', false);
+WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 
 -------------
  t
@@ -281,6 +285,7 @@ SELECT objname, label FROM pg_seclabels;
 ALTER TABLE slabel DROP COLUMN x;
 ALTER TABLE slabel ADD COLUMN x numeric;
 SELECT spock.delta_apply('slabel', 'x', false);
+WARNING:  delta_apply setting has not been propagated to other spock nodes
  delta_apply 
 -------------
  t

--- a/tests/regress/expected/basic.out
+++ b/tests/regress/expected/basic.out
@@ -222,7 +222,8 @@ CREATE TABLE slabel_ri (x integer NOT NULL, y text, z text);
 CREATE UNIQUE INDEX slabel_ri_idx ON slabel_ri(x);
 ALTER TABLE slabel_ri REPLICA IDENTITY USING INDEX slabel_ri_idx;
 SELECT spock.delta_apply('slabel', 'x');
-WARNING:  delta_apply setting has not been propagated to other spock nodes
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)
  delta_apply 
 -------------
  t
@@ -233,7 +234,8 @@ ERROR:  type "text" can not be used in delta_apply conflict resolution
 SELECT spock.delta_apply('slabel', 'z'); -- ERROR
 ERROR:  column z does not exist in the table slabel
 SELECT spock.delta_apply('slabel', 'x'); -- repeating call do nothing
-WARNING:  delta_apply setting has not been propagated to other spock nodes
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)
  delta_apply 
 -------------
  t
@@ -258,7 +260,8 @@ SELECT objname, label FROM pg_seclabels;
 \c :provider_dsn
 -- Label drop checks
 SELECT spock.delta_apply('slabel', 'x', true);
-WARNING:  delta_apply setting has not been propagated to other spock nodes
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)
  delta_apply 
 -------------
  t
@@ -275,7 +278,8 @@ SELECT objname, label FROM pg_seclabels;
 
 -- Dependencies
 SELECT spock.delta_apply('slabel', 'x', false);
-WARNING:  delta_apply setting has not been propagated to other spock nodes
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)
  delta_apply 
 -------------
  t
@@ -291,7 +295,8 @@ SELECT objname, label FROM pg_seclabels;
 ALTER TABLE slabel DROP COLUMN x;
 ALTER TABLE slabel ADD COLUMN x numeric NOT NULL;
 SELECT spock.delta_apply('slabel', 'x', false);
-WARNING:  delta_apply setting has not been propagated to other spock nodes
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.enable_ddl_replication is set to off)
+WARNING:  delta_apply setting has not been propagated to other spock nodes (spock.allow_ddl_from_functions is set to off)
  delta_apply 
 -------------
  t

--- a/tests/regress/expected/infofuncs.out
+++ b/tests/regress/expected/infofuncs.out
@@ -21,7 +21,7 @@ WHERE extname = 'spock';
 (1 row)
 
 -- Check that security label is cleaned up on the extension drop
-CREATE TABLE slabel (x money, y text PRIMARY KEY);
+CREATE TABLE slabel (x money NOT NULL, y text PRIMARY KEY);
 SELECT spock.delta_apply('slabel', 'x', false);
  delta_apply 
 -------------

--- a/tests/regress/expected/infofuncs.out
+++ b/tests/regress/expected/infofuncs.out
@@ -20,4 +20,24 @@ WHERE extname = 'spock';
  t
 (1 row)
 
+-- Check that security label is cleaned up on the extension drop
+CREATE TABLE slabel (x money, y text PRIMARY KEY);
+SELECT spock.delta_apply('slabel', 'x', false);
+ delta_apply 
+-------------
+ t
+(1 row)
+
+SELECT objname, label FROM pg_seclabels;
+ objname  |    label    
+----------+-------------
+ slabel.x | delta_apply
+(1 row)
+
 DROP EXTENSION spock;
+SELECT objname, label FROM pg_seclabels;
+ objname | label 
+---------+-------
+(0 rows)
+
+DROP TABLE slabel;

--- a/tests/regress/expected/infofuncs.out
+++ b/tests/regress/expected/infofuncs.out
@@ -29,9 +29,9 @@ SELECT spock.delta_apply('slabel', 'x', false);
 (1 row)
 
 SELECT objname, label FROM pg_seclabels;
- objname  |    label    
-----------+-------------
- slabel.x | delta_apply
+ objname  |       label       
+----------+-------------------
+ slabel.x | spock.delta_apply
 (1 row)
 
 DROP EXTENSION spock;

--- a/tests/regress/sql/autoddl.sql
+++ b/tests/regress/sql/autoddl.sql
@@ -68,7 +68,7 @@ DROP TABLE test_383 CASCADE;
 \c :provider_dsn
 \set VERBOSITY terse
 -- Check propagation of security labels
-CREATE TABLE slabel1 (x integer, y text PRIMARY KEY);
+CREATE TABLE slabel1 (x integer NOT NULL, y text PRIMARY KEY);
 
 SELECT spock.delta_apply('slabel1', 'x');
 SELECT spock.delta_apply('slabel1', 'y'); -- ERROR

--- a/tests/regress/sql/autoddl.sql
+++ b/tests/regress/sql/autoddl.sql
@@ -65,10 +65,33 @@ CREATE INDEX test_383_y_idx ON test_383 (a);
 CLUSTER test_383 USING test_383_y_idx; -- Should not be replicated
 DROP TABLE test_383 CASCADE;
 
+\c :provider_dsn
+\set VERBOSITY terse
+-- Check propagation of security labels
+CREATE TABLE slabel1 (x integer, y text PRIMARY KEY);
+
+SELECT spock.delta_apply('slabel1', 'x');
+SELECT spock.delta_apply('slabel1', 'y'); -- ERROR
+SELECT spock.delta_apply('slabel1', 'z'); -- ERROR
+SELECT spock.delta_apply('slabel1', 'x'); -- repeating call do nothing
+SELECT objname, label FROM pg_seclabels;
+
+-- Wait for the apply worker to process the security label before checking.
+SELECT spock.sync_event() AS sync_lsn \gset
 \c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 60);
+SELECT objname, label FROM pg_seclabels;
+\c :provider_dsn
+
+SELECT spock.delta_apply('slabel1', 'x', true);
+-- Wait for the apply worker to process the removal before checking.
+SELECT spock.sync_event() AS sync_lsn \gset
+\c :subscriber_dsn
+CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 60);
+SELECT objname, label FROM pg_seclabels;
+\c :provider_dsn
 
 -- Reset the configuration to the default value
-\c :provider_dsn
 ALTER SYSTEM SET spock.enable_ddl_replication = 'off';
 ALTER SYSTEM SET spock.include_ddl_repset = 'off';
 ALTER SYSTEM SET spock.allow_ddl_from_functions = 'off';

--- a/tests/regress/sql/basic.sql
+++ b/tests/regress/sql/basic.sql
@@ -119,12 +119,17 @@ DROP FUNCTION call_fn;
 
 -- A label creation checks
 CREATE TABLE slabel (x integer, y text PRIMARY KEY);
+CREATE TABLE slabel_ri (x integer NOT NULL, y text);
+CREATE UNIQUE INDEX slabel_ri_idx ON slabel_ri(x);
+ALTER TABLE slabel_ri REPLICA IDENTITY USING INDEX slabel_ri_idx;
 
 SELECT spock.delta_apply('slabel', 'x');
 SELECT spock.delta_apply('slabel', 'y'); -- ERROR
 SELECT spock.delta_apply('slabel', 'z'); -- ERROR
 SELECT spock.delta_apply('slabel', 'x'); -- repeating call do nothing
+SELECT spock.delta_apply('slabel_ri', 'x'); -- ERROR
 SELECT objname, label FROM pg_seclabels;
+DROP TABLE slabel_ri CASCADE;
 
 -- Short round trip to check that subscriber has no security labels
 \c :subscriber_dsn

--- a/tests/regress/sql/basic.sql
+++ b/tests/regress/sql/basic.sql
@@ -118,8 +118,8 @@ DROP FUNCTION call_fn;
 --
 
 -- A label creation checks
-CREATE TABLE slabel (x integer, y text PRIMARY KEY);
-CREATE TABLE slabel_ri (x integer NOT NULL, y text);
+CREATE TABLE slabel (x integer NOT NULL, y text PRIMARY KEY);
+CREATE TABLE slabel_ri (x integer NOT NULL, y text, z text);
 CREATE UNIQUE INDEX slabel_ri_idx ON slabel_ri(x);
 ALTER TABLE slabel_ri REPLICA IDENTITY USING INDEX slabel_ri_idx;
 
@@ -147,7 +147,7 @@ SELECT spock.delta_apply('slabel', 'x', false);
 ALTER TABLE slabel ALTER COLUMN x TYPE text; -- just warn
 SELECT objname, label FROM pg_seclabels;
 ALTER TABLE slabel DROP COLUMN x;
-ALTER TABLE slabel ADD COLUMN x numeric;
+ALTER TABLE slabel ADD COLUMN x numeric NOT NULL;
 SELECT spock.delta_apply('slabel', 'x', false);
 ALTER TABLE slabel DROP COLUMN x;
 SELECT objname, label FROM pg_seclabels;

--- a/tests/regress/sql/basic.sql
+++ b/tests/regress/sql/basic.sql
@@ -119,11 +119,17 @@ DROP FUNCTION call_fn;
 
 -- A label creation checks
 CREATE TABLE slabel (x integer, y text PRIMARY KEY);
+
 SELECT spock.delta_apply('slabel', 'x');
 SELECT spock.delta_apply('slabel', 'y'); -- ERROR
 SELECT spock.delta_apply('slabel', 'z'); -- ERROR
 SELECT spock.delta_apply('slabel', 'x'); -- repeating call do nothing
 SELECT objname, label FROM pg_seclabels;
+
+-- Short round trip to check that subscriber has no security labels
+\c :subscriber_dsn
+SELECT objname, label FROM pg_seclabels;
+\c :provider_dsn
 
 -- Label drop checks
 SELECT spock.delta_apply('slabel', 'x', true);

--- a/tests/regress/sql/infofuncs.sql
+++ b/tests/regress/sql/infofuncs.sql
@@ -10,7 +10,7 @@ FROM pg_extension
 WHERE extname = 'spock';
 
 -- Check that security label is cleaned up on the extension drop
-CREATE TABLE slabel (x money, y text PRIMARY KEY);
+CREATE TABLE slabel (x money NOT NULL, y text PRIMARY KEY);
 SELECT spock.delta_apply('slabel', 'x', false);
 SELECT objname, label FROM pg_seclabels;
 

--- a/tests/regress/sql/infofuncs.sql
+++ b/tests/regress/sql/infofuncs.sql
@@ -9,4 +9,12 @@ SELECT spock.spock_version() = extversion
 FROM pg_extension
 WHERE extname = 'spock';
 
+-- Check that security label is cleaned up on the extension drop
+CREATE TABLE slabel (x money, y text PRIMARY KEY);
+SELECT spock.delta_apply('slabel', 'x', false);
+SELECT objname, label FROM pg_seclabels;
+
 DROP EXTENSION spock;
+
+SELECT objname, label FROM pg_seclabels;
+DROP TABLE slabel;

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -34,6 +34,7 @@ test: 014_pgdump_restore_conflict
 #        break
 #    fi
 # done
+test: 012_delta_apply
 test: 013_exception_handling
 # test: 014_rolling_upgrade
 test: 015_skip_lsn

--- a/tests/tap/t/012_delta_apply.pl
+++ b/tests/tap/t/012_delta_apply.pl
@@ -1,0 +1,102 @@
+use strict;
+use warnings;
+use Test::More tests => 13;
+use IPC::Run;
+use lib '.';
+use lib 't';
+use SpockTest qw(create_cluster destroy_cluster system_or_bail get_test_config cross_wire psql_or_bail scalar_query);
+
+my ($result1, $result2, $result3, $lsn1, $lsn2);
+
+create_cluster(3, 'Create initial 3-node Spock test cluster');
+cross_wire(3, ['n1', 'n2', 'n3'], 'Cross-wire nodes');
+# Get cluster configuration
+my $config = get_test_config();
+my $node_count = $config->{node_count};
+my $node_ports = $config->{node_ports};
+my $host = $config->{host};
+my $dbname = $config->{db_name};
+my $db_user = $config->{db_user};
+my $db_password = $config->{db_password};
+my $pg_bin = $config->{pg_bin};
+
+psql_or_bail(1, qq(
+	CREATE TABLE t1 (id integer PRIMARY KEY, x integer NOT NULL, y integer);
+	INSERT INTO t1 (id, x) VALUES (1,42);
+));
+
+psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+psql_or_bail(2, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+psql_or_bail(3, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+
+psql_or_bail(1, "SELECT spock.delta_apply('t1', 'x');");
+psql_or_bail(2, "SELECT spock.delta_apply('t1', 'x');");
+psql_or_bail(3, "SELECT spock.delta_apply('t1', 'x');");
+
+psql_or_bail(3, q(
+CREATE PROCEDURE counter_change(relname name, attname name,
+								value integer, cycles integer)
+AS $$
+DECLARE
+	i integer := 0;
+BEGIN
+  WHILE i < cycles LOOP
+    EXECUTE format('UPDATE %I SET %s = %s + %L;', relname, attname, attname, value);
+	-- raise WARNING '[%] iteration % from %', value, i, cycles;
+	COMMIT;
+	i := i + 1;
+
+  END LOOP;
+  raise NOTICE '[%] FINISH: iteration % from %', value, i, cycles;
+END;
+$$ LANGUAGE plpgsql;));
+
+psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+psql_or_bail(2, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+psql_or_bail(3, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+
+$result1 = scalar_query(1,"SELECT * FROM pg_catalog.pg_seclabels");
+$result2 = scalar_query(2,"SELECT * FROM pg_catalog.pg_seclabels");
+$result3 = scalar_query(3,"SELECT * FROM pg_catalog.pg_seclabels");
+print STDERR "DEBUGGING. Spock nodes IDs: \n$result1 $result2 $result3\n";
+
+my ($pgbench_stdout1, $pgbench_stderr1) = ('', '');
+my $phandle1 = IPC::Run::start(
+	[
+		'psql',
+		'-c', "CALL counter_change('t1', 'x', -1, 10000)",
+		'-h', $host, '-p', $node_ports->[1], '-U', $db_user, $dbname
+	],
+	'>' => \$pgbench_stdout1,
+	'2>' => \$pgbench_stderr1);
+#$phandle1->pump();
+
+psql_or_bail(1, "CALL counter_change('t1', 'x', +1, 10001)");
+
+$phandle1->finish;
+is($phandle1->full_result(0), 0, "alternative run successfull");
+
+print STDERR "##### output of psql #####\n";
+print STDERR "$pgbench_stdout1";
+print STDERR "$pgbench_stderr1";
+print STDERR "##### end of output #####\n";
+
+# Wait for sync ...
+$lsn1 = scalar_query(1, "SELECT spock.sync_event()");
+$lsn2 = scalar_query(2, "SELECT spock.sync_event()");
+psql_or_bail(1, "CALL spock.wait_for_sync_event(true, 'n2', '$lsn2'::pg_lsn, 600)");
+psql_or_bail(2, "CALL spock.wait_for_sync_event(true, 'n1', '$lsn1'::pg_lsn, 600)");
+psql_or_bail(3, "CALL spock.wait_for_sync_event(true, 'n1', '$lsn1'::pg_lsn, 600)");
+psql_or_bail(3, "CALL spock.wait_for_sync_event(true, 'n2', '$lsn2'::pg_lsn, 600)");
+
+$result1 = scalar_query(1, "SELECT x FROM t1");
+$result2 = scalar_query(2, "SELECT x FROM t1");
+$result3 = scalar_query(3, "SELECT x FROM t1");
+
+ok($result1 eq '43', "Data on the node N1 has correct value");
+ok($result1 eq $result3, "Equality of the data on N1 and N3 is confirmed");
+ok($result2 eq $result3, "Equality of the data on N2 and N3 is confirmed");
+print STDERR "DEBUGGING. Results: $result1 | $result2 | $result3\n";
+
+# Cleanup will be handled by SpockTest.pm END block
+# No need for done_testing() when using a test plan

--- a/tests/tap/t/012_delta_apply.pl
+++ b/tests/tap/t/012_delta_apply.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 13;
+use Test::More tests => 14;
 use IPC::Run;
 use lib '.';
 use lib 't';
@@ -30,8 +30,8 @@ psql_or_bail(2, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
 psql_or_bail(3, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
 
 psql_or_bail(1, "SELECT spock.delta_apply('t1', 'x');");
-psql_or_bail(2, "SELECT spock.delta_apply('t1', 'x');");
-psql_or_bail(3, "SELECT spock.delta_apply('t1', 'x');");
+#psql_or_bail(2, "SELECT spock.delta_apply('t1', 'x');");
+#psql_or_bail(3, "SELECT spock.delta_apply('t1', 'x');");
 
 psql_or_bail(3, q(
 CREATE PROCEDURE counter_change(relname name, attname name,
@@ -98,5 +98,10 @@ ok($result1 eq $result3, "Equality of the data on N1 and N3 is confirmed");
 ok($result2 eq $result3, "Equality of the data on N2 and N3 is confirmed");
 print STDERR "DEBUGGING. Results: $result1 | $result2 | $result3\n";
 
+# Remove delta_apply from the column x and set it on the column y
+psql_or_bail(1, "SELECT spock.delta_apply('t1', 'x', true)");
+$result1 = scalar_query(1, "SELECT spock.delta_apply('t1', 'y')"); # ERROR
+print STDERR "DEBUGGING. Result: $result1\n";
+ok($result1 eq 'f', "delta_apply can't be used with nullable columns");
 # Cleanup will be handled by SpockTest.pm END block
 # No need for done_testing() when using a test plan


### PR DESCRIPTION
These were previously removed, now added back, however the patches to PG 15 - 18 will remain. That way, Spock 5.x and 6.x will continue to work against the same single version of Postgres; the existing patched delta apply code is simply unused if using Spock 6.