### PR TITLE
spock_apply_heap: reuse ResultRelInfo indexes; free index predicate tree

### DIFF
--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -452,8 +452,9 @@ FindReplTupleInLocalRel(ApplyExecutionData *edata, Relation localrel,
  * Find a matching tuple using all usable unique indexes (excluding PK and RI
  * indexes)
  *
- * This is a fallback mechanism when PK/RI indexes do not match. The caller must
- * ensure this function is only called in that context.
+ * Fallback for INSERT conflict resolution when PK/RI indexes do not match.
+ * Iterates over the indexes already opened and locked by ExecOpenIndices so
+ * the apply path does not re-open and re-lock every index per row.
  */
 static bool
 FindReplTupleByUCIndex(ApplyExecutionData *edata,
@@ -462,45 +463,32 @@ FindReplTupleByUCIndex(ApplyExecutionData *edata,
 					   TupleTableSlot **localslot,
 					   Oid *indexoid)
 {
-	List	   *indexoidlist = NIL;
-	ListCell   *lc;
+	ResultRelInfo *relinfo;
+	int			i;
 	bool		found = false;
 
 	if (!check_all_uc_indexes)
 		elog(ERROR, "spock.check_all_uc_indexes must be enabled to call this function");
 
 	*indexoid = InvalidOid;
-	/* Get the list of index OIDs for the table from the relcache. */
-	indexoidlist = RelationGetIndexList(localrel);
+	relinfo = edata->targetRelInfo;
 
-	foreach(lc, indexoidlist)
+	for (i = 0; i < relinfo->ri_NumIndices; i++)
 	{
-		Relation idxrel;
-
-		*indexoid = lfirst_oid(lc);
-
-		/* Open the index. */
-		idxrel = index_open(*indexoid, RowExclusiveLock);
+		Relation	idxrel = relinfo->ri_IndexRelationDescs[i];
 
 		if (!IsIndexUsableForInsertConflict(idxrel))
-		{
-			index_close(idxrel, RowExclusiveLock);
 			continue;
-		}
 
 		found = SpockRelationFindReplTupleByIndex(edata->estate, localrel, idxrel,
-											 LockTupleExclusive,
-											 remoteslot, *localslot);
+												  LockTupleExclusive,
+												  remoteslot, *localslot);
 		if (found)
 		{
-			/* Don't release lock until commit. */
-			index_close(idxrel, NoLock);
+			*indexoid = RelationGetRelid(idxrel);
 			break;
 		}
-		index_close(idxrel, RowExclusiveLock);
 	}
-
-	list_free(indexoidlist);
 
 	return found;
 }

--- a/src/spock_common.c
+++ b/src/spock_common.c
@@ -20,6 +20,7 @@
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
+#include "utils/memutils.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 
@@ -245,21 +246,39 @@ index_keys_have_nonnulls(TupleTableSlot *slot1, TupleTableSlot *slot2, Relation 
 
 /*
  * If the index is partial (has a WHERE clause), prepare the predicate
- * expression for evaluation.
+ * expression for evaluation.  Build the raw predicate tree in a scratch
+ * context so it is freed once ExecPrepareQual has consumed it; the
+ * resulting ExprState is owned by estate->es_query_cxt.
  */
 static ExprState *
 SpockPreparePredicateExpr(Relation idxrel, EState *estate)
 {
-	List *predExprList = NIL;
+	List	   *predExprList;
+	ExprState  *result;
+	MemoryContext tmpcxt;
+	MemoryContext oldcxt;
 
 	if (heap_attisnull(idxrel->rd_indextuple, Anum_pg_index_indpred, NULL))
 		return NULL;
 
+	tmpcxt = AllocSetContextCreate(CurrentMemoryContext,
+								   "Spock predicate prep",
+								   ALLOCSET_SMALL_SIZES);
+	oldcxt = MemoryContextSwitchTo(tmpcxt);
+
 	predExprList = RelationGetIndexPredicate(idxrel);
 	if (predExprList == NIL)
+	{
+		MemoryContextSwitchTo(oldcxt);
+		MemoryContextDelete(tmpcxt);
 		return NULL;
+	}
 
-	return ExecPrepareQual(predExprList, estate);
+	result = ExecPrepareQual(predExprList, estate);
+
+	MemoryContextSwitchTo(oldcxt);
+	MemoryContextDelete(tmpcxt);
+	return result;
 }
 
 /*

--- a/src/spock_common.c
+++ b/src/spock_common.c
@@ -253,34 +253,19 @@ index_keys_have_nonnulls(TupleTableSlot *slot1, TupleTableSlot *slot2, Relation 
 static ExprState *
 SpockPreparePredicateExpr(Relation idxrel, EState *estate)
 {
-	List	   *predExprList;
+	List       *predExprList;
 	ExprState  *result;
-	MemoryContext tmpcxt;
 	MemoryContext oldcxt;
 
 	if (heap_attisnull(idxrel->rd_indextuple, Anum_pg_index_indpred, NULL))
-		return NULL;
+	    return NULL;
 
-	tmpcxt = AllocSetContextCreate(CurrentMemoryContext,
-								   "Spock predicate prep",
-								   ALLOCSET_SMALL_SIZES);
-	oldcxt = MemoryContextSwitchTo(tmpcxt);
-
+	oldcxt = MemoryContextSwitchTo(estate->es_query_cxt);
 	predExprList = RelationGetIndexPredicate(idxrel);
-	if (predExprList == NIL)
-	{
-		MemoryContextSwitchTo(oldcxt);
-		MemoryContextDelete(tmpcxt);
-		return NULL;
-	}
-
-	result = ExecPrepareQual(predExprList, estate);
-
+	result = (predExprList != NIL) ? ExecPrepareQual(predExprList, estate) : NULL;
 	MemoryContextSwitchTo(oldcxt);
-	MemoryContextDelete(tmpcxt);
 	return result;
 }
-
 /*
  * Check if the predicate matches by evaluating the index predicate on the
  * given tuple slot. This is used for both remote and local tuples.


### PR DESCRIPTION
Iterate edata->targetRelInfo->ri_IndexRelationDescs instead of re-opening each index per row, and only set *indexoid on a match. Wrap RelationGetIndexPredicate in a scratch context so the tree is freed.