### PR TITLE
[SPOC-594] Revise Zodan README to emphasize SQL workflows

### DIFF
--- a/docs/modify/zodan/index.md
+++ b/docs/modify/zodan/index.md
@@ -25,19 +25,6 @@ files, etc.).
 
     Each script must be run from the target node being added or removed.
 
-## Zodan Use Cases
-
-The following table describes when to use the Python scripts versus the
-SQL scripts:
-
-| Use Case                           | Use `zodan.py` & `zodremove.py` | Use `zodan.sql` & `zodremove.sql` |
-| ---------------------------------- | :-----------------------------: | :-------------------------------: |
-| CLI automation or scripting        | Good                            |                                   |
-| SQL-only environments              |                                 | Good                              |
-| No Python or shell access          |                                 | Good                              |
-| Postgres extension workflows       | Good                            | Good                              |
-
-
 ## Key Differences Between using Zodan and the Manual Process
 
 The following differences highlight how Zodan automates and simplifies

--- a/docs/modify/zodan/zodan_readme.md
+++ b/docs/modify/zodan/zodan_readme.md
@@ -10,13 +10,9 @@ Zodan's workflows and scripts streamline the process of adding a node to
 or removing a node from a Spock cluster. Zodan features the following
 scripts and workflows:
 
-- The [zodan.py](#the-zodanpy-python-script) script is a Python CLI script
-  that uses `psql` to perform automated node addition.
 - The [zodan.sql](#using-the-zodansql-sql-workflow) workflow is a complete
   SQL-based workflow that uses `dblink` to perform the same add node
   operations from within Postgres.
-- The [zodremove.py](#the-zodremovepy-python-script) script is a Python
-  CLI script that uses `psql` to perform node removal.
 - The [zodremove.sql](#the-zodremovesql-workflow) workflow is a complete
   SQL-based workflow that uses `dblink` to perform the same removal
   operations from within Postgres.
@@ -24,95 +20,6 @@ scripts and workflows:
 ## Components
 
 The following scripts and workflows are available via Zodan.
-
-### The zodan.py Python Script
-
-This Python script leverages `psql` and is intended for use in
-environments where you have shell and Python access. The script is located
-in the [samples/Z0DAN](https://github.com/pgEdge/spock/tree/main/samples/Z0DAN)
-directory of the [Spock GitHub](https://github.com/pgEdge/spock)
-repository.
-
-The script has three execution modes:
-
-- `add_node`
-- `health-check --check-type pre`
-- `health-check --check-type post`
-
-We recommend running the health check before adding a node. The health
-check script checks connectivity, ensures that the Spock extension is
-installed and configured, verifies that subscriptions on the existing
-nodes are healthy, and confirms that there are no user-created tables on
-the new target node.
-
-After adding the new node, you can use health checks on your cluster to
-ensure that the cluster is healthy and replicating.
-
-#### Prerequisites
-
-The `zodan.py` script requires the following components:
-
-- Postgres 15 or later.
-- Spock extension installed and configured.
-- `dblink` extension enabled on all nodes.
-- Python 3.
-- Passwordless access or a properly configured `.pgpass` file for remote
-  connections.
-
-#### Running a Health Check
-
-Invoke the script on the node you are validating. In the following example,
-the `zodan.py` script performs a health check on the cluster:
-
-```bash
-./zodan.py \
-  health-check
-   --check-type [pre|post] \
-  --src-node-name <source_node> \
-  --src-dsn "<source_dsn>" \
-  --new-node-name <new_node> \
-  --new-node-dsn "<new_node_dsn>" \
-  [options]
-```
-
-The following options are available:
-
-- `--src-node-name` - Name of an existing node in the cluster.
-- `--src-dsn` - DSN of the source node (e.g., `"host=127.0.0.1 dbname=pgedge port=5431 user=pgedge password=<PASSWORD>"`).
-- `--new-node-name` - Name of the new node to add.
-- `--new-node-dsn` - DSN of the new node.
-- `--new-node-location` - Location of the new node (default: "NY").
-- `--new-node-country` - Country of the new node (default: "USA").
-- `--new-node-info` - A JSON string with additional metadata (default:
-  "{}").
-- `--verbose` - Provide verbose output for debugging.
-
-#### Using Add Node
-
-After performing a health check, you can use the following command to add
-a node:
-
-```bash
-./zodan.py \
-  add_node
-  --src-node-name <source_node> \
-  --src-dsn "<source_dsn>" \
-  --new-node-name <new_node> \
-  --new-node-dsn "<new_node_dsn>" \
-  [options]
-```
-
-The command supports the following options:
-
-- `--src-node-name` - Name of an existing node in the cluster.
-- `--src-dsn` - DSN of the source node (e.g., `"host=127.0.0.1 dbname=pgedge port=5431 user=pgedge password=<PASSWORD>"`).
-- `--new-node-name` - Name of the new node to add.
-- `--new-node-dsn` - DSN of the new node.
-- `--new-node-location` - Location of the new node (default: "NY").
-- `--new-node-country` - Country of the new node (default: "USA").
-- `--new-node-info` - A JSON string with additional metadata (default:
-  "{}").
-- `--verbose` - Provide verbose output for debugging.
 
 ### Using the zodan.sql SQL Workflow
 
@@ -161,43 +68,6 @@ CALL spock.add_node(
   'host=127.0.0.1 dbname=pgedge port=5434 user=pgedge password=<PASSWORD>'
 );
 ```
-
-### The zodremove.py Python Script
-
-This Python script leverages `psql` and is intended for use in
-environments where you have shell and Python access. The script can safely
-remove fully or partially added nodes.
-
-The script is located in the 
-[samples/Z0DAN](https://github.com/pgEdge/spock/tree/main/samples/Z0DAN)
-directory of the [Spock GitHub](https://github.com/pgEdge/spock)
-repository.
-
-#### Prerequisites
-
-The `zodremove.py` script requires the following components:
-
-- Postgres 15 or later.
-- Spock extension installed and configured.
-- `dblink` extension enabled on all nodes.
-- Python 3.
-- Passwordless access or a properly configured `.pgpass` file for remote
-  connections.
-
-To remove a node, use the `zodremove.py` command. In the following example,
-the `zodremove.py` script removes a node from the cluster:
-
-```bash
-./zodremove.py \
-  remove_node \
-  --target-node-name <target_node> \
-  --target-dsn "<target_dsn>" \
-  [options]
-```
-
-The command supports the following option:
-
-- `--verbose` - Provide verbose output for debugging.
 
 ### The zodremove.sql Workflow
 


### PR DESCRIPTION
Removed detailed sections about zodan.py and zodremove.py scripts, focusing on the SQL workflows instead.