### PR TITLE
spock_conflict: fix spurious tiebreaker-equal WARNING in single-writer topology

### DIFF
--- a/src/spock_conflict.c
+++ b/src/spock_conflict.c
@@ -132,32 +132,52 @@ conflict_resolve_by_timestamp(RepOriginId local_origin_id,
 		/*
 		 * The timestamps were equal. Use the "tiebreaker" from the spock.node
 		 * configuration to come up with a winner.
+		 *
+		 * loc_node is always this node (the one applying the change), not the
+		 * origin of the local tuple.  The tiebreaker answers "which physical
+		 * node wins?" — that is a property of the applying node vs the remote
+		 * sending node, regardless of what origin is stamped on the existing
+		 * local tuple.  Using local_origin_id here incorrectly resolves to the
+		 * same node on both sides whenever the local row was replicated from
+		 * the same source that is sending the update (single-writer topology).
+		 *
+		 * Same-origin shortcut: when the local tuple and the remote change share
+		 * the same origin (e.g. the same row updated twice in one upstream
+		 * transaction), there is no real conflict — apply the remote value.
 		 */
+		SpockLocalNode *applying_node;
 		SpockNode  *loc_node;
 		SpockNode  *rmt_node;
 
-		/* If the current local tuple is really local, use our own node.id */
-		if (local_origin_id == InvalidRepOriginId)
+		if (local_origin_id != InvalidRepOriginId &&
+			local_origin_id == remote_origin_id)
 		{
-			SpockLocalNode *local_node = get_local_node(false, false);
-
-			local_origin_id = local_node->node->id;
+			*resolution = SpockResolution_ApplyRemote;
+			return true;
 		}
 
-		/* Get the two nodes for their "tiebreaker" */
-		loc_node = get_node(local_origin_id, false);
+		applying_node = get_local_node(false, false);
+		loc_node = applying_node->node;
 		rmt_node = get_node(remote_origin_id, false);
 
 		if (loc_node->tiebreaker == rmt_node->tiebreaker)
 		{
 			/*
-			 * Major pilot error here. Our default for the tiebreaker is the
-			 * unique 16-bit node.id but the user somehow managed to get
-			 * identical values into the "info" jsonb "tiebreaker" element.
+			 * Equal tiebreaker values. Node creation prevents this for new
+			 * nodes, but existing clusters may still hit it. Apply remote and
+			 * warn so the operator can assign unique tiebreaker values:
+			 *
+			 *   UPDATE spock.node
+			 *      SET info = COALESCE(info, '{}'::jsonb) ||
+			 *                 '{"tiebreaker": <unique_integer>}'
+			 *    WHERE node_name = '<name>';
 			 */
-			elog(WARNING, "CONFLICT: current node=%d and remote node=%d "
-				 "tiebreaker values are equal!",
-				 loc_node->id, rmt_node->id);
+			ereport(WARNING,
+					(errmsg("CONFLICT: node \"%s\" (id=%d) and node \"%s\" (id=%d) "
+							"have equal tiebreaker value %d; applying remote",
+							loc_node->name, loc_node->id,
+							rmt_node->name, rmt_node->id,
+							loc_node->tiebreaker)));
 			*resolution = SpockResolution_ApplyRemote;
 			return true;
 		}

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -178,6 +178,7 @@ create_node(SpockNode *node)
 	Datum		values[Natts_node];
 	bool		nulls[Natts_node];
 	NameData	node_name;
+	SpockNode  *existing;
 
 	if (get_node_by_name(node->name, true) != NULL)
 		elog(ERROR, "node %s already exists", node->name);
@@ -187,6 +188,19 @@ create_node(SpockNode *node)
 		node->id =
 			DatumGetUInt32(hash_any((const unsigned char *) node->name,
 									strlen(node->name))) & 0xffff;
+
+	/*
+	 * Detect node_id hash collisions before insertion.  The id is a 16-bit
+	 * hash of the node name, so two different names can produce the same
+	 * value.  A collision causes replication-origin ambiguity between the
+	 * two nodes.
+	 */
+	existing = get_node(node->id, true);
+	if (existing != NULL)
+		elog(ERROR,
+				"node id %u (computed from name \"%s\") collides with existing "
+				"node \"%s\"; rename this node to resolve the collision",
+				node->id, node->name, existing->name);
 
 	rv = makeRangeVar(EXTENSION_NAME, CATALOG_NODE, -1);
 	rel = table_openrv(rv, RowExclusiveLock);

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -44,6 +44,7 @@ test: 018_failover_slots
 test: 019_stale_fd_epoll_after_conn_death
 test: 022_rmgr_progress_post_checkpoint_crash
 test: 024_node_id_collision
+test: 025_tiebreaker_equal_warning
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match
 #

--- a/tests/tap/t/024_node_id_collision.pl
+++ b/tests/tap/t/024_node_id_collision.pl
@@ -113,8 +113,8 @@ my $sub_rc     = $?;
 
 isnt($sub_rc, 0, 'sub_create from tampered n2 to n1 fails as expected');
 like($sub_output,
-     qr/duplicate key|unique constraint|already exists|node.*exists/i,
-     "failure mode is a uniqueness / duplicate diagnostic " .
+     qr/duplicate key|unique constraint|already exists|node.*exists|collides with existing node/i,
+     "failure mode is a collision diagnostic " .
      "(sees: " . substr($sub_output, 0, 120) . "...)");
 
 # ---- Step 4: same in the reverse direction ---------------------------------
@@ -129,8 +129,8 @@ my $sub_rc2     = $?;
 
 isnt($sub_rc2, 0, 'sub_create from n1 to tampered n2 fails as expected');
 like($sub_output2,
-     qr/duplicate key|unique constraint|already exists|node.*exists/i,
-     "reverse failure mode is also a uniqueness diagnostic " .
+     qr/duplicate key|unique constraint|already exists|node.*exists|collides with existing node/i,
+     "reverse failure mode is also a collision diagnostic " .
      "(sees: " . substr($sub_output2, 0, 120) . "...)");
 
 # ---- Step 5: verify catalog state was not corrupted by the failed attempts -

--- a/tests/tap/t/025_tiebreaker_equal_warning.pl
+++ b/tests/tap/t/025_tiebreaker_equal_warning.pl
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster
+                 get_test_config scalar_query psql_or_bail
+                 wait_for_sub_status);
+
+# Verify that updating the same row twice in one transaction does not produce
+# a spurious "tiebreaker values are equal" WARNING on the subscriber.
+#
+# When a single transaction updates the same row twice, both WAL records are
+# applied in one apply transaction.  The second update finds xmin equal to the
+# current apply transaction XID, so get_tuple_origin() returns
+# local_ts == remote_ts, entering the tiebreaker path.  The bug was that
+# conflict_resolve_by_timestamp() looked up get_node(local_origin_id) for
+# loc_node; in single-writer topology local_origin_id == remote_origin_id
+# (both n1.id), so both sides resolved to the same SpockNode and the WARNING
+# fired trivially.  The fix uses get_local_node() for loc_node so the
+# comparison is always applying-node vs remote-node.
+
+create_cluster(2, 'tiebreaker equal-warning test');
+
+my $config      = get_test_config();
+my $ports       = $config->{node_ports};
+my $log_dir     = $config->{log_dir};
+my $host        = $config->{host};
+my $dbname      = $config->{db_name};
+my $db_user     = $config->{db_user};
+my $db_password = $config->{db_password};
+
+my $conn_n1 = "host=$host dbname=$dbname port=$ports->[0] user=$db_user password=$db_password";
+psql_or_bail(2,
+    "SELECT spock.sub_create('sub_n2n1', '$conn_n1', " .
+    "ARRAY['default','default_insert_only','ddl_sql'], true, true)");
+
+ok(wait_for_sub_status(2, 'sub_n2n1', 'replicating', 30),
+   'n2 subscription replicating');
+
+psql_or_bail(1, "
+    CREATE TABLE tiebreaker_test (id int PRIMARY KEY, val text);
+    INSERT INTO tiebreaker_test VALUES (1, 'initial');
+");
+
+for (1..30) {
+    last if scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1") eq 'initial';
+    sleep 1;
+}
+
+is(scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1"),
+   'initial', 'initial row replicated');
+
+my $log_file   = "${log_dir}/00$ports->[1].log";
+my $log_before = -s $log_file // 0;
+
+psql_or_bail(1, "
+    BEGIN;
+    UPDATE tiebreaker_test SET val = 'first'  WHERE id = 1;
+    UPDATE tiebreaker_test SET val = 'second' WHERE id = 1;
+    COMMIT;
+");
+
+for (1..30) {
+    last if scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1") eq 'second';
+    sleep 1;
+}
+
+is(scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1"),
+   'second', 'final value replicated');
+
+open(my $fh, '<', $log_file)
+    or BAIL_OUT("cannot open n2 log $log_file: $!");
+seek($fh, $log_before, 0);
+my $new_log = do { local $/; <$fh> };
+close($fh);
+
+unlike($new_log, qr/equal tiebreaker|tiebreaker.*equal/i,
+       'no spurious tiebreaker-equal WARNING after same-row double-update');
+
+destroy_cluster('tiebreaker equal-warning test');
+done_testing();


### PR DESCRIPTION
conflict_resolve_by_timestamp() used get_node(local_origin_id) for loc_node,
where local_origin_id is the replication origin stamped on the existing local
tuple.  In a single-writer topology every row on the subscriber carries
origin = provider.id and incoming changes also have remote_origin = provider.id,
so both lookups resolved to the same SpockNode.  The same ambiguity arises from
a node_id hash collision: the id is a 16-bit hash of the node name, so two
distinct nodes can share the same id and again resolve to the same SpockNode.
In either case the tiebreaker comparison is trivially equal, firing a spurious
WARNING on every timestamp-tied conflict.

Use get_local_node() for loc_node so the tiebreaker always compares the
applying node against the remote sender, not the tuple's origin.  Add a
same-origin shortcut: when local_origin_id == remote_origin_id the change
shares the same source (e.g. the same row updated twice in one upstream
transaction), so there is no real conflict and remote is applied directly
without consulting the tiebreaker.

Detect node_id hash collisions at node creation time.