### PR TITLE
Prepare v5.0.10

### DIFF
--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -1,8 +1,39 @@
 # Spock Release Notes
 
-## Spock 5.0.9
+## Spock 5.0.10
 
 ### Bug Fixes
+* Improve apply performance on tables with a unique index over a frequently
+  NULL column. Rows with a NULL in such a key are now recognized as
+  non-conflicting without an unnecessary index scan, avoiding a slowdown that
+  grew with table size.
+* Correctly handle conflicts on `NULLS NOT DISTINCT` unique indexes.
+  On these indexes (PostgreSQL 15+) two NULL values are treated as equal, so
+  matching NULL-keyed rows are now resolved through normal conflict resolution
+  (last-update-wins) instead of failing with a duplicate-key error.
+* Fix a `could not open relation` error in the apply worker when an index is
+  dropped while replication is running. The worker now refreshes its cached
+  view of a table's indexes before using it.
+* Fix gradual memory growth during a transaction that logs to
+  `spock.exception_log`. Memory used while recording exceptions is now released
+  per row instead of accumulating until the transaction commits.
+* Fix ZODAN (`add_node`) version checking. Spock versions were compared as
+  text, so `5.0.10` sorted below `5.0.4` and a valid node was wrongly rejected.
+  Versions are now compared numerically, and nodes may differ in patch level as
+  long as their major.minor matches, allowing rolling upgrades.
+
+## Spock 5.0.9
+
+### New Features
+* Initial PostgreSQL 19 support. Adds the server-side patches required to build
+  and run Spock against PostgreSQL 19.
+
+### Bug Fixes
+* Fix silently dropped writes after a synchronous-standby failover.
+  Spock could report an incorrect replication position to the publisher, so a
+  promoted standby resumed from the wrong point and lost the changes in
+  between. The position reported to the publisher is now always taken from the
+  publisher's own WAL stream.
 * Fix `spock_failover_slots` stalling on PG17+ standbys. Slot
   synchronization could hold replication-slot and proc-array locks
   exclusively long enough to block every backend trying to start up on the
@@ -12,6 +43,15 @@
   connections disabled (`datconnlimit = -2`) concurrently with Spock
   starting a per-database worker. The database OID is now revalidated
   immediately before the worker is registered to avoid race.
+* Reduce per-row work and memory growth in the apply path. Replicated
+  changes no longer re-open a table's indexes for every row, and transient
+  memory is freed per row instead of building up over the transaction.
+
+### Performance
+* Skip building conflict log messages that would not be logged. When the log
+  level is suppressed, Spock no longer formats the conflicting rows for an
+  `ereport()` that would be discarded, speeding up apply on high-conflict
+  workloads. Recording conflicts in `spock.resolutions` is unaffected.
 
 ## Spock 5.0.8
 

--- a/include/spock.h
+++ b/include/spock.h
@@ -24,8 +24,8 @@
 #include "spock_fe.h"
 #include "spock_node.h"
 
-#define SPOCK_VERSION "5.0.9"
-#define SPOCK_VERSION_NUM 50009
+#define SPOCK_VERSION "5.0.10"
+#define SPOCK_VERSION_NUM 50010
 
 #define EXTENSION_NAME "spock"
 #define SPOCK_SECLABEL_PROVIDER "spock"

--- a/samples/Z0DAN/zodan.py
+++ b/samples/Z0DAN/zodan.py
@@ -24,7 +24,7 @@ import re
 
 class SpockClusterManager:
     VERSION = "1.0.0"
-    MIN_SPOCK_VERSION = "5.0.4"
+    MIN_SPOCK_VERSION = "5.0.9"
     
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
@@ -917,6 +917,21 @@ class SpockClusterManager:
 
         self.notice("=========================================")
 
+    @staticmethod
+    def _version_key(v: str) -> Tuple[int, ...]:
+        """Convert a Spock version string (e.g. '5.0.10', '5.0.4-devel') into a
+        tuple of ints (e.g. (5, 0, 10)) so versions compare numerically. A plain
+        string comparison is wrong because it orders versions lexically
+        (e.g. '5.0.10' < '5.0.4')."""
+        return tuple(int(x) for x in re.findall(r'\d+', v))
+
+    @classmethod
+    def _version_major_minor(cls, v: str) -> Tuple[int, ...]:
+        """Return the (major, minor) components of a version string. Used to allow
+        rolling upgrades: nodes may differ in patch level as long as their
+        major.minor matches."""
+        return cls._version_key(v)[:2]
+
     def check_spock_version_compatibility(self, src_dsn: str, new_node_dsn: str):
         """Check that all nodes have the required Spock version"""
         self.info("Checking Spock version compatibility across all nodes")
@@ -930,9 +945,8 @@ class SpockClusterManager:
             raise Exception("Spock extension not found on source node")
         src_version = src_version.strip()
         
-        # Check source node has required version (strip -devel suffix for comparison)
-        src_version_clean = src_version.replace('-devel', '')
-        if src_version_clean < min_required_version:
+        # Check source node has required version (compare numerically, not lexically)
+        if self._version_key(src_version) < self._version_key(min_required_version):
             raise Exception(f"Spock version mismatch: source node has version {src_version}, "
                           f"but minimum required version is {min_required_version}. Please upgrade all nodes to at least {min_required_version}.")
         
@@ -944,15 +958,15 @@ class SpockClusterManager:
             raise Exception("Spock extension not found on new node")
         new_version = new_version.strip()
         
-        # Check new node has required version (strip -devel suffix for comparison)
-        new_version_clean = new_version.replace('-devel', '')
-        if new_version_clean < min_required_version:
+        # Check new node has required version (compare numerically, not lexically)
+        if self._version_key(new_version) < self._version_key(min_required_version):
             raise Exception(f"Spock version mismatch: new node has version {new_version}, "
                           f"but minimum required version is {min_required_version}. Please upgrade all nodes to at least {min_required_version}.")
-        
-        if new_version_clean != src_version_clean:
+
+        # Allow rolling upgrades: patch differences are fine, but major.minor must match
+        if self._version_major_minor(new_version) != self._version_major_minor(src_version):
             raise Exception(f"Spock version mismatch: new node has version {new_version}, "
-                          f"but source version is {src_version}. Please ensure they are the same.")
+                          f"but source version is {src_version}. Major.minor versions must match (patch differences are allowed).")
 
         # Check all existing nodes in cluster
         nodes = self.get_spock_nodes(src_dsn)
@@ -965,15 +979,15 @@ class SpockClusterManager:
                 raise Exception(f"Spock extension not found on node {node['node_name']}")
             node_version = node_version.strip()
             
-            node_version_clean = node_version.replace('-devel', '')
-            if node_version_clean < min_required_version:
+            if self._version_key(node_version) < self._version_key(min_required_version):
                 raise Exception(f"Spock version mismatch: node {node['node_name']} has version {node_version}, "
                               f"but minimum required version is {min_required_version}. "
                               f"All nodes must have version {min_required_version}.")
 
-            if node_version_clean != new_version_clean:
+            # Allow rolling upgrades: patch differences are fine, but major.minor must match
+            if self._version_major_minor(node_version) != self._version_major_minor(new_version):
                 raise Exception(f"Spock version mismatch: new node has version {new_version}, "
-                              f"but node version is {node_version}. Please ensure they are the same.")
+                              f"but node version is {node_version}. Major.minor versions must match (patch differences are allowed).")
 
         self.notice(f"Version check passed: All nodes running at least Spock version {min_required_version}. Source node {src_version}, new node {new_version}")
 

--- a/sql/spock--5.0.9--5.0.10.sql
+++ b/sql/spock--5.0.9--5.0.10.sql
@@ -1,0 +1,6 @@
+/* spock--5.0.9--5.0.10.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION spock UPDATE TO '5.0.10'" to load this file. \quit
+
+-- No schema changes in 5.0.10.

--- a/tests/regress/expected/init.out
+++ b/tests/regress/expected/init.out
@@ -49,7 +49,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
                List of installed extensions
  Name  | Version | Schema |          Description           
 -------+---------+--------+--------------------------------
- spock | 5.0.9   | spock  | PostgreSQL Logical Replication
+ spock | 5.0.10  | spock  | PostgreSQL Logical Replication
 (1 row)
 
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super');

--- a/tests/regress/expected/init_1.out
+++ b/tests/regress/expected/init_1.out
@@ -49,7 +49,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
                         List of installed extensions
  Name  | Version | Default version | Schema |          Description           
 -------+---------+-----------------+--------+--------------------------------
- spock | 5.0.9   | 5.0.9           | spock  | PostgreSQL Logical Replication
+ spock | 5.0.10  | 5.0.10          | spock  | PostgreSQL Logical Replication
 (1 row)
 
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super');


### PR DESCRIPTION
Bump SPOCK_VERSION to 5.0.10, add the 5.0.9->5.0.10 migration script (no schema changes), and document the 5.0.10 release notes. Also backfills the 5.0.9 notes for changes that shipped in that tag (PG19 support, the sync-standby data-loss fix, apply-path work/memory reduction, and the conflict-log skip). Update init regression expected output for the new version string.