### PR TITLE
Handle NULLS NOT DISTINCT unique indexes

### DIFF
--- a/src/spock_common.c
+++ b/src/spock_common.c
@@ -195,18 +195,39 @@ IsIndexUsableForInsertConflict(Relation idxrel)
 }
 
 /*
- * Check whether the index key attributes in the two tuples are all non-NULL.
+ * Does this unique index treat NULLs as distinct (the default)?
  *
- * This function does not compare actual values for equality. Instead, it verifies
- * that all index key columns (excluding dropped and generated ones) are non-NULL
- * in both tuples.
- * In SQL semantics, NULLs are not considered equals, even when both sides are
- * NULLs. so any NULL in a key column implies that they do not match.
+ * For such an index a NULL in any key column means the row can never have a
+ * uniqueness conflict, because NULL is never equal to anything -- including
+ * another NULL.  With NULLS NOT DISTINCT a single NULL row is allowed and
+ * NULLs do compare equal, so a NULL search value can legitimately match.
+ */
+static inline bool
+SpockIndexNullsAreDistinct(Relation idxrel)
+{
+	return !idxrel->rd_index->indnullsnotdistinct;
+}
+
+/*
+ * Check whether the index key columns of the two tuples match, applying the
+ * index's NULL semantics.
+ *
+ * This does not compare non-NULL values for equality -- the index scan already
+ * did that.  It only decides the NULL cases:
+ *
+ *   - NULLS DISTINCT (the default): a NULL is never equal to anything, even
+ *     another NULL, so any NULL in a key column means the rows do not match.
+ *   - NULLS NOT DISTINCT: two NULLs in the same key column compare equal, so a
+ *     column that is NULL on both sides is a match; a column that is NULL on
+ *     only one side is not.
+ *
+ * Dropped and generated columns are ignored (the publisher doesn't send them).
  */
 static bool
-index_keys_have_nonnulls(TupleTableSlot *slot1, TupleTableSlot *slot2, Relation idxrel,
+index_keys_match(TupleTableSlot *slot1, TupleTableSlot *slot2, Relation idxrel,
 			 ScanKey skey, int ncols)
 {
+	bool		nulls_distinct = SpockIndexNullsAreDistinct(idxrel);
 	int			i;
 	int			attrnum;
 
@@ -220,6 +241,8 @@ index_keys_have_nonnulls(TupleTableSlot *slot1, TupleTableSlot *slot2, Relation 
 	for (i = 0; i < ncols; i++)
 	{
 		Form_pg_attribute att;
+		bool		isnull1;
+		bool		isnull2;
 
 		attrnum = idxrel->rd_index->indkey.values[skey[i].sk_attno - 1] - 1;
 
@@ -232,13 +255,21 @@ index_keys_have_nonnulls(TupleTableSlot *slot1, TupleTableSlot *slot2, Relation 
 		if (att->attisdropped || att->attgenerated)
 			continue;
 
-		/*
-		 * If either value is NULL, then according to SQL semantics,
-		 * they are not considered equal, even if both are NULL.
-		 */
-		if (slot1->tts_isnull[attrnum] || slot2->tts_isnull[attrnum])
-			return false;
+		isnull1 = slot1->tts_isnull[attrnum];
+		isnull2 = slot2->tts_isnull[attrnum];
 
+		if (isnull1 || isnull2)
+		{
+			/*
+			 * Under NULLS NOT DISTINCT, two NULLs in the same column compare
+			 * equal, so a both-NULL column is a match.  Every other NULL
+			 * pairing (and any NULL under NULLS DISTINCT) means no match.
+			 */
+			if (isnull1 && isnull2 && !nulls_distinct)
+				continue;
+
+			return false;
+		}
 	}
 
 	return true;
@@ -322,17 +353,23 @@ SpockRelationFindReplTupleByIndex(EState *estate,
 		return false;
 
 	/*
-	 * A unique index treats NULLs as distinct, so a remote row with a NULL in
-	 * any of this index's key columns can never conflict with an existing row
-	 * here -- skip the probe entirely.
+	 * Under NULLS DISTINCT (the default), a remote row with a NULL in any of
+	 * this index's key columns can never conflict with an existing row here --
+	 * NULL is never equal to anything, including another NULL -- so skip the
+	 * probe entirely.
 	 *
 	 * This is not just an optimization: spock_build_replindex_scan_key() emits
 	 * SK_SEARCHNULL for a NULL key value, which makes the btree return *every*
-	 * row whose key IS NULL.  index_keys_have_nonnulls() below then discards
-	 * each of them, so without this short-circuit every applied insert would
-	 * run an O(rows) scan -- guaranteed to find nothing -- on a unique index
-	 * over a mostly-NULL key column.
+	 * row whose key IS NULL.  index_keys_match() below then discards each of
+	 * them, so without this short-circuit every applied insert would run an
+	 * O(rows) scan -- guaranteed to find nothing -- on a unique index over a
+	 * mostly-NULL key column.
+	 *
+	 * Under NULLS NOT DISTINCT, NULLs compare equal, so a NULL-keyed row CAN
+	 * conflict; don't short-circuit -- let the scan run and let
+	 * index_keys_match() apply the right semantics.
 	 */
+	if (SpockIndexNullsAreDistinct(idxrel))
 	{
 		int2vector *indkey = &idxrel->rd_index->indkey;
 		int			i;
@@ -364,7 +401,7 @@ retry:
 	/* Try to find the tuple */
 	while (index_getnext_slot(scan, ForwardScanDirection, outslot))
 	{
-		if (!index_keys_have_nonnulls(outslot, searchslot, idxrel, skey, skey_attoff))
+		if (!index_keys_match(outslot, searchslot, idxrel, skey, skey_attoff))
 			continue;
 
 		/* Skip if local tuple does not satisfy the index predicate */

--- a/tests/regress/expected/conflict_secondary_unique.out
+++ b/tests/regress/expected/conflict_secondary_unique.out
@@ -2,6 +2,25 @@
 SELECT * FROM spock_regress_variables()
 \gset
 \c :provider_dsn
+-- This test exercises the secondary unique index path, so enable it explicitly
+-- on both nodes (restored to off at the end) rather than relying on the suite
+-- default.
+ALTER SYSTEM SET spock.check_all_uc_indexes = true;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.check_all_uc_indexes = true;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :provider_dsn
 -- Test conflicts where a secondary unique constraint with a predicate exits,
 -- ensuring we don't generate false conflicts.
 SELECT spock.replicate_ddl($$
@@ -86,6 +105,115 @@ SELECT * FROM secondary_unique_pred ORDER BY a;
 (4 rows)
 
 \c :provider_dsn
+-- Test a NULLS DISTINCT unique index (the default) on a nullable column.
+-- NULL is never equal to NULL, so rows with a NULL key can never conflict
+-- and any number of them are allowed. The apply path must short-circuit the
+-- NULL search key instead of scanning every NULL-keyed row.
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.secondary_unique_null (
+    a integer PRIMARY KEY,
+    b integer
+);
+
+CREATE UNIQUE INDEX ON public.secondary_unique_null (b);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'secondary_unique_null');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+-- Multiple NULLs in the unique column must all be allowed (no false conflict),
+-- and a non-NULL row alongside them must replicate normally. On apply, the
+-- subscriber probes the unique index on (b); the NULL-keyed rows must take the
+-- short-circuit rather than scanning every NULL-keyed row.
+INSERT INTO secondary_unique_null (a, b) VALUES (1, NULL);
+INSERT INTO secondary_unique_null (a, b) VALUES (2, NULL);
+INSERT INTO secondary_unique_null (a, b) VALUES (3, 10);
+INSERT INTO secondary_unique_null (a, b) VALUES (4, NULL);
+SELECT * FROM secondary_unique_null ORDER BY a;
+ a | b  
+---+----
+ 1 |   
+ 2 |   
+ 3 | 10
+ 4 |   
+(4 rows)
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM secondary_unique_null ORDER BY a;
+ a | b  
+---+----
+ 1 |   
+ 2 |   
+ 3 | 10
+ 4 |   
+(4 rows)
+
+\c :provider_dsn
+-- Test a NULLS NOT DISTINCT unique index (PG15+). Here NULL == NULL, so a
+-- NULL-keyed row CAN conflict with another NULL-keyed row. The apply path must
+-- detect that conflict (and resolve it) rather than skipping it -- otherwise
+-- the insert would fall through and raise a duplicate-key error.
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.secondary_unique_nnd (
+    a integer PRIMARY KEY,
+    b integer
+);
+
+CREATE UNIQUE INDEX ON public.secondary_unique_nnd (b) NULLS NOT DISTINCT;
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'secondary_unique_nnd');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+-- Seed a local-only row on the subscriber with a NULL key.
+\c :subscriber_dsn
+INSERT INTO secondary_unique_nnd (a, b) VALUES (100, NULL);
+-- The provider inserts a different PK with a NULL key. On the subscriber this
+-- conflicts with the local NULL-keyed row via the NULLS NOT DISTINCT index and
+-- is resolved (last-update-wins): the local row is overwritten by the remote
+-- tuple, so a=100 is replaced by a=200.
+\c :provider_dsn
+INSERT INTO secondary_unique_nnd (a, b) VALUES (200, NULL);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM secondary_unique_nnd ORDER BY a;
+  a  | b 
+-----+---
+ 200 |  
+(1 row)
+
+\c :provider_dsn
 \set VERBOSITY terse
 SELECT spock.replicate_ddl($$
 	DROP TABLE public.secondary_unique_pred CASCADE;
@@ -93,6 +221,40 @@ $$);
 NOTICE:  drop cascades to table secondary_unique_pred membership in replication set default
  replicate_ddl 
 ---------------
+ t
+(1 row)
+
+SELECT spock.replicate_ddl($$
+	DROP TABLE public.secondary_unique_null CASCADE;
+$$);
+NOTICE:  drop cascades to table secondary_unique_null membership in replication set default
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT spock.replicate_ddl($$
+	DROP TABLE public.secondary_unique_nnd CASCADE;
+$$);
+NOTICE:  drop cascades to table secondary_unique_nnd membership in replication set default
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+-- Restore the default (off) on both nodes.
+ALTER SYSTEM SET spock.check_all_uc_indexes = false;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.check_all_uc_indexes = false;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
  t
 (1 row)
 

--- a/tests/regress/sql/conflict_secondary_unique.sql
+++ b/tests/regress/sql/conflict_secondary_unique.sql
@@ -4,6 +4,16 @@ SELECT * FROM spock_regress_variables()
 
 \c :provider_dsn
 
+-- This test exercises the secondary unique index path, so enable it explicitly
+-- on both nodes (restored to off at the end) rather than relying on the suite
+-- default.
+ALTER SYSTEM SET spock.check_all_uc_indexes = true;
+SELECT pg_reload_conf();
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.check_all_uc_indexes = true;
+SELECT pg_reload_conf();
+\c :provider_dsn
+
 -- Test conflicts where a secondary unique constraint with a predicate exits,
 -- ensuring we don't generate false conflicts.
 SELECT spock.replicate_ddl($$
@@ -49,7 +59,87 @@ SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
 SELECT * FROM secondary_unique_pred ORDER BY a;
 
 \c :provider_dsn
+
+-- Test a NULLS DISTINCT unique index (the default) on a nullable column.
+-- NULL is never equal to NULL, so rows with a NULL key can never conflict
+-- and any number of them are allowed. The apply path must short-circuit the
+-- NULL search key instead of scanning every NULL-keyed row.
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.secondary_unique_null (
+    a integer PRIMARY KEY,
+    b integer
+);
+
+CREATE UNIQUE INDEX ON public.secondary_unique_null (b);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'secondary_unique_null');
+
+-- Multiple NULLs in the unique column must all be allowed (no false conflict),
+-- and a non-NULL row alongside them must replicate normally. On apply, the
+-- subscriber probes the unique index on (b); the NULL-keyed rows must take the
+-- short-circuit rather than scanning every NULL-keyed row.
+INSERT INTO secondary_unique_null (a, b) VALUES (1, NULL);
+INSERT INTO secondary_unique_null (a, b) VALUES (2, NULL);
+INSERT INTO secondary_unique_null (a, b) VALUES (3, 10);
+INSERT INTO secondary_unique_null (a, b) VALUES (4, NULL);
+
+SELECT * FROM secondary_unique_null ORDER BY a;
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+
+SELECT * FROM secondary_unique_null ORDER BY a;
+
+\c :provider_dsn
+
+-- Test a NULLS NOT DISTINCT unique index (PG15+). Here NULL == NULL, so a
+-- NULL-keyed row CAN conflict with another NULL-keyed row. The apply path must
+-- detect that conflict (and resolve it) rather than skipping it -- otherwise
+-- the insert would fall through and raise a duplicate-key error.
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.secondary_unique_nnd (
+    a integer PRIMARY KEY,
+    b integer
+);
+
+CREATE UNIQUE INDEX ON public.secondary_unique_nnd (b) NULLS NOT DISTINCT;
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'secondary_unique_nnd');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+-- Seed a local-only row on the subscriber with a NULL key.
+\c :subscriber_dsn
+INSERT INTO secondary_unique_nnd (a, b) VALUES (100, NULL);
+
+-- The provider inserts a different PK with a NULL key. On the subscriber this
+-- conflicts with the local NULL-keyed row via the NULLS NOT DISTINCT index and
+-- is resolved (last-update-wins): the local row is overwritten by the remote
+-- tuple, so a=100 is replaced by a=200.
+\c :provider_dsn
+INSERT INTO secondary_unique_nnd (a, b) VALUES (200, NULL);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM secondary_unique_nnd ORDER BY a;
+
+\c :provider_dsn
 \set VERBOSITY terse
 SELECT spock.replicate_ddl($$
 	DROP TABLE public.secondary_unique_pred CASCADE;
 $$);
+SELECT spock.replicate_ddl($$
+	DROP TABLE public.secondary_unique_null CASCADE;
+$$);
+SELECT spock.replicate_ddl($$
+	DROP TABLE public.secondary_unique_nnd CASCADE;
+$$);
+
+-- Restore the default (off) on both nodes.
+ALTER SYSTEM SET spock.check_all_uc_indexes = false;
+SELECT pg_reload_conf();
+\c :subscriber_dsn
+ALTER SYSTEM SET spock.check_all_uc_indexes = false;
+SELECT pg_reload_conf();

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -38,6 +38,7 @@ test: 013_origin_change_restore
 test: 016_sub_disable_missing_relation
 test: 018_failover_slots
 test: 019_stale_fd_epoll_after_conn_death
+test: 021_uc_null_key_skip
 
 # Regression tests
 test: 103_manager_worker_dboid_race


### PR DESCRIPTION
  Background

  Builds on #496 (already merged), which fixed the check_all_uc_indexes handling where a unique index on a
  nullable column turned each applied insert's probe into an IS NULL scan of every NULL-keyed row. #496
  short-circuits when a remote key column is NULL.

  That short-circuit is correct for NULLS DISTINCT indexes (the default) but fires unconditionally. On a
  NULLS NOT DISTINCT index (PG15+), NULL = NULL, so a NULL-keyed row can genuinely conflict with another
  NULL-keyed row. Skipping the probe there lets the insert fall through to ExecSimpleRelationInsert, where
  the physical index raises a duplicate-key error instead of going through conflict resolution.

  Changes

  - spock_apply: handle NULLS NOT DISTINCT unique indexes — gate the short-circuit on
  SpockIndexNullsAreDistinct() so it only fires for NULLS DISTINCT. For NULLS NOT DISTINCT the (bounded) IS
  NULL scan runs as before — at most one matching row, so no perf concern — and the post-scan recheck
  (renamed index_keys_have_nonnulls → index_keys_match) now applies the index's NULL semantics: 
  both-NULL is  a match under NULLS NOT DISTINCT; any NULL is a non-match under NULLS DISTINCT.
  - tests: regress coverage for nullable unique indexes — extends conflict_secondary_unique with a NULLS
  DISTINCT case (multiple NULL-keyed rows replicate with no false conflicts; a non-NULL row applies normally)
  and a NULLS NOT DISTINCT case (a local NULL-keyed row conflicts with a replicated NULL-keyed insert and
  resolves last-update-wins instead of erroring). Enables spock.check_all_uc_indexes explicitly on both nodes
  and restores it at the end, rather than relying on the suite default + test ordering. Complements #496's
  TAP 021 (which proves the scan is skipped) by proving the resulting behavior is correct.
  - tests: register 021_uc_null_key_skip in the TAP schedule — #496 added the test file but no
  tests/tap/schedule entry, so the schedule-driven runner skipped it. Now it runs.

  Behavior change

  On a NULLS NOT DISTINCT unique index, a replicated NULL-keyed conflict is now resolved through normal
  conflict handling instead of failing with a duplicate-key error. No change for NULLS DISTINCT (the
  default).