### PR TITLE
Ship a valid SET search_path with replicated DDL for an empty path

### DIFF
--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2200,6 +2200,53 @@ spock_replication_set_remove_partition(PG_FUNCTION_ARGS)
 }
 
 /*
+ * Append a "SET search_path TO ...;" command to buf that reproduces the given
+ * search_path GUC value with every schema name properly quoted.
+ *
+ * The value must be parsed and re-quoted rather than interpolated verbatim:
+ * GetConfigOptionByName() does not always return a value that is valid SQL on
+ * its own.  In particular set_config('search_path', ' ', false) (as the core
+ * "namespace" regression test does) yields a bare space, which interpolated
+ * directly would emit the invalid "SET search_path TO  ;".  A value that
+ * resolves to no schemas (empty or whitespace-only) yields
+ * "SET search_path TO '';", so the command is always valid SQL and the
+ * subscriber ends up with the same (empty) effective search path as the
+ * publisher.
+ */
+static void
+append_set_search_path(StringInfo buf, const char *search_path)
+{
+	List	   *path_list = NIL;
+	char	   *rawname;
+	ListCell   *lc;
+
+	/* SplitIdentifierString scribbles on its argument, so work on a copy. */
+	rawname = pstrdup(search_path);
+
+	if (!SplitIdentifierString(rawname, ',', &path_list))
+		elog(ERROR, "invalid value for search_path: \"%s\"", search_path);
+
+	if (path_list == NIL)
+	{
+		appendStringInfoString(buf, "SET search_path TO ''; ");
+		pfree(rawname);
+		return;
+	}
+
+	appendStringInfoString(buf, "SET search_path TO ");
+	foreach(lc, path_list)
+	{
+		if (lc != list_head(path_list))
+			appendStringInfo(buf, ", ");
+		appendStringInfoString(buf, quote_identifier((char *) lfirst(lc)));
+	}
+	appendStringInfoString(buf, "; ");
+
+	list_free(path_list);
+	pfree(rawname);
+}
+
+/*
  * spock_replicate_ddl_command
  *
  * Queues the input SQL for replication.
@@ -2215,7 +2262,6 @@ spock_replicate_ddl_command(PG_FUNCTION_ARGS)
 	SpockLocalNode *node;
 	StringInfoData cmd;
 	StringInfoData q;
-	List	   *path_list = NIL;
 	char	   *search_path;
 	char	   *role;
 
@@ -2246,22 +2292,7 @@ spock_replicate_ddl_command(PG_FUNCTION_ARGS)
 
 	/* Add search path to the query for execution on the target node */
 	initStringInfo(&q);
-	SplitIdentifierString(search_path, ',', &path_list);
-	if (path_list != NIL)
-	{
-		ListCell   *lc2;
-
-		appendStringInfoString(&q, "SET search_path TO ");
-		foreach(lc2, path_list)
-		{
-			if (lc2 != list_head(path_list))
-				appendStringInfoChar(&q, ',');
-			appendStringInfo(&q, "%s", quote_identifier((char *) lfirst(lc2)));
-		}
-		appendStringInfo(&q, "; ");
-	}
-	else
-		appendStringInfo(&q, "SET search_path TO ''; ");
+	append_set_search_path(&q, search_path);
 	appendStringInfoString(&q, query);
 
 	/* Convert the query to json string. */
@@ -2534,10 +2565,7 @@ spock_auto_replicate_ddl(const char *query, List *replication_sets,
 	{
 		/* Add search path to the query for execution on the target node */
 		search_path = GetConfigOptionByName("search_path", NULL, false);
-		if (strlen(search_path) > 0)
-			appendStringInfo(&q, "SET search_path TO %s; ", search_path);
-		else
-			appendStringInfo(&q, "SET search_path TO ''; ");
+		append_set_search_path(&q, search_path);
 	}
 	/* add query to buffer */
 	appendStringInfoString(&q, query);

--- a/src/spock_relcache.c
+++ b/src/spock_relcache.c
@@ -88,8 +88,11 @@ spock_relation_open(uint32 remoteid, LOCKMODE lockmode)
 						HASH_FIND, &found);
 
 	if (!found)
-		elog(ERROR, "cache lookup failed for remote relation %u",
-			 remoteid);
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("cache lookup failed for remote relation %u", remoteid),
+				 errdetail("No relation metadata has been received for remote relation %u; a data change referencing it arrived before its RELATION message.", remoteid),
+				 errhint("This usually indicates a schema mismatch. Check logs, then restart the subscription.")));
 
 	/* Need to update the local cache? */
 	if (!OidIsValid(entry->reloid))

--- a/tests/regress/expected/autoddl.out
+++ b/tests/regress/expected/autoddl.out
@@ -100,7 +100,44 @@ WARNING:  This DDL statement will not be replicated.
 DROP TABLE test_383 CASCADE;
 NOTICE:  drop cascades to table test_383 membership in replication set default_insert_only
 INFO:  DDL statement replicated.
+-- An empty search_path set via set_config() leaves a bare space in the GUC
+-- (as the core "namespace" regression test does). It must be shipped as a
+-- valid, empty path, not the invalid "SET search_path TO  ;" that fails to
+-- parse on the subscriber.
+SELECT set_config('search_path', ' ', false);
+ set_config 
+------------
+  
+(1 row)
+
+CREATE SCHEMA test_ns_schema_1
+       CREATE TABLE abc (a serial, b int UNIQUE);
+INFO:  DDL statement replicated.
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+RESET search_path;
+SELECT spock.sync_event() as sync_event
+\gset
 \c :subscriber_dsn
+-- Wait for the empty-search_path DDL to be applied on subscriber (node 2)
+CALL spock.wait_for_sync_event(true, 'test_provider', :'sync_event');
+ result 
+--------
+ t
+(1 row)
+
+-- Schema, table and the inserted row must all replicate to the subscriber
+SELECT count(*) FROM spock.tables where nspname = 'test_ns_schema_1' AND set_name IS NOT NULL;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM test_ns_schema_1.abc;
+ count 
+-------
+     1
+(1 row)
+
 -- Reset the configuration to the default value
 \c :provider_dsn
 ALTER SYSTEM SET spock.enable_ddl_replication = 'off';

--- a/tests/regress/expected/exception_row_capture.out
+++ b/tests/regress/expected/exception_row_capture.out
@@ -183,11 +183,11 @@ CALL spock.wait_for_sync_event(NULL, 'test_provider', :'sync_lsn', 30);
 SELECT table_name, operation, (error_message <> '') AS has_error, ddl_statement
 FROM spock.exception_log
 ORDER BY command_counter;
- table_name | operation | has_error |                                       ddl_statement                                        
-------------+-----------+-----------+--------------------------------------------------------------------------------------------
+ table_name | operation | has_error |                                        ddl_statement                                        
+------------+-----------+-----------+---------------------------------------------------------------------------------------------
  drl_t1     | UPDATE    | t         | 
  queue      | INSERT    | t         | 
-            | DDL       | t         | "SET search_path TO \"$user\",public; CREATE TABLE IF NOT EXISTS public.drl_dummy (x int)"
+            | DDL       | t         | "SET search_path TO \"$user\", public; CREATE TABLE IF NOT EXISTS public.drl_dummy (x int)"
  drl_t3     | UPDATE    | t         | 
 (4 rows)
 

--- a/tests/regress/sql/autoddl.sql
+++ b/tests/regress/sql/autoddl.sql
@@ -65,7 +65,26 @@ CREATE INDEX test_383_y_idx ON test_383 (a);
 CLUSTER test_383 USING test_383_y_idx; -- Should not be replicated
 DROP TABLE test_383 CASCADE;
 
+-- An empty search_path set via set_config() leaves a bare space in the GUC
+-- (as the core "namespace" regression test does). It must be shipped as a
+-- valid, empty path, not the invalid "SET search_path TO  ;" that fails to
+-- parse on the subscriber.
+SELECT set_config('search_path', ' ', false);
+CREATE SCHEMA test_ns_schema_1
+       CREATE TABLE abc (a serial, b int UNIQUE);
+INSERT INTO test_ns_schema_1.abc DEFAULT VALUES;
+RESET search_path;
+SELECT spock.sync_event() as sync_event
+\gset
+
 \c :subscriber_dsn
+
+-- Wait for the empty-search_path DDL to be applied on subscriber (node 2)
+CALL spock.wait_for_sync_event(true, 'test_provider', :'sync_event');
+
+-- Schema, table and the inserted row must all replicate to the subscriber
+SELECT count(*) FROM spock.tables where nspname = 'test_ns_schema_1' AND set_name IS NOT NULL;
+SELECT count(*) FROM test_ns_schema_1.abc;
 
 -- Reset the configuration to the default value
 \c :provider_dsn


### PR DESCRIPTION
## Summary

The auto-DDL path in `spock_auto_replicate_ddl()` interpolated the publisher's `search_path` GUC straight into the queued command with a bare `%s`, guarded only by `strlen(search_path) > 0`. That is unsafe: `GetConfigOptionByName("search_path", ...)` does not always return something that is valid SQL on its own. In particular `set_config('search_path', ' ', false)` — exactly what core's `namespace` regression test does — leaves a bare space in the GUC, which interpolated directly emits the invalid `SET search_path TO  ;`. That statement fails to parse on the subscriber, so the DDL (and any rows depending on it) never lands.

`spock_replicate_ddl_command()` already parsed and re-quoted the path correctly, so the two code paths disagreed. This PR factors the correct logic into a single helper and routes both call sites through it.

## Changes

- Add `append_set_search_path()`, which parses the `search_path` value with `SplitIdentifierString()` and re-emits each schema name through `quote_identifier()`. A value that resolves to no schemas (empty or whitespace-only) is shipped as `SET search_path TO '';`, so the command is always valid SQL and the subscriber ends up with the same effective (empty) path as the publisher.
- Replace the unsafe `%s` interpolation in `spock_auto_replicate_ddl()` with a call to the helper.
- Replace the duplicated open-coded loop in `spock_replicate_ddl_command()` with the same helper.
- Upgrade the `spock_relation_open()` cache-miss `elog` to an `ereport` with `errdetail`/`errhint` that point at the likely cause — a relation message arriving after a data change that references it, usually a schema mismatch — so the subscriber-side failure is diagnosable rather than a bare "cache lookup failed".
