### PR TITLE
Discard an un-appliable TRUNCATE instead of looping the apply worker

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1912,33 +1912,84 @@ handle_truncate(StringInfo s)
 	xact_action_counter++;
 	remote_relids = spock_read_truncate(s, &cascade, &restart_seqs);
 
-	/*
-	 * TRANSDISCARD/SUB_DISABLE: skip the TRUNCATE and log it as discarded.
-	 * ExecuteTruncateGuts is called directly (not via ProcessUtility), so
-	 * transaction_read_only does not protect against it — we must skip
-	 * explicitly, matching the pattern in handle_insert/update/delete.
-	 */
-	if (MyApplyWorker->use_try_block &&
-		(exception_behaviour == TRANSDISCARD ||
-		 exception_behaviour == SUB_DISABLE))
+	if (MyApplyWorker->use_try_block)
 	{
-		char	   *error_msg =
-			(xact_action_counter ==
-			 exception_log_ptr[my_exception_log_index].failed_action &&
-			 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0') ?
-			exception_log_ptr[my_exception_log_index].initial_error_message :
-			NULL;
+		if (exception_behaviour == TRANSDISCARD ||
+			exception_behaviour == SUB_DISABLE)
+		{
+			/*
+			 * TRANSDISCARD/SUB_DISABLE: the whole transaction is being
+			 * abandoned, so skip the TRUNCATE outright and log it as discarded
+			 * -- do not attempt it.  (ExecuteTruncateGuts is called directly,
+			 * not via ProcessUtility, so transaction_read_only would not have
+			 * protected us anyway.)
+			 */
+			char	   *error_msg =
+				(xact_action_counter ==
+				 exception_log_ptr[my_exception_log_index].failed_action &&
+				 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0') ?
+				exception_log_ptr[my_exception_log_index].initial_error_message :
+				NULL;
 
-		exception_command_counter++;
-		exception_log_ptr[my_exception_log_index].local_tuple = NULL;
-		log_insert_exception(false, error_msg, NULL, NULL, NULL, "TRUNCATE");
-		end_replication_step();
-		return;
+			exception_command_counter++;
+			exception_log_ptr[my_exception_log_index].local_tuple = NULL;
+			log_insert_exception(false, error_msg, NULL, NULL, NULL, "TRUNCATE");
+		}
+		else
+		{
+			/*
+			 * DISCARD: attempt the TRUNCATE in a subtransaction.  If it fails
+			 * -- including a relation that is missing on this node -- discard
+			 * it and carry on, rather than letting the error escape and be
+			 * re-thrown on every retry, which would loop the apply worker.
+			 * Matches the pattern in handle_insert/update/delete and
+			 * handle_sql_or_exception().
+			 */
+			bool		failed = false;
+			ErrorData  *edata = NULL;
+
+			PG_TRY();
+			{
+				exception_command_counter++;
+				BeginInternalSubTransaction(NULL);
+				apply_truncate(remote_relids, restart_seqs);
+			}
+			PG_CATCH();
+			{
+				failed = true;
+				xact_had_exception = true;
+
+				MemoryContextSwitchTo(ApplyOperationContext);
+				edata = CopyErrorData();
+
+				FlushErrorState();
+				RollbackAndReleaseCurrentSubTransaction();
+
+				/*
+				 * Rollback switches to the parent transaction context;
+				 * restore ApplyOperationContext for the code below.
+				 */
+				MemoryContextSwitchTo(ApplyOperationContext);
+			}
+			PG_END_TRY();
+
+			if (!failed)
+				ReleaseCurrentSubTransaction();
+			else
+			{
+				exception_log_ptr[my_exception_log_index].local_tuple = NULL;
+				log_insert_exception(true, edata->message, NULL, NULL, NULL,
+									 "TRUNCATE");
+			}
+		}
 	}
-
-	apply_truncate(remote_relids, restart_seqs);
+	else
+		apply_truncate(remote_relids, restart_seqs);
 
 	end_replication_step();
+
+	/* Free CopyErrorData allocations from the DISCARD-mode PG_CATCH path. */
+	MemoryContextReset(ApplyOperationContext);
 }
 
 inline static bool

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1777,14 +1777,18 @@ handle_delete(StringInfo s)
 }
 
 /*
- * Handle TRUNCATE
+ * apply_truncate
+ *		Resolve the remote relation OIDs to local relations -- expanding any
+ *		partitioned table to its leaf partitions -- and TRUNCATE them.
+ *
+ *		May throw: a relation missing on this node, or a constraint or trigger
+ *		fired by the truncate.  Callers replaying under exception handling must
+ *		wrap this in a subtransaction so such a failure can be discarded; see
+ *		handle_truncate().
  */
 static void
-handle_truncate(StringInfo s)
+apply_truncate(List *remote_relids, bool restart_seqs)
 {
-	bool		cascade = false;
-	bool		restart_seqs = false;
-	List	   *remote_relids = NIL;
 	List	   *remote_rels = NIL;
 	List	   *rels = NIL;
 	List	   *part_rels = NIL;
@@ -1792,42 +1796,6 @@ handle_truncate(StringInfo s)
 	List	   *relids_logged = NIL;
 	ListCell   *lc;
 	LOCKMODE	lockmode = AccessExclusiveLock;
-
-	/*
-	 * Quick return if we are skipping data modification changes.
-	 */
-	if (is_skipping_changes())
-		return;
-
-	begin_replication_step();
-
-	errcallback_arg.action_name = "TRUNCATE";
-	xact_action_counter++;
-	remote_relids = spock_read_truncate(s, &cascade, &restart_seqs);
-
-	/*
-	 * TRANSDISCARD/SUB_DISABLE: skip the TRUNCATE and log it as discarded.
-	 * ExecuteTruncateGuts is called directly (not via ProcessUtility), so
-	 * transaction_read_only does not protect against it — we must skip
-	 * explicitly, matching the pattern in handle_insert/update/delete.
-	 */
-	if (MyApplyWorker->use_try_block &&
-		(exception_behaviour == TRANSDISCARD ||
-		 exception_behaviour == SUB_DISABLE))
-	{
-		char	   *error_msg =
-			(xact_action_counter ==
-			 exception_log_ptr[my_exception_log_index].failed_action &&
-			 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0') ?
-			exception_log_ptr[my_exception_log_index].initial_error_message :
-			NULL;
-
-		exception_command_counter++;
-		exception_log_ptr[my_exception_log_index].local_tuple = NULL;
-		log_insert_exception(false, error_msg, NULL, NULL, NULL, "TRUNCATE");
-		end_replication_step();
-		return;
-	}
 
 	foreach(lc, remote_relids)
 	{
@@ -1920,6 +1888,55 @@ handle_truncate(StringInfo s)
 
 		table_close(rel, NoLock);
 	}
+}
+
+/*
+ * Handle TRUNCATE
+ */
+static void
+handle_truncate(StringInfo s)
+{
+	bool		cascade = false;
+	bool		restart_seqs = false;
+	List	   *remote_relids = NIL;
+
+	/*
+	 * Quick return if we are skipping data modification changes.
+	 */
+	if (is_skipping_changes())
+		return;
+
+	begin_replication_step();
+
+	errcallback_arg.action_name = "TRUNCATE";
+	xact_action_counter++;
+	remote_relids = spock_read_truncate(s, &cascade, &restart_seqs);
+
+	/*
+	 * TRANSDISCARD/SUB_DISABLE: skip the TRUNCATE and log it as discarded.
+	 * ExecuteTruncateGuts is called directly (not via ProcessUtility), so
+	 * transaction_read_only does not protect against it — we must skip
+	 * explicitly, matching the pattern in handle_insert/update/delete.
+	 */
+	if (MyApplyWorker->use_try_block &&
+		(exception_behaviour == TRANSDISCARD ||
+		 exception_behaviour == SUB_DISABLE))
+	{
+		char	   *error_msg =
+			(xact_action_counter ==
+			 exception_log_ptr[my_exception_log_index].failed_action &&
+			 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0') ?
+			exception_log_ptr[my_exception_log_index].initial_error_message :
+			NULL;
+
+		exception_command_counter++;
+		exception_log_ptr[my_exception_log_index].local_tuple = NULL;
+		log_insert_exception(false, error_msg, NULL, NULL, NULL, "TRUNCATE");
+		end_replication_step();
+		return;
+	}
+
+	apply_truncate(remote_relids, restart_seqs);
 
 	end_replication_step();
 }

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -39,6 +39,7 @@ test: 013_exception_handling
 test: 015_skip_lsn
 test: 015_forward_origin_advance
 test: 016_sub_disable_missing_relation
+test: 031_discard_truncate_missing_relation
 test: 018_forward_origins
 test: 018_failover_slots
 test: 019_stale_fd_epoll_after_conn_death

--- a/tests/tap/t/031_discard_truncate_missing_relation.pl
+++ b/tests/tap/t/031_discard_truncate_missing_relation.pl
@@ -1,0 +1,157 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query psql_or_bail
+    wait_for_sub_status wait_for_exception_log
+);
+
+# =============================================================================
+# Test 031: DISCARD mode skips only an un-appliable TRUNCATE
+# =============================================================================
+#
+# A single replicated transaction mixes INSERT/UPDATE/DELETE on one table with
+# a TRUNCATE of another table that has been dropped on the subscriber (modelling
+# a missing relation by removing it manually).  In 'discard' mode:
+#
+#   - only the TRUNCATE must be discarded (and logged), and
+#   - the INSERT/UPDATE/DELETE in the same transaction must still apply, and
+#   - the apply worker must keep running -- the un-appliable TRUNCATE must not
+#     escape and send the worker into a crash/restart loop.
+#
+# Before the fix, the replayed TRUNCATE raised "Spock can't find relation",
+# which escaped handle_truncate() and was re-thrown by the apply worker on every
+# retry: the whole transaction (row changes included) never applied and the
+# stream wedged.
+
+create_cluster(2, 'Create 2-node cluster for DISCARD truncate test');
+
+my $config      = get_test_config();
+my $node_ports  = $config->{node_ports};
+my $host        = $config->{host};
+my $dbname      = $config->{db_name};
+my $db_user     = $config->{db_user};
+my $db_password = $config->{db_password};
+
+my $p1 = $node_ports->[0];   # n1 -- provider
+my $p2 = $node_ports->[1];   # n2 -- subscriber
+
+my $conn_n1 = "host=$host dbname=$dbname port=$p1 user=$db_user password=$db_password";
+
+# ---------------------------------------------------------------------------
+# Setup: two tables on both nodes, then a one-way subscription n1 -> n2.
+# t_data carries the row changes; t_trunc is the TRUNCATE target.  Both go into
+# the 'default' repset on the provider, which replicates TRUNCATE (unlike
+# 'default_insert_only').  DDL replication is turned off for the creation so the
+# subscriber copy can be created explicitly and dropped later.
+# ---------------------------------------------------------------------------
+psql_or_bail(1,
+    "SET spock.enable_ddl_replication = off; " .
+    "CREATE TABLE t_data (id int PRIMARY KEY, val text); " .
+    "CREATE TABLE t_trunc (id int PRIMARY KEY, val text); " .
+    "SELECT spock.repset_add_table('default', 't_data'); " .
+    "SELECT spock.repset_add_table('default', 't_trunc')");
+
+psql_or_bail(2,
+    "CREATE TABLE t_data (id int PRIMARY KEY, val text); " .
+    "CREATE TABLE t_trunc (id int PRIMARY KEY, val text)");
+
+psql_or_bail(2,
+    "SELECT spock.sub_create('sub_n1_n2', '$conn_n1', " .
+    "ARRAY['default', 'default_insert_only', 'ddl_sql'], false, false)");
+
+ok(wait_for_sub_status(2, 'sub_n1_n2', 'replicating', 30),
+    'sub_n1_n2 reaches replicating state');
+
+# Discard failed actions individually rather than disabling the subscription.
+psql_or_bail(2, "ALTER SYSTEM SET spock.exception_behaviour = 'DISCARD'");
+psql_or_bail(2, "ALTER SYSTEM SET spock.enable_ddl_replication = off");
+psql_or_bail(2, "ALTER SYSTEM SET spock.exception_logging = 'ALL'");
+psql_or_bail(2, "SELECT pg_reload_conf()");
+
+# Seed rows the UPDATE/DELETE will target, plus a row in the TRUNCATE target.
+psql_or_bail(1, "INSERT INTO t_data VALUES (10, 'to_update'), (20, 'to_delete')");
+psql_or_bail(1, "INSERT INTO t_trunc VALUES (1, 'survivor')");
+
+# Both tables and their seed rows should reach the subscriber.
+my $seeded = 0;
+for (1 .. 30)
+{
+    my $a = scalar_query(2, "SELECT count(*) FROM t_data");
+    my $b = scalar_query(2, "SELECT count(*) FROM t_trunc");
+    if ($a eq '2' && $b eq '1') { $seeded = 1; last; }
+    sleep(1);
+}
+ok($seeded, 'schema and seed rows replicated to subscriber');
+
+psql_or_bail(2, "TRUNCATE spock.exception_log");
+
+# Drop the TRUNCATE target on the subscriber only -- a replicated TRUNCATE of
+# t_trunc can now no longer be applied ("Spock can't find relation").
+psql_or_bail(2, "DROP TABLE t_trunc CASCADE");
+
+# ---------------------------------------------------------------------------
+# One transaction mixing row changes with the un-appliable TRUNCATE.
+# ---------------------------------------------------------------------------
+psql_or_bail(1, "
+    BEGIN;
+    INSERT INTO t_data VALUES (1, 'inserted');
+    UPDATE t_data SET val = 'updated' WHERE id = 10;
+    DELETE FROM t_data WHERE id = 20;
+    TRUNCATE t_trunc;
+    COMMIT;
+");
+
+# The TRUNCATE must be discarded and recorded in the exception log.
+ok(wait_for_exception_log(2, "operation = 'TRUNCATE'", 30),
+    'discarded TRUNCATE is recorded in spock.exception_log');
+
+# The row changes in the SAME transaction must still apply.
+my $applied = 0;
+for (1 .. 30)
+{
+    my $ins = scalar_query(2, "SELECT val FROM t_data WHERE id = 1");
+    my $upd = scalar_query(2, "SELECT val FROM t_data WHERE id = 10");
+    my $del = scalar_query(2, "SELECT count(*) FROM t_data WHERE id = 20");
+    if ($ins eq 'inserted' && $upd eq 'updated' && $del eq '0')
+    {
+        $applied = 1;
+        last;
+    }
+    sleep(1);
+}
+ok($applied, 'INSERT/UPDATE/DELETE applied while only the TRUNCATE was skipped');
+
+# Per-statement checks, for a clear message if the combined check above fails.
+is(scalar_query(2, "SELECT val FROM t_data WHERE id = 1"), 'inserted',
+    'INSERT from the mixed transaction applied on subscriber');
+is(scalar_query(2, "SELECT val FROM t_data WHERE id = 10"), 'updated',
+    'UPDATE from the mixed transaction applied on subscriber');
+is(scalar_query(2, "SELECT count(*) FROM t_data WHERE id = 20"), '0',
+    'DELETE from the mixed transaction applied on subscriber');
+
+# The apply worker must survive: the subscription stays replicating (not
+# disabled, not stuck) -- i.e. no crash/restart loop on the missing relation.
+is(scalar_query(2,
+    "SELECT status FROM spock.sub_show_status() WHERE subscription_name = 'sub_n1_n2'"),
+    'replicating', 'subscription still replicating after the discarded TRUNCATE');
+
+# And a later change still flows end-to-end, proving the stream did not wedge.
+psql_or_bail(1, "INSERT INTO t_data VALUES (2, 'after')");
+my $flows = 0;
+for (1 .. 30)
+{
+    if (scalar_query(2, "SELECT val FROM t_data WHERE id = 2") eq 'after')
+    {
+        $flows = 1;
+        last;
+    }
+    sleep(1);
+}
+ok($flows, 'replication keeps flowing after the discarded TRUNCATE');
+
+destroy_cluster('Destroy cluster after DISCARD truncate test');
+
+done_testing();


### PR DESCRIPTION
## Problem

In `DISCARD` exception mode, `handle_truncate()` had no per-action exception handling. On the retry (`use_try_block`) pass it re-ran the truncate directly, so any failure — most commonly a relation that does not exist on the subscriber — escaped as an `ERROR`.

With `use_try_block` set and `xact_had_exception` still clear, `apply_work()`'s outer handler re-throws to exit the worker; the background worker then restarts, replays from the same position, and fails identically. The result is an apply-worker crash/restart loop that stalls every later change from that origin — `spock.sync_event()` included — so the whole transaction (its row changes too) never lands and the stream wedges.

The row handlers (`handle_insert`/`update`/`delete`) and the queued-SQL handler (`handle_sql_or_exception()`) already wrap their work in a subtransaction for exactly this reason. `TRUNCATE` was the one directly-applied operation missing it: `ExecuteTruncateGuts()` is called directly (not via `ProcessUtility`), and on a missing relation `handle_truncate()` simply `ereport`ed, with no savepoint to roll back to.

## Fix

1. **Extract `apply_truncate()`** — a preparatory refactor with no behaviour change, isolating the relation resolution (including partition expansion) and the `ExecuteTruncateGuts()` call, i.e. the part of the path that can throw.

2. **Discard the failing TRUNCATE in `DISCARD` mode** — on the retry path, run `apply_truncate()` inside an internal subtransaction. On failure, roll back the savepoint, set `xact_had_exception`, log the discarded TRUNCATE to `spock.exception_log`, and carry on. This mirrors the pattern already used by the row and SQL handlers.

   `TRANSDISCARD` and `SUB_DISABLE` keep their unconditional skip: the whole transaction is being abandoned, so the truncate must not be attempted at all.

## Behaviour

A TRUNCATE that cannot be applied on the subscriber is now discarded individually — recorded in `spock.exception_log` with `operation = 'TRUNCATE'` — while the other changes in the same transaction still apply and the apply worker keeps running. No more crash/restart loop on a missing relation.
