### PR TITLE
autoddl: keep ALTER TABLE from yanking tables out of custom repsets

### DIFF
--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -527,6 +527,31 @@ classify_alter_pkri_change(AlterTableStmt *atstmt, Relation targetrel)
 						has_add_pkri_cmd = true;
 				}
 				break;
+			case AT_AddColumn:
+				/*
+				 * "ALTER TABLE ... ADD COLUMN x int PRIMARY KEY" arrives as
+				 * AT_AddColumn with the PRIMARY KEY embedded in the
+				 * ColumnDef's inline constraints list, not as a separate
+				 * AT_AddConstraint command.
+				 */
+				if (cmd->def && IsA(cmd->def, ColumnDef))
+				{
+					ColumnDef  *col = (ColumnDef *) cmd->def;
+					ListCell   *cc;
+
+					foreach(cc, col->constraints)
+					{
+						Constraint *con = (Constraint *) lfirst(cc);
+
+						if (IsA(con, Constraint) &&
+							con->contype == CONSTR_PRIMARY)
+						{
+							has_add_pkri_cmd = true;
+							break;
+						}
+					}
+				}
+				break;
 			case AT_ReplicaIdentity:
 				/*
 				 * Could be adding or removing RI; let the post-state

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -35,13 +35,35 @@
 #include "spock_output_plugin.h"
 #include "spock.h"
 
+/*
+ * Classification of a post-execution ALTER TABLE with respect to the
+ * table's primary key / replica identity. apply_repset_policy_for_reloid()
+ * runs after the DDL has executed, so post-state is read from the relcache
+ * and combined with parse-tree intent. "PKRI" covers PK and replica
+ * identity since either is sufficient for UPDATE/DELETE replication.
+ */
+typedef enum AlterPkRiChange
+{
+	PKRI_UNCHANGED = 0,
+	PKRI_ADDED,
+	PKRI_DROPPED
+} AlterPkRiChange;
+
 static void remove_table_from_repsets(Oid nodeid, Oid reloid,
 									  bool only_for_update);
 static bool autoddl_can_proceed(Node *parsetree, ProcessUtilityContext context,
 								NodeTag toplevel_stmt);
 static bool extract_ddl_target(Node *parsetree, RangeVar **relation,
-							   Oid *reloid, bool *missing_ok);
-static void apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid);
+							   Oid *reloid, bool *missing_ok,
+							   bool *check_alter_stickiness);
+static void apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
+										   AlterTableStmt *atstmt,
+										   bool check_alter_stickiness);
+static AlterPkRiChange classify_alter_pkri_change(AlterTableStmt *atstmt,
+												  Relation targetrel);
+static void classify_repset_membership(Oid nodeid, Oid reloid,
+									   bool *in_any_upd_del,
+									   bool *in_any_custom);
 
 /*
  * spock_autoddl_process
@@ -143,11 +165,14 @@ add_ddl_to_repset(Node *parsetree)
 	List		   *reloids = NIL;
 	ListCell	   *lc;
 	bool			missing_ok = false;
+	bool			check_alter_stickiness = false;
+	AlterTableStmt *atstmt;
 
 	if (!spock_include_ddl_repset)
 		return;
 
-	if (!extract_ddl_target(parsetree, &relation, &reloid, &missing_ok))
+	if (!extract_ddl_target(parsetree, &relation, &reloid, &missing_ok,
+							&check_alter_stickiness))
 		return;
 
 	node = get_local_node(false, true);
@@ -174,8 +199,11 @@ add_ddl_to_repset(Node *parsetree)
 		reloids = lappend_oid(reloids, reloid);
 	table_close(targetrel, NoLock);
 
+	atstmt = check_alter_stickiness ? (AlterTableStmt *) parsetree : NULL;
+
 	foreach(lc, reloids)
-		apply_repset_policy_for_reloid(node, lfirst_oid(lc));
+		apply_repset_policy_for_reloid(node, lfirst_oid(lc), atstmt,
+									   check_alter_stickiness);
 }
 
 /*
@@ -189,14 +217,18 @@ add_ddl_to_repset(Node *parsetree)
  * statement.
  *
  * On a true return:
- *	*relation	- RangeVar of the target, or NULL if *reloid is set
- *	*reloid		- pre-resolved oid (currently only the
- *				  ALTER INDEX ... ATTACH PARTITION path)
- *	*missing_ok	- whether table_openrv_extended should tolerate a missing rel
+ *	*relation				- RangeVar of the target, or NULL if *reloid is set
+ *	*reloid					- pre-resolved oid (currently only the
+ *							  ALTER INDEX ... ATTACH PARTITION path)
+ *	*missing_ok				- whether table_openrv_extended should tolerate a
+ *							  missing relation
+ *	*check_alter_stickiness	- true for plain ALTER TABLE; the caller will
+ *							  apply ALTER stickiness rules in the per-reloid
+ *							  policy
  */
 static bool
 extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
-				   bool *missing_ok)
+				   bool *missing_ok, bool *check_alter_stickiness)
 {
 	switch (nodeTag(parsetree))
 	{
@@ -205,15 +237,18 @@ extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
 				AlterTableStmt *atstmt = (AlterTableStmt *) parsetree;
 
 				if (atstmt->objtype == OBJECT_TABLE)
+				{
 					*relation = atstmt->relation;
+					*check_alter_stickiness = true;
+				}
 				else if (atstmt->objtype == OBJECT_INDEX)
 				{
 					ListCell *cell;
 
 					/*
 					 * ALTER INDEX ... ATTACH PARTITION may complete a
-					 * partitioned primary key, so re-evaluate the partitioned
-					 * table that owns the index.
+					 * partitioned primary key, so always re-evaluate (no
+					 * stickiness check).
 					 */
 					foreach(cell, atstmt->cmds)
 					{
@@ -297,12 +332,27 @@ extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
  * apply_repset_policy_for_reloid
  *		Repset routing for a single concrete relation oid.
  *
+ *	atstmt is the originating ALTER TABLE statement, or NULL if this DDL was
+ *	not an ALTER TABLE. check_alter_stickiness must match: it is true iff
+ *	atstmt is non-NULL and ALTER stickiness rules should be applied.
+ *
+ * Decision tree:
  *	- UNLOGGED/TEMP	-> evict from every repset, done.
- *	- PK or replica identity present -> 'default' repset.
- *	- No PK/RI -> 'default_insert_only'.
+ *	- ALTER with no PK/RI change -> leave membership alone (sticky).
+ *	- ALTER that adds/drops PK on a table in a custom repset:
+ *		- PK dropped + custom repset replicates UPD/DEL: WARNING, fall through
+ *		  and move to default_insert_only (replication would break otherwise).
+ *		- PK added on a custom repset: NOTICE and leave membership alone.
+ *		- Otherwise: leave membership alone.
+ *	- Else (CREATE, CREATE TABLE AS, ATTACH PARTITION, ALTER with no custom
+ *	  repset, or fall-through from the PK-dropped safety net):
+ *		- PK or replica identity present -> 'default' repset.
+ *		- No PK/RI -> 'default_insert_only'.
  */
 static void
-apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid)
+apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
+							   AlterTableStmt *atstmt,
+							   bool check_alter_stickiness)
 {
 	Relation		targetrel;
 	SpockRepSet	   *repset;
@@ -318,11 +368,92 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid)
 	}
 
 	/*
-	 * Force index list build so rd_pkindex and rd_replidindex are populated
-	 * before we read them below.
+	 * Force index list build so rd_pkindex and rd_replidindex reflect the
+	 * post-ALTER state before we read them below.
 	 */
 	if (targetrel->rd_indexvalid == 0)
 		RelationGetIndexList(targetrel);
+
+	/*
+	 * ALTER TABLE stickiness.
+	 *
+	 *	PKRI_UNCHANGED	- leave membership entirely alone.
+	 *	PKRI_DROPPED	- any UPD/DEL repset (default or custom) now has a
+	 *					  table without a PK/RI and would produce broken
+	 *					  replication. Emit WARNING when a custom membership
+	 *					  is affected, then fall through and let the routing
+	 *					  block evict from UPD/DEL repsets and place the
+	 *					  table in default_insert_only. If the table is only
+	 *					  in insert-only repsets (custom and/or
+	 *					  default_insert_only), there is nothing to fix —
+	 *					  stay sticky.
+	 *	PKRI_ADDED		- tables in any custom repset stay sticky (operator
+	 *					  intent) and get a NOTICE; tables that are only
+	 *					  default-managed fall through to standard routing
+	 *					  (e.g. move from default_insert_only to default).
+	 */
+	if (check_alter_stickiness)
+	{
+		AlterPkRiChange pkchange;
+		bool			in_any_upd_del;
+		bool			in_any_custom;
+
+		pkchange = classify_alter_pkri_change(atstmt, targetrel);
+
+		if (pkchange == PKRI_UNCHANGED)
+		{
+			table_close(targetrel, NoLock);
+			return;
+		}
+
+		classify_repset_membership(node->node->id, reloid,
+								   &in_any_upd_del, &in_any_custom);
+
+		if (pkchange == PKRI_DROPPED)
+		{
+			if (in_any_upd_del)
+			{
+				/*
+				 * One or more UPD/DEL memberships need the now-missing
+				 * PK/RI. Loud-warn only when a custom membership is in
+				 * play, since pure default-routed tables already produce
+				 * an INFO from the standard remove+add flow.
+				 */
+				if (in_any_custom)
+					ereport(WARNING,
+							(errmsg("table \"%s\" lost its primary key while in a replication set that replicates UPDATE/DELETE; moving to \"%s\"",
+									get_rel_name(reloid),
+									DEFAULT_INSONLY_REPSET_NAME)));
+				/* fall through to the remove+add path below */
+			}
+			else if (in_any_custom)
+			{
+				/*
+				 * Only insert-only memberships (custom and/or
+				 * default_insert_only). Nothing replicates UPD/DEL so the
+				 * missing PK is harmless. Sticky.
+				 */
+				table_close(targetrel, NoLock);
+				return;
+			}
+			/* else: no custom, no UPD/DEL — fall through */
+		}
+		else	/* PKRI_ADDED */
+		{
+			if (in_any_custom)
+			{
+				ereport(NOTICE,
+						(errmsg("table \"%s\" gained a primary key while in a custom replication set; leaving membership unchanged",
+								get_rel_name(reloid)),
+						 errhint("Move the table to \"%s\" manually if full UPDATE/DELETE replication is desired.",
+								 DEFAULT_REPSET_NAME)));
+				/* sticky: respect the operator's custom placement */
+				table_close(targetrel, NoLock);
+				return;
+			}
+			/* else: only default-managed — fall through to standard routing */
+		}
+	}
 
 	/* Choose default vs default_insert_only based on PK/RI presence. */
 	if (OidIsValid(targetrel->rd_pkindex) || OidIsValid(targetrel->rd_replidindex))
@@ -355,6 +486,112 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid)
 		replication_set_add_table(repset->id, reloid, NIL, NULL);
 		elog(LOG, "table '%s' was added to '%s' replication set.",
 			 get_rel_name(reloid), repset->name);
+	}
+}
+
+/*
+ * classify_alter_pkri_change
+ *		Determine, given the AlterTableStmt and the post-execution relcache
+ *		state, whether this ALTER added a primary key / replica identity,
+ *		dropped one, or left PK/RI unchanged.
+ *
+ * Called after standard utility processing, so targetrel reflects the new
+ * state. Parse-tree intent narrows ambiguity (e.g. AT_DropConstraint may
+ * have targeted a UNIQUE, not the PK — but if the post-state still has a
+ * PK, we know the PK was not dropped).
+ */
+static AlterPkRiChange
+classify_alter_pkri_change(AlterTableStmt *atstmt, Relation targetrel)
+{
+	ListCell   *cell;
+	bool		has_add_pkri_cmd = false;
+	bool		has_drop_pkri_candidate = false;
+	bool		post_has_pk_or_ri;
+
+	post_has_pk_or_ri = OidIsValid(targetrel->rd_pkindex) ||
+		OidIsValid(targetrel->rd_replidindex);
+
+	foreach(cell, atstmt->cmds)
+	{
+		AlterTableCmd *cmd = (AlterTableCmd *) lfirst(cell);
+
+		switch (cmd->subtype)
+		{
+			case AT_AddConstraint:
+			case AT_AddIndexConstraint:
+				if (cmd->def && IsA(cmd->def, Constraint))
+				{
+					Constraint *con = (Constraint *) cmd->def;
+
+					if (con->contype == CONSTR_PRIMARY)
+						has_add_pkri_cmd = true;
+				}
+				break;
+			case AT_ReplicaIdentity:
+				/*
+				 * Could be adding or removing RI; let the post-state
+				 * disambiguate.
+				 */
+				has_add_pkri_cmd = true;
+				has_drop_pkri_candidate = true;
+				break;
+			case AT_DropConstraint:
+			case AT_DropColumn:
+				has_drop_pkri_candidate = true;
+				break;
+			default:
+				break;
+		}
+	}
+
+	if (post_has_pk_or_ri && has_add_pkri_cmd)
+		return PKRI_ADDED;
+	if (!post_has_pk_or_ri && has_drop_pkri_candidate)
+		return PKRI_DROPPED;
+	return PKRI_UNCHANGED;
+}
+
+/*
+ * classify_repset_membership
+ *		Single-pass classification of a table's current repset membership.
+ *
+ *	in_any_upd_del	- true if the table is in any repset (default or custom)
+ *					  that replicates UPDATE or DELETE. Such repsets require
+ *					  a PK / replica identity to function.
+ *	in_any_custom	- true if the table is in at least one user-defined
+ *					  (non-default) repset. Signals that ALTER stickiness
+ *					  should respect the operator's manual placement.
+ *
+ * Combining both questions into one walk avoids re-fetching the membership
+ * list in the stickiness path.
+ */
+static void
+classify_repset_membership(Oid nodeid, Oid reloid,
+						   bool *in_any_upd_del,
+						   bool *in_any_custom)
+{
+	List	   *repsets = get_table_replication_sets(nodeid, reloid);
+	ListCell   *lc;
+
+	*in_any_upd_del = false;
+	*in_any_custom = false;
+
+	foreach(lc, repsets)
+	{
+		SpockRepSet *rs = (SpockRepSet *) lfirst(lc);
+		bool		is_default;
+
+		is_default = (strcmp(rs->name, DEFAULT_REPSET_NAME) == 0 ||
+					  strcmp(rs->name, DEFAULT_INSONLY_REPSET_NAME) == 0);
+
+		if (!is_default)
+			*in_any_custom = true;
+
+		if (rs->replicate_update || rs->replicate_delete)
+			*in_any_upd_del = true;
+
+		if (*in_any_upd_del && *in_any_custom)
+			break;	/* both flags are now in their terminal state */
 	}
 }
 

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -57,8 +57,7 @@ static bool extract_ddl_target(Node *parsetree, RangeVar **relation,
 							   Oid *reloid, bool *missing_ok,
 							   bool *check_alter_stickiness);
 static void apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
-										   AlterTableStmt *atstmt,
-										   bool check_alter_stickiness);
+										   AlterTableStmt *atstmt);
 static AlterPkRiChange classify_alter_pkri_change(AlterTableStmt *atstmt,
 												  Relation targetrel);
 static void classify_repset_membership(Oid nodeid, Oid reloid,
@@ -202,8 +201,7 @@ add_ddl_to_repset(Node *parsetree)
 	atstmt = check_alter_stickiness ? (AlterTableStmt *) parsetree : NULL;
 
 	foreach(lc, reloids)
-		apply_repset_policy_for_reloid(node, lfirst_oid(lc), atstmt,
-									   check_alter_stickiness);
+		apply_repset_policy_for_reloid(node, lfirst_oid(lc), atstmt);
 }
 
 /*
@@ -262,7 +260,7 @@ extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
 													 AccessShareLock);
 							*reloid = IndexGetRelation(RelationGetRelid(indrel),
 													   false);
-							table_close(indrel, NoLock);
+							relation_close(indrel, NoLock);
 						}
 					}
 
@@ -333,8 +331,7 @@ extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
  *		Repset routing for a single concrete relation oid.
  *
  *	atstmt is the originating ALTER TABLE statement, or NULL if this DDL was
- *	not an ALTER TABLE. check_alter_stickiness must match: it is true iff
- *	atstmt is non-NULL and ALTER stickiness rules should be applied.
+ *	not an ALTER TABLE (in which case stickiness rules are skipped).
  *
  * Decision tree:
  *	- UNLOGGED/TEMP	-> evict from every repset, done.
@@ -351,8 +348,7 @@ extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
  */
 static void
 apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
-							   AlterTableStmt *atstmt,
-							   bool check_alter_stickiness)
+							   AlterTableStmt *atstmt)
 {
 	Relation		targetrel;
 	SpockRepSet	   *repset;
@@ -392,7 +388,7 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
 	 *					  default-managed fall through to standard routing
 	 *					  (e.g. move from default_insert_only to default).
 	 */
-	if (check_alter_stickiness)
+	if (atstmt != NULL)
 	{
 		AlterPkRiChange pkchange;
 		bool			in_any_upd_del;
@@ -421,7 +417,7 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
 				 */
 				if (in_any_custom)
 					ereport(WARNING,
-							(errmsg("table \"%s\" lost its primary key while in a replication set that replicates UPDATE/DELETE; moving to \"%s\"",
+							(errmsg("table \"%s\" has no replica identity while in a replication set that replicates UPDATE/DELETE; moving to \"%s\"",
 									get_rel_name(reloid),
 									DEFAULT_INSONLY_REPSET_NAME)));
 				/* fall through to the remove+add path below */
@@ -509,7 +505,8 @@ classify_alter_pkri_change(AlterTableStmt *atstmt, Relation targetrel)
 	bool		post_has_pk_or_ri;
 
 	post_has_pk_or_ri = OidIsValid(targetrel->rd_pkindex) ||
-		OidIsValid(targetrel->rd_replidindex);
+		OidIsValid(targetrel->rd_replidindex) ||
+		targetrel->rd_rel->relreplident == REPLICA_IDENTITY_FULL;
 
 	foreach(cell, atstmt->cmds)
 	{
@@ -553,15 +550,38 @@ classify_alter_pkri_change(AlterTableStmt *atstmt, Relation targetrel)
 				}
 				break;
 			case AT_ReplicaIdentity:
-				/*
-				 * Could be adding or removing RI; let the post-state
-				 * disambiguate.
-				 */
-				has_add_pkri_cmd = true;
-				has_drop_pkri_candidate = true;
+				{
+					ReplicaIdentityStmt *ri = (ReplicaIdentityStmt *) cmd->def;
+
+					if (ri->identity_type == REPLICA_IDENTITY_FULL ||
+						ri->identity_type == REPLICA_IDENTITY_INDEX)
+						has_add_pkri_cmd = true;
+					else if (ri->identity_type == REPLICA_IDENTITY_NOTHING)
+						has_drop_pkri_candidate = true;
+					else
+					{
+						/*
+						 * REPLICA_IDENTITY_DEFAULT resets to "use the primary
+						 * key if one exists, otherwise nothing".  We cannot
+						 * determine the effective direction from the parse tree
+						 * alone, so set both flags and let the post-state
+						 * disambiguate: if rd_pkindex is valid after the ALTER,
+						 * the table gains effective RI (PKRI_ADDED); if not,
+						 * it loses whatever RI was in effect (PKRI_DROPPED).
+						 */
+						has_add_pkri_cmd = true;
+						has_drop_pkri_candidate = true;
+					}
+				}
 				break;
 			case AT_DropConstraint:
 			case AT_DropColumn:
+				/*
+				 * Pessimistic: any constraint or column drop could remove
+				 * the PK.  The post-state check (!post_has_pk_or_ri) is the
+				 * real filter; if the table still has a PK/RI after the
+				 * ALTER, PKRI_UNCHANGED is returned regardless.
+				 */
 				has_drop_pkri_candidate = true;
 				break;
 			default:
@@ -654,12 +674,8 @@ static bool
 autoddl_can_proceed(Node *parsetree, ProcessUtilityContext context,
 					NodeTag toplevel_stmt)
 {
+	/* Repair mode: nothing should be decoded and sent to subscribers. */
 	if (spock_replication_repair_mode)
-
-		/*
-		 * Repair mode means that nothing happened in this state should be
-		 * decoded and sent to any subscriber.
-		 */
 		return false;
 
 	/* Only process DDL statements */

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -39,6 +39,9 @@ static void remove_table_from_repsets(Oid nodeid, Oid reloid,
 									  bool only_for_update);
 static bool autoddl_can_proceed(Node *parsetree, ProcessUtilityContext context,
 								NodeTag toplevel_stmt);
+static bool extract_ddl_target(Node *parsetree, RangeVar **relation,
+							   Oid *reloid, bool *missing_ok);
+static void apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid);
 
 /*
  * spock_autoddl_process
@@ -120,15 +123,20 @@ end:
 
 /*
  * add_ddl_to_repset
- *		Check if the DDL statement can be added to the replication set. (For
- * now only tables are added). The function also checks whether the table has
- * needed indexes to be added to replication set. If not, they are ignored.
+ *		Route a just-executed DDL statement into the appropriate replication
+ *		set(s). Only tables are auto-managed.
+ *
+ * Pipeline:
+ *	1. extract_ddl_target() inspects the parse tree, decides if this DDL
+ *	   targets a table, and reports the target.
+ *	2. The target is opened and (if partitioned) expanded into all inheritors.
+ *	3. apply_repset_policy_for_reloid() handles each concrete relation:
+ *	   UNLOGGED/TEMP skip and default/insert-only repset routing.
  */
 void
 add_ddl_to_repset(Node *parsetree)
 {
 	Relation		targetrel;
-	SpockRepSet	   *repset;
 	SpockLocalNode *node;
 	Oid				reloid = InvalidOid;
 	RangeVar	   *relation = NULL;
@@ -136,88 +144,11 @@ add_ddl_to_repset(Node *parsetree)
 	ListCell	   *lc;
 	bool			missing_ok = false;
 
-	/* no need to proceed if spock_include_ddl_repset is off */
 	if (!spock_include_ddl_repset)
 		return;
 
-	if (nodeTag(parsetree) == T_AlterTableStmt)
-	{
-		if (castNode(AlterTableStmt, parsetree)->objtype == OBJECT_TABLE)
-			relation = castNode(AlterTableStmt, parsetree)->relation;
-		else if (castNode(AlterTableStmt, parsetree)->objtype == OBJECT_INDEX)
-		{
-			ListCell   *cell;
-			AlterTableStmt *atstmt = (AlterTableStmt *) parsetree;
-
-			foreach(cell, atstmt->cmds)
-			{
-				AlterTableCmd *cmd = (AlterTableCmd *) lfirst(cell);
-
-				if (cmd->subtype == AT_AttachPartition)
-				{
-					RangeVar   *rv = castNode(AlterTableStmt, parsetree)->relation;
-					Relation	indrel;
-
-					indrel = relation_openrv(rv, AccessShareLock);
-					reloid = IndexGetRelation(RelationGetRelid(indrel), false);
-					table_close(indrel, NoLock);
-				}
-			}
-
-			if (!OidIsValid(reloid))
-				return;
-		}
-		else
-		{
-			return;
-		}
-
-		missing_ok = ((AlterTableStmt *) parsetree)->missing_ok;
-	}
-	else if (nodeTag(parsetree) == T_CreateStmt)
-		relation = castNode(CreateStmt, parsetree)->relation;
-	else if (nodeTag(parsetree) == T_CreateTableAsStmt &&
-			 castNode(CreateTableAsStmt, parsetree)->objtype == OBJECT_TABLE)
-		relation = castNode(CreateTableAsStmt, parsetree)->into->rel;
-	else if (nodeTag(parsetree) == T_CreateSchemaStmt)
-	{
-		ListCell   *cell;
-		CreateSchemaStmt *cstmt = (CreateSchemaStmt *) parsetree;
-
-		foreach(cell, cstmt->schemaElts)
-		{
-			if (nodeTag(lfirst(cell)) == T_CreateStmt)
-				add_ddl_to_repset(lfirst(cell));
-		}
+	if (!extract_ddl_target(parsetree, &relation, &reloid, &missing_ok))
 		return;
-	}
-	else if (nodeTag(parsetree) == T_ExplainStmt)
-	{
-		ExplainStmt *stmt = (ExplainStmt *) parsetree;
-		bool		analyze = false;
-		ListCell   *cell;
-
-		/* Look through an EXPLAIN ANALYZE to the contained stmt */
-		foreach(cell, stmt->options)
-		{
-			DefElem    *opt = (DefElem *) lfirst(cell);
-
-			if (strcmp(opt->defname, "analyze") == 0)
-				analyze = defGetBoolean(opt);
-			/* don't "break", as explain.c will use the last value */
-		}
-
-		if (analyze &&
-			castNode(Query, stmt->query)->commandType == CMD_UTILITY)
-			add_ddl_to_repset(castNode(Query, stmt->query)->utilityStmt);
-
-		return;
-	}
-	else
-	{
-		/* only tables are added to repset. */
-		return;
-	}
 
 	node = get_local_node(false, true);
 	if (!node)
@@ -226,15 +157,14 @@ add_ddl_to_repset(Node *parsetree)
 	if (OidIsValid(reloid))
 		targetrel = RelationIdGetRelation(reloid);
 	else
-	{
 		targetrel = table_openrv_extended(relation, AccessShareLock, missing_ok);
-		if (targetrel == NULL)
-		/*
-		 * If relation doesn't exist - quietly exit. It is assumed that the core
-		 * already produced an INFO message.
-		 */
-			return;
-	}
+
+	/*
+	 * If the relation doesn't exist (concurrent drop, or missing_ok hit),
+	 * quietly exit. The core already produced an INFO message.
+	 */
+	if (targetrel == NULL)
+		return;
 
 	reloid = RelationGetRelid(targetrel);
 
@@ -245,65 +175,186 @@ add_ddl_to_repset(Node *parsetree)
 	table_close(targetrel, NoLock);
 
 	foreach(lc, reloids)
+		apply_repset_policy_for_reloid(node, lfirst_oid(lc));
+}
+
+/*
+ * extract_ddl_target
+ *		Parse-tree dispatch: decide whether this DDL targets a table that
+ *		auto-DDL should auto-manage, and if so, fill in the target outputs.
+ *
+ * Returns true if *relation or *reloid identifies a target the caller should
+ * process. Returns false otherwise; in the CreateSchema and EXPLAIN ANALYZE
+ * cases this also recurses back into add_ddl_to_repset() for each contained
+ * statement.
+ *
+ * On a true return:
+ *	*relation	- RangeVar of the target, or NULL if *reloid is set
+ *	*reloid		- pre-resolved oid (currently only the
+ *				  ALTER INDEX ... ATTACH PARTITION path)
+ *	*missing_ok	- whether table_openrv_extended should tolerate a missing rel
+ */
+static bool
+extract_ddl_target(Node *parsetree, RangeVar **relation, Oid *reloid,
+				   bool *missing_ok)
+{
+	switch (nodeTag(parsetree))
 	{
-		reloid = lfirst_oid(lc);
-		targetrel = RelationIdGetRelation(reloid);
+		case T_AlterTableStmt:
+			{
+				AlterTableStmt *atstmt = (AlterTableStmt *) parsetree;
 
-		/* UNLOGGED and TEMP relations cannot be part of replication set. */
-		if (!RelationNeedsWAL(targetrel))
-		{
-			/* remove table from the repsets. */
-			remove_table_from_repsets(node->node->id, reloid, false);
+				if (atstmt->objtype == OBJECT_TABLE)
+					*relation = atstmt->relation;
+				else if (atstmt->objtype == OBJECT_INDEX)
+				{
+					ListCell *cell;
 
-			table_close(targetrel, NoLock);
-			return;
-		}
+					/*
+					 * ALTER INDEX ... ATTACH PARTITION may complete a
+					 * partitioned primary key, so re-evaluate the partitioned
+					 * table that owns the index.
+					 */
+					foreach(cell, atstmt->cmds)
+					{
+						AlterTableCmd *cmd = (AlterTableCmd *) lfirst(cell);
 
-		if (targetrel->rd_indexvalid == 0)
-			RelationGetIndexList(targetrel);
+						if (cmd->subtype == AT_AttachPartition)
+						{
+							Relation indrel;
 
-		/*
-		 * choose the 'default' repset, if table has PK or replica identity
-		 * defined.
-		 */
-		if (OidIsValid(targetrel->rd_pkindex) || OidIsValid(targetrel->rd_replidindex))
-		{
-			repset = get_replication_set_by_name(node->node->id, DEFAULT_REPSET_NAME, false);
+							indrel = relation_openrv(atstmt->relation,
+													 AccessShareLock);
+							*reloid = IndexGetRelation(RelationGetRelid(indrel),
+													   false);
+							table_close(indrel, NoLock);
+						}
+					}
 
-			/*
-			 * remove table from previous repsets, it will be added to
-			 * 'default' down below.
-			 */
-			remove_table_from_repsets(node->node->id, reloid, false);
-		}
-		else
-		{
-			repset = get_replication_set_by_name(node->node->id, DEFAULT_INSONLY_REPSET_NAME, false);
+					if (!OidIsValid(*reloid))
+						return false;
+				}
+				else
+					return false;
 
-			/*
-			 * no primary key defined. let's see if the table is part of any
-			 * other repset or not?
-			 */
-			remove_table_from_repsets(node->node->id, reloid, true);
-		}
+				*missing_ok = atstmt->missing_ok;
+				return true;
+			}
 
-		if (!OidIsValid(targetrel->rd_replidindex) &&
-			(repset->replicate_update || repset->replicate_delete))
-		{
-			table_close(targetrel, NoLock);
-			return;
-		}
+		case T_CreateStmt:
+			*relation = castNode(CreateStmt, parsetree)->relation;
+			return true;
 
+		case T_CreateTableAsStmt:
+			if (castNode(CreateTableAsStmt, parsetree)->objtype != OBJECT_TABLE)
+				return false;
+			*relation = castNode(CreateTableAsStmt, parsetree)->into->rel;
+			return true;
+
+		case T_CreateSchemaStmt:
+			{
+				CreateSchemaStmt *cstmt = (CreateSchemaStmt *) parsetree;
+				ListCell   *cell;
+
+				foreach(cell, cstmt->schemaElts)
+				{
+					if (nodeTag(lfirst(cell)) == T_CreateStmt)
+						add_ddl_to_repset(lfirst(cell));
+				}
+				return false;
+			}
+
+		case T_ExplainStmt:
+			{
+				ExplainStmt *stmt = (ExplainStmt *) parsetree;
+				bool		analyze = false;
+				ListCell   *cell;
+
+				/* Look through an EXPLAIN ANALYZE to the contained stmt */
+				foreach(cell, stmt->options)
+				{
+					DefElem    *opt = (DefElem *) lfirst(cell);
+
+					if (strcmp(opt->defname, "analyze") == 0)
+						analyze = defGetBoolean(opt);
+					/* don't "break", as explain.c will use the last value */
+				}
+
+				if (analyze &&
+					castNode(Query, stmt->query)->commandType == CMD_UTILITY)
+					add_ddl_to_repset(castNode(Query, stmt->query)->utilityStmt);
+
+				return false;
+			}
+
+		default:
+			/* only tables are added to repset. */
+			return false;
+	}
+}
+
+/*
+ * apply_repset_policy_for_reloid
+ *		Repset routing for a single concrete relation oid.
+ *
+ *	- UNLOGGED/TEMP	-> evict from every repset, done.
+ *	- PK or replica identity present -> 'default' repset.
+ *	- No PK/RI -> 'default_insert_only'.
+ */
+static void
+apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid)
+{
+	Relation		targetrel;
+	SpockRepSet	   *repset;
+
+	targetrel = RelationIdGetRelation(reloid);
+
+	/* UNLOGGED and TEMP relations cannot be part of replication set. */
+	if (!RelationNeedsWAL(targetrel))
+	{
+		remove_table_from_repsets(node->node->id, reloid, false);
 		table_close(targetrel, NoLock);
+		return;
+	}
 
-		/* Add if not already present. */
-		if (get_table_replication_row(repset->id, reloid, NULL, NULL) == NULL)
-		{
-			replication_set_add_table(repset->id, reloid, NIL, NULL);
+	/*
+	 * Force index list build so rd_pkindex and rd_replidindex are populated
+	 * before we read them below.
+	 */
+	if (targetrel->rd_indexvalid == 0)
+		RelationGetIndexList(targetrel);
 
-			elog(LOG, "table '%s' was added to '%s' replication set.",
-				 get_rel_name(reloid), repset->name);
-		}
+	/* Choose default vs default_insert_only based on PK/RI presence. */
+	if (OidIsValid(targetrel->rd_pkindex) || OidIsValid(targetrel->rd_replidindex))
+	{
+		repset = get_replication_set_by_name(node->node->id,
+											 DEFAULT_REPSET_NAME, false);
+		/* will be added to 'default' below; clear any prior membership */
+		remove_table_from_repsets(node->node->id, reloid, false);
+	}
+	else
+	{
+		repset = get_replication_set_by_name(node->node->id,
+											 DEFAULT_INSONLY_REPSET_NAME, false);
+		/* no PK: only evict from repsets that need UPDATE/DELETE */
+		remove_table_from_repsets(node->node->id, reloid, true);
+	}
+
+	if (!OidIsValid(targetrel->rd_replidindex) &&
+		(repset->replicate_update || repset->replicate_delete))
+	{
+		table_close(targetrel, NoLock);
+		return;
+	}
+
+	table_close(targetrel, NoLock);
+
+	/* Add if not already present. */
+	if (get_table_replication_row(repset->id, reloid, NULL, NULL) == NULL)
+	{
+		replication_set_add_table(repset->id, reloid, NIL, NULL);
+		elog(LOG, "table '%s' was added to '%s' replication set.",
+			 get_rel_name(reloid), repset->name);
 	}
 }
 

--- a/src/spock_executor.c
+++ b/src/spock_executor.c
@@ -15,6 +15,7 @@
 
 #include "access/hash.h"
 #include "access/htup_details.h"
+#include "access/table.h"
 #include "access/xact.h"
 #include "access/xlog.h"
 

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -48,6 +48,7 @@ test: 022_rmgr_progress_post_checkpoint_crash
 test: 022_apply_mem_context
 test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
+test: 030_autoddl_repset_stickiness
 test: 044_apply_change_logging
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match

--- a/tests/tap/t/030_autoddl_repset_stickiness.pl
+++ b/tests/tap/t/030_autoddl_repset_stickiness.pl
@@ -1,0 +1,167 @@
+use strict;
+use warnings;
+use Test::More tests => 25;
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster system_or_bail psql_or_bail
+                 scalar_query get_test_config);
+
+# =============================================================================
+# Test: 030_autoddl_repset_stickiness.pl
+# =============================================================================
+# With autoDDL + spock.include_ddl_repset, verify that:
+#   - ALTER TABLE that does not touch PK/RI leaves repset membership alone
+#   - tables placed in a user-defined repset are not yanked back into the
+#     default repsets on unrelated ALTERs
+#   - PK is only auto-managed when the ALTER actually adds or drops it
+#   - dropping a PK from a custom UPDATE/DELETE repset emits a WARNING
+#     and falls back to default_insert_only (replication safety net)
+#   - adding a PK to a table in a custom repset emits a NOTICE and
+#     leaves the membership unchanged
+
+# A single provider node is enough to exercise the local repset logic.
+create_cluster(1, 'Create single-node cluster for repset stickiness tests');
+
+my $config = get_test_config();
+my $node_port = $config->{node_ports}->[0];
+my $pg_bin    = $config->{pg_bin};
+my $dbname    = $config->{db_name};
+
+# Helper: comma-joined sorted list of repsets the table belongs to.
+sub repsets_for {
+    my ($relname) = @_;
+    return scalar_query(1,
+        "SELECT coalesce(string_agg(set_name, ',' ORDER BY set_name), '')" .
+        " FROM spock.tables WHERE relname = '$relname'" .
+        " AND set_name IS NOT NULL");
+}
+
+# Custom repsets.
+psql_or_bail(1, "SELECT spock.repset_create('spoc539_full')");
+psql_or_bail(1, "SELECT spock.repset_create('spoc539_insonly'," .
+                " replicate_update := false, replicate_delete := false)");
+
+# -----------------------------------------------------------------------------
+# T1: ALTER ADD COLUMN on a table in a custom repset -> sticky.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t1 (id int primary key, a text)");
+psql_or_bail(1, "SELECT spock.repset_remove_table('default', 'spoc539_t1')");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_full', 'spoc539_t1')");
+is(repsets_for('spoc539_t1'), 'spoc539_full',
+   'T1: table starts in custom repset only');
+psql_or_bail(1, "ALTER TABLE spoc539_t1 ADD COLUMN b int");
+is(repsets_for('spoc539_t1'), 'spoc539_full',
+   'T1: ALTER ADD COLUMN leaves custom-repset membership alone');
+
+# -----------------------------------------------------------------------------
+# T2: ALTER ADD COLUMN on a table in default -> still in default only.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t2 (id int primary key, a text)");
+is(repsets_for('spoc539_t2'), 'default',
+   'T2: table with PK auto-placed in default');
+psql_or_bail(1, "ALTER TABLE spoc539_t2 ADD COLUMN b int");
+is(repsets_for('spoc539_t2'), 'default',
+   'T2: ALTER ADD COLUMN does not churn default membership');
+
+# -----------------------------------------------------------------------------
+# T3: drop PK on a table in default -> default_insert_only.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t3 (id int primary key, a text)");
+is(repsets_for('spoc539_t3'), 'default',
+   'T3: table starts in default');
+psql_or_bail(1, "ALTER TABLE spoc539_t3 DROP CONSTRAINT spoc539_t3_pkey");
+is(repsets_for('spoc539_t3'), 'default_insert_only',
+   'T3: dropping PK moves table from default to default_insert_only');
+
+# -----------------------------------------------------------------------------
+# T4: drop PK on a table in a custom UPDATE/DELETE repset -> WARNING + move
+# to default_insert_only (custom membership would break replication).
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t4 (id int primary key, a text)");
+psql_or_bail(1, "SELECT spock.repset_remove_table('default', 'spoc539_t4')");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_full', 'spoc539_t4')");
+is(repsets_for('spoc539_t4'), 'spoc539_full',
+   'T4: table starts in custom UPDATE/DELETE repset');
+
+# Capture stderr for the DROP CONSTRAINT to assert the WARNING fired.
+my $t4_cmd = qq{$pg_bin/psql -X -p $node_port -d $dbname }
+           . qq{-c "ALTER TABLE spoc539_t4 DROP CONSTRAINT spoc539_t4_pkey" 2>&1};
+my $output = `$t4_cmd`;
+like($output, qr/WARNING:.*lost its primary key.*moving to/i,
+     'T4: WARNING emitted on PK drop from UPDATE/DELETE custom repset');
+is(repsets_for('spoc539_t4'), 'default_insert_only',
+   'T4: table moved to default_insert_only by safety net');
+
+# -----------------------------------------------------------------------------
+# T5: drop PK on a table in a custom insert-only repset -> sticky.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t5 (id int primary key, a text)");
+psql_or_bail(1, "SELECT spock.repset_remove_table('default', 'spoc539_t5')");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_insonly', 'spoc539_t5')");
+is(repsets_for('spoc539_t5'), 'spoc539_insonly',
+   'T5: table starts in custom insert-only repset');
+psql_or_bail(1, "ALTER TABLE spoc539_t5 DROP CONSTRAINT spoc539_t5_pkey");
+is(repsets_for('spoc539_t5'), 'spoc539_insonly',
+   'T5: dropping PK leaves table in custom insert-only repset');
+
+# -----------------------------------------------------------------------------
+# T6: add PK on a no-PK table that already lives in a custom insert-only repset
+# -> sticky (NOTICE emitted but membership unchanged). spoc539_full replicates
+# UPDATE/DELETE and would reject a no-PK table, so use the insert-only repset.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t6 (id int, a text)");
+psql_or_bail(1, "SELECT spock.repset_remove_table('default_insert_only', 'spoc539_t6')");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_insonly', 'spoc539_t6')");
+is(repsets_for('spoc539_t6'), 'spoc539_insonly',
+   'T6: no-PK table starts in custom insert-only repset');
+my $t6_cmd = qq{$pg_bin/psql -X -p $node_port -d $dbname }
+           . qq{-c "ALTER TABLE spoc539_t6 ADD PRIMARY KEY (id)" 2>&1};
+my $t6_output = `$t6_cmd`;
+like($t6_output, qr/NOTICE:.*gained a primary key.*leaving membership unchanged/i,
+     'T6: NOTICE emitted on PK add to custom repset');
+is(repsets_for('spoc539_t6'), 'spoc539_insonly',
+   'T6: adding PK leaves custom-repset membership alone');
+
+# -----------------------------------------------------------------------------
+# T7 (regression for the upstream behavior): ensure CREATE TABLE still adds
+# to default_insert_only when there is no PK.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t7 (id int)");
+is(repsets_for('spoc539_t7'), 'default_insert_only',
+   'T7: CREATE TABLE without PK still lands in default_insert_only');
+psql_or_bail(1, "ALTER TABLE spoc539_t7 ADD COLUMN b int");
+is(repsets_for('spoc539_t7'), 'default_insert_only',
+   'T7: unrelated ALTER on no-PK table does not churn membership');
+
+# -----------------------------------------------------------------------------
+# T8: mixed membership (default + custom insert-only), PK dropped.
+# The 'default' repset replicates UPDATE/DELETE and would break without a PK,
+# so the safety net must evict the table from 'default' and place it in
+# 'default_insert_only'. The custom insert-only membership must be preserved.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t8 (id int primary key, a text)");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_insonly', 'spoc539_t8')");
+is(repsets_for('spoc539_t8'), 'default,spoc539_insonly',
+   'T8: table starts in default + custom insert-only');
+my $t8_cmd = qq{$pg_bin/psql -X -p $node_port -d $dbname }
+           . qq{-c "ALTER TABLE spoc539_t8 DROP CONSTRAINT spoc539_t8_pkey" 2>&1};
+my $t8_output = `$t8_cmd`;
+like($t8_output, qr/WARNING:.*lost its primary key.*moving to/i,
+     'T8: WARNING emitted when PK drop affects a UPDATE/DELETE repset');
+is(repsets_for('spoc539_t8'), 'default_insert_only,spoc539_insonly',
+   'T8: evicted from default, preserved in custom insert-only');
+
+# -----------------------------------------------------------------------------
+# T9: mixed membership (default_insert_only + custom insert-only), PK dropped.
+# Nothing replicates UPDATE/DELETE; the missing PK is harmless. Sticky.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t9 (id int)");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_insonly', 'spoc539_t9')");
+psql_or_bail(1, "ALTER TABLE spoc539_t9 ADD PRIMARY KEY (id)");
+# Sticky path on the ADD PRIMARY KEY leaves it in both repsets; we now drop.
+is(repsets_for('spoc539_t9'), 'default_insert_only,spoc539_insonly',
+   'T9: table starts in default_insert_only + custom insert-only with PK');
+psql_or_bail(1, "ALTER TABLE spoc539_t9 DROP CONSTRAINT spoc539_t9_pkey");
+is(repsets_for('spoc539_t9'), 'default_insert_only,spoc539_insonly',
+   'T9: PK drop on insert-only-only membership leaves placement alone');
+
+destroy_cluster();

--- a/tests/tap/t/030_autoddl_repset_stickiness.pl
+++ b/tests/tap/t/030_autoddl_repset_stickiness.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 25;
+use Test::More tests => 27;
 use lib '.';
 use SpockTest qw(create_cluster destroy_cluster system_or_bail psql_or_bail
                  scalar_query get_test_config);
@@ -163,5 +163,18 @@ is(repsets_for('spoc539_t9'), 'default_insert_only,spoc539_insonly',
 psql_or_bail(1, "ALTER TABLE spoc539_t9 DROP CONSTRAINT spoc539_t9_pkey");
 is(repsets_for('spoc539_t9'), 'default_insert_only,spoc539_insonly',
    'T9: PK drop on insert-only-only membership leaves placement alone');
+
+# -----------------------------------------------------------------------------
+# T10: inline-PK form of ADD COLUMN. "ALTER TABLE ... ADD COLUMN x int PRIMARY
+# KEY" attaches the PK via the ColumnDef's inline constraints list rather than
+# as a separate AT_AddConstraint command; the classifier must still recognize
+# it as a PK add so the table moves out of default_insert_only into default.
+# -----------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE spoc539_t10 (b int)");
+is(repsets_for('spoc539_t10'), 'default_insert_only',
+   'T10: no-PK table starts in default_insert_only');
+psql_or_bail(1, "ALTER TABLE spoc539_t10 ADD COLUMN id int PRIMARY KEY");
+is(repsets_for('spoc539_t10'), 'default',
+   'T10: ADD COLUMN ... PRIMARY KEY promotes table to default');
 
 destroy_cluster();

--- a/tests/tap/t/030_autoddl_repset_stickiness.pl
+++ b/tests/tap/t/030_autoddl_repset_stickiness.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 27;
+use Test::More tests => 29;
 use lib '.';
 use SpockTest qw(create_cluster destroy_cluster system_or_bail psql_or_bail
                  scalar_query get_test_config);
@@ -86,7 +86,7 @@ is(repsets_for('spoc539_t4'), 'spoc539_full',
 my $t4_cmd = qq{$pg_bin/psql -X -p $node_port -d $dbname }
            . qq{-c "ALTER TABLE spoc539_t4 DROP CONSTRAINT spoc539_t4_pkey" 2>&1};
 my $output = `$t4_cmd`;
-like($output, qr/WARNING:.*lost its primary key.*moving to/i,
+like($output, qr/WARNING:.*no replica identity.*moving to/i,
      'T4: WARNING emitted on PK drop from UPDATE/DELETE custom repset');
 is(repsets_for('spoc539_t4'), 'default_insert_only',
    'T4: table moved to default_insert_only by safety net');
@@ -145,7 +145,7 @@ is(repsets_for('spoc539_t8'), 'default,spoc539_insonly',
 my $t8_cmd = qq{$pg_bin/psql -X -p $node_port -d $dbname }
            . qq{-c "ALTER TABLE spoc539_t8 DROP CONSTRAINT spoc539_t8_pkey" 2>&1};
 my $t8_output = `$t8_cmd`;
-like($t8_output, qr/WARNING:.*lost its primary key.*moving to/i,
+like($t8_output, qr/WARNING:.*no replica identity.*moving to/i,
      'T8: WARNING emitted when PK drop affects a UPDATE/DELETE repset');
 is(repsets_for('spoc539_t8'), 'default_insert_only,spoc539_insonly',
    'T8: evicted from default, preserved in custom insert-only');
@@ -176,5 +176,34 @@ is(repsets_for('spoc539_t10'), 'default_insert_only',
 psql_or_bail(1, "ALTER TABLE spoc539_t10 ADD COLUMN id int PRIMARY KEY");
 is(repsets_for('spoc539_t10'), 'default',
    'T10: ADD COLUMN ... PRIMARY KEY promotes table to default');
+
+# -----------------------------------------------------------------------------
+# T11: REPLICA_IDENTITY_FULL table (no PK) in a custom UPDATE/DELETE repset.
+# Dropping an unrelated UNIQUE constraint via ALTER TABLE must NOT emit a
+# WARNING and must leave the custom membership alone.
+#
+# Regression for post_has_pk_or_ri missing the FULL case: without the fix,
+# rd_pkindex=invalid AND rd_replidindex=invalid → post_has_pk_or_ri=false →
+# AT_DropConstraint → PKRI_DROPPED → spurious WARNING + eviction.
+# -----------------------------------------------------------------------------
+# Setup: create with PK (rd_replidindex valid), move to custom repset, then
+# set REPLICA IDENTITY FULL (sticky path fires — in_any_custom=true — so the
+# standard routing is never reached and the table stays in spoc539_full), then
+# drop the PK (post_has_pk_or_ri=true due to RI_FULL → PKRI_UNCHANGED → sticky).
+# After all that, the table is in spoc539_full with RI_FULL and no PK.
+psql_or_bail(1, "CREATE TABLE spoc539_t11 (id int PRIMARY KEY, a text, " .
+                "CONSTRAINT spoc539_t11_a UNIQUE (a))");
+psql_or_bail(1, "SELECT spock.repset_remove_table('default', 'spoc539_t11')");
+psql_or_bail(1, "SELECT spock.repset_add_table('spoc539_full', 'spoc539_t11')");
+psql_or_bail(1, "ALTER TABLE spoc539_t11 REPLICA IDENTITY FULL");
+psql_or_bail(1, "ALTER TABLE spoc539_t11 DROP CONSTRAINT spoc539_t11_pkey");
+my $t11_cmd = qq{$pg_bin/psql -X -p $node_port -d $dbname }
+            . qq{-c "ALTER TABLE spoc539_t11 DROP CONSTRAINT spoc539_t11_a" 2>&1};
+my $t11_output = `$t11_cmd`;
+BAIL_OUT("T11 ALTER TABLE failed: $t11_output") if ($? >> 8) != 0;
+unlike($t11_output, qr/WARNING/i,
+       'T11: REPLICA_IDENTITY_FULL table: no WARNING on unrelated constraint drop');
+is(repsets_for('spoc539_t11'), 'spoc539_full',
+   'T11: REPLICA_IDENTITY_FULL table: custom membership unchanged after constraint drop');
 
 destroy_cluster();


### PR DESCRIPTION
    With autoDDL and spock.include_ddl_repset both enabled, any ALTER TABLE
    on a table that lived in a user-defined replication set was being
    forcibly re-routed back into 'default' (or 'default_insert_only'),
    silently undoing the operator's repset placement.

    Apply ALTER stickiness rules in apply_repset_policy_for_reloid():

      - If the ALTER did not add or drop a PK / replica identity, leave
        repset membership entirely alone.
      - If the ALTER added a PK on a table in a custom repset, emit a
        NOTICE and leave membership alone. The operator can move it
        manually if they want full UPDATE/DELETE replication.
      - If the ALTER dropped the PK on a table in a custom repset that
        replicates UPDATE/DELETE, emit a WARNING and move it to
        default_insert_only. Without a replica identity, that custom
        repset would otherwise produce broken downstream replication.
      - Tables in the default repsets continue to be auto-re-routed as
        before.