### PR TITLE
Bugfix: do not skip LOLOR extension and schema from Spock replication

### DIFF
--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -114,18 +114,16 @@ typedef struct SubscriptionTuple
 
 /*
  * List of extensions and schemas that we should skip globally.
- * By-default, it is spock, lolor, and snowflake related objects.
+ * By-default, it is spock and snowflake related objects.
  * Don't merge it with subscription-specific skip-schema list to avoid cases
  * when user drops 'sub->skip_schema' and violates these restrictions.
  */
 const char *const skip_schema[] = {
-	"lolor",
 	"snowflake",
 	"spock",
 	NULL  /* sentinel */
 };
 const char *const skip_extension[] = {
-	"lolor",
 	"snowflake",
 	"spock",
 	NULL  /* sentinel */


### PR DESCRIPTION
## Summary

Spock keeps two static deny-lists, `skip_schema` and `skip_extension` (`src/spock_node.c`), that name schemas and extensions whose relations are never replicated. Any object in those lists is rejected from replication sets by `EnsureRelationNotIgnored()`, and is excluded from the initial subscription sync via `--exclude-schema` / `--exclude-extension` flags passed to `pg_dump` (`build_exclude_schema_string()` / `build_exclude_extension_string()` in `src/spock_sync.c`).

`lolor` was wrongly listed in both arrays. That directly contradicts the purpose of the LOLOR extension: it relocates large objects out of the catalog into ordinary tables (`lolor.pg_largeobject`, `lolor.pg_largeobject_metadata`) precisely so they *can* be logically replicated, and the lolor docs instruct users to add those tables to their replication set. With lolor on the deny-lists, that documented step failed and large objects were silently skipped during initial sync.

This change removes `"lolor"` from both `skip_schema` and `skip_extension`.

## Effect

- `EnsureRelationNotIgnored()` no longer rejects `lolor.pg_largeobject` and `lolor.pg_largeobject_metadata` when they are added to a replication set, so the documented `repset-add-table` workflow now works.
- The initial Spock sync no longer passes `--exclude-schema=lolor` / `--exclude-extension=lolor` to `pg_dump`, so existing large objects are copied to the replica.

## Notes

We cannot automatically add an arbitrary extension's objects to a subscription, so manual addition of the two lolor tables to the replication set still stands as the supported workflow. `snowflake` and `spock` remain on the deny-lists; only `lolor` is removed.
