### PR TITLE
Skip conflict-log message assembly when the level is suppressed

### DIFF
--- a/src/spock_conflict.c
+++ b/src/spock_conflict.c
@@ -764,6 +764,14 @@ spock_report_conflict(SpockConflictType conflict_type,
 							 conflict_idx_oid);
 	}
 
+	/*
+	 * Building the log message below stringifies both full tuples and does
+	 * catalog lookups, once per conflict.  Skip it when the level would not be
+	 * emitted.  (The resolutions-table write above is gated separately.)
+	 */
+	if (!message_level_is_interesting(spock_conflict_log_level))
+		return;
+
 	memset(local_tup_ts_str, 0, MAXDATELEN);
 	strlcpy(local_origin_str, "unknown", sizeof(local_origin_str));
 	if (found_local_origin)


### PR DESCRIPTION
spock_report_conflict() stringified both the local and remote tuples (tuple_to_stringinfo deforms every attribute and calls type-output functions) and did catalog lookups unconditionally, once per conflicting row -- even when the ereport() would be discarded by the active log thresholds.

Guard the message assembly with message_level_is_interesting() so a high-conflict apply stream stops paying to format log lines nobody will see. The resolutions-table write above is gated separately and is unaffected.