### PR TITLE
spock_conflict: fix spurious tiebreaker-equal WARNING in single-write…

### DIFF
--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -62,7 +62,7 @@ typedef struct SpockSubscription
 extern void create_node(SpockNode *node);
 extern void drop_node(Oid nodeid);
 
-extern SpockNode *get_node(Oid nodeid);
+extern SpockNode *get_node(Oid nodeid, bool missing_ok);
 extern SpockNode *get_node_by_name(const char *name, bool missing_ok);
 
 extern void create_node_interface(SpockInterface *node);

--- a/src/spock_conflict.c
+++ b/src/spock_conflict.c
@@ -440,32 +440,52 @@ conflict_resolve_by_timestamp(RepOriginId local_origin_id,
 		/*
 		 * The timestamps were equal. Use the "tiebreaker" from the spock.node
 		 * configuration to come up with a winner.
+		 *
+		 * loc_node is always this node (the one applying the change), not the
+		 * origin of the local tuple.  The tiebreaker answers "which physical
+		 * node wins?" — that is a property of the applying node vs the remote
+		 * sending node, regardless of what origin is stamped on the existing
+		 * local tuple.  Using local_origin_id here incorrectly resolves to the
+		 * same node on both sides whenever the local row was replicated from
+		 * the same source that is sending the update (single-writer topology).
+		 *
+		 * Same-origin shortcut: when the local tuple and the remote change share
+		 * the same origin (e.g. the same row updated twice in one upstream
+		 * transaction), there is no real conflict — apply the remote value.
 		 */
+		SpockLocalNode *applying_node;
 		SpockNode  *loc_node;
 		SpockNode  *rmt_node;
 
-		/* If the current local tuple is really local, use our own node.id */
-		if (local_origin_id == InvalidRepOriginId)
+		if (local_origin_id != InvalidRepOriginId &&
+			local_origin_id == remote_origin_id)
 		{
-			SpockLocalNode *local_node = get_local_node(false, false);
-
-			local_origin_id = local_node->node->id;
+			*resolution = SpockResolution_ApplyRemote;
+			return true;
 		}
 
-		/* Get the two nodes for their "tiebreaker" */
-		loc_node = get_node(local_origin_id);
-		rmt_node = get_node(remote_origin_id);
+		applying_node = get_local_node(false, false);
+		loc_node = applying_node->node;
+		rmt_node = get_node(remote_origin_id, false);
 
 		if (loc_node->tiebreaker == rmt_node->tiebreaker)
 		{
 			/*
-			 * Major pilot error here. Our default for the tiebreaker is the
-			 * unique 16-bit node.id but the user somehow managed to get
-			 * identical values into the "info" jsonb "tiebreaker" element.
+			 * Equal tiebreaker values. Node creation prevents this for new
+			 * nodes, but existing clusters may still hit it. Apply remote and
+			 * warn so the operator can assign unique tiebreaker values:
+			 *
+			 *   UPDATE spock.node
+			 *      SET info = COALESCE(info, '{}'::jsonb) ||
+			 *                 '{"tiebreaker": <unique_integer>}'
+			 *    WHERE node_name = '<name>';
 			 */
-			elog(WARNING, "CONFLICT: current node=%d and remote node=%d "
-				 "tiebreaker values are equal!",
-				 loc_node->id, rmt_node->id);
+			ereport(WARNING,
+					(errmsg("CONFLICT: node \"%s\" (id=%d) and node \"%s\" (id=%d) "
+							"have equal tiebreaker value %d; applying remote",
+							loc_node->name, loc_node->id,
+							rmt_node->name, rmt_node->id,
+							loc_node->tiebreaker)));
 			*resolution = SpockResolution_ApplyRemote;
 			return true;
 		}

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -157,6 +157,7 @@ create_node(SpockNode *node)
 	Datum		values[Natts_node];
 	bool		nulls[Natts_node];
 	NameData	node_name;
+	SpockNode  *existing;
 
 	if (get_node_by_name(node->name, true) != NULL)
 		elog(ERROR, "node %s already exists", node->name);
@@ -166,6 +167,19 @@ create_node(SpockNode *node)
 		node->id =
 			DatumGetUInt32(hash_any((const unsigned char *) node->name,
 									strlen(node->name))) & 0xffff;
+
+	/*
+	 * Detect node_id hash collisions before insertion.  The id is a 16-bit
+	 * hash of the node name, so two different names can produce the same
+	 * value.  A collision causes replication-origin ambiguity between the
+	 * two nodes.
+	 */
+	existing = get_node(node->id, true);
+	if (existing != NULL)
+		elog(ERROR,
+			 "node id %u (computed from name \"%s\") collides with existing "
+			 "node \"%s\"; rename this node to resolve the collision",
+			 node->id, node->name, existing->name);
 
 	rv = makeRangeVar(EXTENSION_NAME, CATALOG_NODE, -1);
 	rel = table_openrv(rv, RowExclusiveLock);
@@ -324,9 +338,9 @@ node_fromtuple(HeapTuple tuple, TupleDesc desc)
  * Load the info for specific node.
  */
 SpockNode *
-get_node(Oid nodeid)
+get_node(Oid nodeid, bool missing_ok)
 {
-	SpockNode  *node;
+	SpockNode  *node = NULL;
 	RangeVar	   *rv;
 	Relation		rel;
 	SysScanDesc		scan;
@@ -346,9 +360,12 @@ get_node(Oid nodeid)
 	tuple = systable_getnext(scan);
 
 	if (!HeapTupleIsValid(tuple))
-		elog(ERROR, "node %u not found", nodeid);
-
-	node = node_fromtuple(tuple, RelationGetDescr(rel));
+	{
+		if (!missing_ok)
+			elog(ERROR, "node %u not found", nodeid);
+	}
+	else
+		node = node_fromtuple(tuple, RelationGetDescr(rel));
 
 	systable_endscan(scan);
 	table_close(rel, RowExclusiveLock);
@@ -536,7 +553,7 @@ get_local_node(bool for_update, bool missing_ok)
 	table_close(rel, for_update ? NoLock : RowExclusiveLock);
 
 	res = (SpockLocalNode *) palloc(sizeof(SpockLocalNode));
-	res->node = get_node(nodeid);
+	res->node = get_node(nodeid, false);
 	res->node_if = get_node_interface(nodeifid);
 
 	return res;
@@ -1001,8 +1018,8 @@ subscription_fromtuple(HeapTuple tuple, TupleDesc desc)
 	sub->slot_name = pstrdup(NameStr(subtup->sub_slot_name));
 	sub->skip_schema = NIL;  /* Initialize to avoid memory corruption */
 
-	sub->origin = get_node(subtup->sub_origin);
-	sub->target = get_node(subtup->sub_target);
+	sub->origin = get_node(subtup->sub_origin, false);
+	sub->target = get_node(subtup->sub_target, false);
 	sub->origin_if = get_node_interface(subtup->sub_origin_if);
 	sub->target_if = get_node_interface(subtup->sub_target_if);
 

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -40,6 +40,7 @@ test: 018_failover_slots
 test: 019_stale_fd_epoll_after_conn_death
 test: 021_uc_null_key_skip
 test: 022_apply_mem_context
+test: 025_tiebreaker_equal_warning
 
 # Regression tests
 test: 103_manager_worker_dboid_race

--- a/tests/tap/t/025_tiebreaker_equal_warning.pl
+++ b/tests/tap/t/025_tiebreaker_equal_warning.pl
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster
+                 get_test_config scalar_query psql_or_bail
+                 wait_for_sub_status);
+
+# Verify that updating the same row twice in one transaction does not produce
+# a spurious "tiebreaker values are equal" WARNING on the subscriber.
+#
+# When a single transaction updates the same row twice, both WAL records are
+# applied in one apply transaction.  The second update finds xmin equal to the
+# current apply transaction XID, so get_tuple_origin() returns
+# local_ts == remote_ts, entering the tiebreaker path.  The bug was that
+# conflict_resolve_by_timestamp() looked up get_node(local_origin_id) for
+# loc_node; in single-writer topology local_origin_id == remote_origin_id
+# (both n1.id), so both sides resolved to the same SpockNode and the WARNING
+# fired trivially.  The fix uses get_local_node() for loc_node so the
+# comparison is always applying-node vs remote-node.
+
+create_cluster(2, 'tiebreaker equal-warning test');
+
+my $config      = get_test_config();
+my $ports       = $config->{node_ports};
+my $log_dir     = $config->{log_dir};
+my $host        = $config->{host};
+my $dbname      = $config->{db_name};
+my $db_user     = $config->{db_user};
+my $db_password = $config->{db_password};
+
+my $conn_n1 = "host=$host dbname=$dbname port=$ports->[0] user=$db_user password=$db_password";
+psql_or_bail(2,
+    "SELECT spock.sub_create('sub_n2n1', '$conn_n1', " .
+    "ARRAY['default','default_insert_only','ddl_sql'], true, true)");
+
+ok(wait_for_sub_status(2, 'sub_n2n1', 'replicating', 30),
+   'n2 subscription replicating');
+
+psql_or_bail(1, "
+    CREATE TABLE tiebreaker_test (id int PRIMARY KEY, val text);
+    INSERT INTO tiebreaker_test VALUES (1, 'initial');
+");
+
+for (1..30) {
+    last if scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1") eq 'initial';
+    sleep 1;
+}
+
+is(scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1"),
+   'initial', 'initial row replicated');
+
+my $log_file   = "${log_dir}/00$ports->[1].log";
+my $log_before = -s $log_file // 0;
+
+psql_or_bail(1, "
+    BEGIN;
+    UPDATE tiebreaker_test SET val = 'first'  WHERE id = 1;
+    UPDATE tiebreaker_test SET val = 'second' WHERE id = 1;
+    COMMIT;
+");
+
+for (1..30) {
+    last if scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1") eq 'second';
+    sleep 1;
+}
+
+is(scalar_query(2, "SELECT val FROM tiebreaker_test WHERE id = 1"),
+   'second', 'final value replicated');
+
+open(my $fh, '<', $log_file)
+    or BAIL_OUT("cannot open n2 log $log_file: $!");
+seek($fh, $log_before, 0);
+my $new_log = do { local $/; <$fh> };
+close($fh);
+
+unlike($new_log, qr/equal tiebreaker|tiebreaker.*equal/i,
+       'no spurious tiebreaker-equal WARNING after same-row double-update');
+
+destroy_cluster('tiebreaker equal-warning test');
+done_testing();


### PR DESCRIPTION
…r topology

* tests: 025 spurious tiebreaker-equal WARNING on same-row double-update

Reproduces the bug where conflict_resolve_by_timestamp() fires a "tiebreaker values are equal" WARNING when the same row is updated twice in a single upstream transaction.

* spock_conflict: fix spurious tiebreaker-equal WARNING in single-writer topology

conflict_resolve_by_timestamp() used get_node(local_origin_id) for loc_node, where local_origin_id is the replication origin stamped on the existing local tuple.  In a single-writer topology every row on the subscriber carries origin = provider.id and incoming changes also have remote_origin = provider.id, so both lookups resolved to the same SpockNode.  The same ambiguity arises from a node_id hash collision: the id is a 16-bit hash of the node name, so two distinct nodes can share the same id and again resolve to the same SpockNode. In either case the tiebreaker comparison is trivially equal, firing a spurious WARNING on every timestamp-tied conflict.

Use get_local_node() for loc_node so the tiebreaker always compares the applying node against the remote sender, not the tuple's origin.  Add a same-origin shortcut: when local_origin_id == remote_origin_id the change shares the same source (e.g. the same row updated twice in one upstream transaction), so there is no real conflict and remote is applied directly without consulting the tiebreaker.

Detect node_id hash collisions at node creation time.

* tests: update 024 collision diagnostic pattern for new error message

The collision check in create_node() now emits "collides with existing node" instead of a PK uniqueness error.  Update the like() patterns in 024 to match the new message.