### PR TITLE
Zodan version check for 5.0.10

### DIFF
--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -1,7 +1,7 @@
 -- ============================================================================
 -- ZODAN (Zero Downtime Add Node) - Spock Extension
 -- Version: 1.0.0
--- Required Spock Version: 5.0.4 or later
+-- Required Spock Version: 5.0.9 or later
 -- ============================================================================
 -- Adds a new node to the cluster of Spock.
 -- NOTE: Run the add_node procedure on the new node you are adding, not on an existing cluster node.
@@ -60,6 +60,21 @@ RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
 $$;
 
 -- ============================================================================
+-- Function: version_major_minor
+-- Purpose : Extract the {major, minor} components of a Spock version string as
+--           an int[] (e.g. '5.0.10' and '5.0.4' both yield {5,0}). Used to
+--           allow rolling upgrades: nodes may differ in patch level as long as
+--           their major.minor matches.
+-- Arguments:
+--   v - The version string. Any non-numeric suffix (such as '-devel') is ignored.
+-- Returns  : int[] of length up to 2, the major and minor components.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.version_major_minor(v text)
+RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
+    SELECT (spock.version_to_array(v))[1:2];
+$$;
+
+-- ============================================================================
 -- Procedure: check_spock_version_compatibility
 -- Purpose: Verify all nodes have the same Spock version before adding a node
 -- ============================================================================
@@ -69,7 +84,7 @@ CREATE OR REPLACE PROCEDURE spock.check_spock_version_compatibility(
     verb boolean DEFAULT false
 ) LANGUAGE plpgsql AS $$
 DECLARE
-    min_required_version text := '5.0.4';
+    min_required_version text := '5.0.9';
     src_version text;
     new_version text;
     node_rec RECORD;
@@ -110,8 +125,9 @@ BEGIN
             new_version, min_required_version, min_required_version;
     END IF;
 
-    IF regexp_replace(new_version, '-devel$', '') != regexp_replace(src_version, '-devel$', '') THEN
-        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Please ensure that they match.',
+    -- Allow rolling upgrades: patch differences are fine, but major.minor must match
+    IF spock.version_major_minor(new_version) IS DISTINCT FROM spock.version_major_minor(src_version) THEN
+        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Major.minor versions must match (patch differences are allowed).',
             new_version, src_version;
     END IF;
 
@@ -134,8 +150,9 @@ BEGIN
                 node_rec.node_name, node_version, min_required_version, min_required_version;
         END IF;
 
-        IF regexp_replace(node_version, '-devel$', '') != regexp_replace(new_version, '-devel$', '') THEN
-            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Please ensure that they match.',
+        -- Allow rolling upgrades: patch differences are fine, but major.minor must match
+        IF spock.version_major_minor(node_version) IS DISTINCT FROM spock.version_major_minor(new_version) THEN
+            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Major.minor versions must match (patch differences are allowed).',
                 new_version, node_version;
         END IF;
     END LOOP;

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -45,6 +45,21 @@ CREATE OR REPLACE FUNCTION spock.gen_sub_name(
 $$;
 
 -- ============================================================================
+-- Function: version_to_array
+-- Purpose : Convert a Spock version string (e.g. '5.0.10', '5.0.4-devel') into
+--           an integer array (e.g. {5,0,10}) so versions can be compared
+--           numerically. A plain text comparison is wrong because it orders
+--           versions lexically (e.g. '5.0.10' < '5.0.4').
+-- Arguments:
+--   v - The version string. Any non-numeric suffix (such as '-devel') is ignored.
+-- Returns  : int[], the dotted numeric components in order.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.version_to_array(v text)
+RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
+    SELECT string_to_array((regexp_match(v, '[0-9]+(?:\.[0-9]+)*'))[1], '.')::int[];
+$$;
+
+-- ============================================================================
 -- Procedure: check_spock_version_compatibility
 -- Purpose: Verify all nodes have the same Spock version before adding a node
 -- ============================================================================
@@ -73,8 +88,8 @@ BEGIN
         RAISE EXCEPTION 'Spock extension not found on source node';
     END IF;
 
-    -- Check source node has required version (strip -devel suffix for comparison)
-    IF regexp_replace(src_version, '-devel$', '') < min_required_version THEN
+    -- Check source node has required version (compare numerically, not lexically)
+    IF spock.version_to_array(src_version) < spock.version_to_array(min_required_version) THEN
         RAISE EXCEPTION 'Spock version mismatch: source node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
             src_version, min_required_version, min_required_version;
     END IF;
@@ -89,8 +104,8 @@ BEGIN
         RAISE EXCEPTION 'Spock extension not found on new node';
     END IF;
 
-    -- Check new node has required version (strip -devel suffix for comparison)
-    IF regexp_replace(new_version, '-devel$', '') < min_required_version THEN
+    -- Check new node has required version (compare numerically, not lexically)
+    IF spock.version_to_array(new_version) < spock.version_to_array(min_required_version) THEN
         RAISE EXCEPTION 'Spock version mismatch: new node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
             new_version, min_required_version, min_required_version;
     END IF;
@@ -113,7 +128,7 @@ BEGIN
             RAISE EXCEPTION 'Spock extension not found on node %', node_rec.node_name;
         END IF;
 
-        IF regexp_replace(node_version, '-devel$', '') < min_required_version THEN
+        IF spock.version_to_array(node_version) < spock.version_to_array(min_required_version) THEN
             version_mismatch := true;
             RAISE EXCEPTION 'Spock version mismatch: node % has version %, but required version is at least %. All nodes must have version % or later.',
                 node_rec.node_name, node_version, min_required_version, min_required_version;


### PR DESCRIPTION
  Fixes Spock version checking in `samples/Z0DAN/zodan.sql` (`check_spock_version_compatibility`).

  - **Numeric version comparison.** The minimum-version check compared `extversion`
    strings with text operators, which order versions lexically — so `'5.0.10' < '5.0.4'`
    was true and a node running 5.0.10 was wrongly rejected as below the minimum
    (e.g. test `009` failing). Added `spock.version_to_array()` to parse versions into
    an `int[]` (stripping any `-devel` suffix) and compare component-wise.

  - **Allow rolling upgrades.** The exact byte-identical cross-node match rejected mixed
    patch levels (e.g. adding a 5.0.10 node to a 5.0.9 cluster). Added
    `spock.version_major_minor()` and now compare on major.minor only — patch differences
    are allowed, a true major.minor mismatch (5.0.x vs 5.1.x) is still rejected.
    Uses `IS DISTINCT FROM` so a malformed/unparseable version can't slip past.

  - Raised the minimum required version to **5.0.9**.