### PR TITLE
node-level skip_schema — schemas a node never replicates

### DIFF
--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -24,6 +24,8 @@ typedef struct SpockNode
 	Jsonb	   *info;
 	/* Fields contained in the info jsonb */
 	int32		tiebreaker;
+	List	   *skip_schema;	/* "skip_schema" array: schemas this node
+								 * never replicates (NIL when unset) */
 } SpockNode;
 
 typedef struct SpockInterface

--- a/include/spock_output_plugin.h
+++ b/include/spock_output_plugin.h
@@ -79,6 +79,9 @@ typedef struct SpockOutputData
 	/* List of SpockRepSet */
 	List	   *replication_sets;
 	RangeVar   *replicate_only_table;
+	/* Never-replicate schemas (info->'skip_schema') as namespace OIDs, reloaded
+	 * when the global skip_schema_valid flag is cleared. */
+	List	   *skip_schema;	/* list of namespace OIDs */
 } SpockOutputData;
 
 /*

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -280,6 +280,46 @@ drop_node(Oid nodeid)
 	spock_subscription_changed(InvalidOid, false);
 }
 
+/*
+ * Extract a top-level jsonb array of strings into a List of palloc'd C
+ * strings.  Returns NIL when the key is absent or is not a string array.
+ * Non-string elements are skipped defensively.
+ */
+static List *
+jsonb_text_array_field(Jsonb *jb, const char *key)
+{
+	List	   *result = NIL;
+	JsonbValue	kval;
+	JsonbValue *aval;
+	JsonbValue	elem;
+	JsonbIterator *it;
+	JsonbIteratorToken tok;
+
+	if (jb == NULL || !JB_ROOT_IS_OBJECT(jb))
+		return NIL;
+
+	kval.type = jbvString;
+	kval.val.string.val = (char *) key;
+	kval.val.string.len = strlen(key);
+
+	aval = findJsonbValueFromContainer(&jb->root, JB_FOBJECT, &kval);
+
+	/* An array stored inside a container surfaces as a binary value. */
+	if (aval == NULL || aval->type != jbvBinary)
+		return NIL;
+
+	it = JsonbIteratorInit(aval->val.binary.data);
+	while ((tok = JsonbIteratorNext(&it, &elem, true)) != WJB_DONE)
+	{
+		if (tok == WJB_ELEM && elem.type == jbvString)
+			result = lappend(result,
+							 pnstrdup(elem.val.string.val,
+									  elem.val.string.len));
+	}
+
+	return result;
+}
+
 static SpockNode *
 node_fromtuple(HeapTuple tuple, TupleDesc desc)
 {
@@ -313,6 +353,9 @@ node_fromtuple(HeapTuple tuple, TupleDesc desc)
 		bool		isnullval;
 
 		node->info = DatumGetJsonbP(datum);
+
+		/* "skip_schema": schemas this node never replicates (NIL if absent) */
+		node->skip_schema = jsonb_text_array_field(node->info, "skip_schema");
 
 		/*
 		 * The node entry has jsonb info, try to extract the tiebreaker value
@@ -1323,6 +1366,28 @@ EnsureRelationNotIgnored(Relation rel)
 				 errdetail("table is in the ignored schema %s",
 						   skip_schema[i]),
 				 errhint("Move this relation to a schema allowed for replication")));
+	}
+
+	/*
+	 * Reject schemas the node registered as skipped (info->'skip_schema').
+	 * Refusing repset membership keeps their changes out of replication.
+	 */
+	{
+		SpockLocalNode *local_node = get_local_node(false, true);
+		ListCell   *lc;
+
+		foreach(lc, (local_node ? local_node->node->skip_schema : NIL))
+		{
+			if (strcmp((char *) lfirst(lc), nspname) != 0)
+				continue;
+
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("relation %s cannot be added to any replication set",
+							RelationGetRelationName(rel)),
+					 errdetail("table is in the ignored schema %s", nspname),
+					 errhint("Move this relation to a schema allowed for replication")));
+		}
 	}
 
 	extoid = getExtensionOfObject(RelationRelationId, RelationGetRelid(rel));

--- a/src/spock_output_plugin.c
+++ b/src/spock_output_plugin.c
@@ -101,6 +101,14 @@ static MemoryContext RelMetaCacheContext = NULL;
 static int	InvalidRelMetaCacheCnt = 0;
 static int	MyWalSenderIdx = 0;
 
+/*
+ * Is the active session's cached skip-schema OID set still valid?  Cleared by a
+ * spock.node change (list may differ) or a relcache invalidation (name->OID may
+ * differ).  Process-global like InvalidRelMetaCacheCnt - the relcache callback
+ * has no SpockOutputData, and only one session is active per process.
+ */
+static bool skip_schema_valid = false;
+
 static bool slot_group_on_exit_set = false;
 static SpockOutputSlotGroup *slot_group = NULL;
 static bool slot_group_skip_xact = false;
@@ -220,6 +228,92 @@ check_binary_compatibility(SpockOutputData *data)
 	return true;
 }
 
+/* Cached oid of the spock.node catalog. */
+static Oid
+get_node_table_oid(void)
+{
+	static Oid	nodetableoid = InvalidOid;
+
+	if (nodetableoid == InvalidOid)
+		nodetableoid = get_spock_table_oid("node");
+
+	return nodetableoid;
+}
+
+/* Cached oid of the spock extension's schema (gates the per-change catalog checks). */
+static Oid
+get_spock_schema_oid(void)
+{
+	static Oid	spockschemaoid = InvalidOid;
+
+	if (spockschemaoid == InvalidOid)
+		spockschemaoid = get_namespace_oid(EXTENSION_NAME, false);
+
+	return spockschemaoid;
+}
+
+/*
+ * Reload the local node's never-replicate set as namespace OIDs (so the
+ * per-change test is a cheap membership check); resolution happens here, off
+ * the hot path.
+ *
+ * Reads only spock.node - a user_catalog_table, safe to scan under the historic
+ * snapshot during decoding, unlike get_local_node()'s other catalogs.  The
+ * decoded tuple is avoided too: its info jsonb could be an unreadable external
+ * TOAST datum.  Stored in data's long-lived context, not the per-message one.
+ */
+static void
+spock_output_reload_skip_schema(SpockOutputData *data)
+{
+	SpockNode	   *node;
+	MemoryContext	target = GetMemoryChunkContext(data);
+	MemoryContext	oldctx;
+	ListCell	   *lc;
+
+	/*
+	 * Set valid *before* the catalog work below: it may process invalidations
+	 * that re-clear the flag, and we want that race to force another reload
+	 * rather than be masked by setting the flag afterwards.
+	 */
+	skip_schema_valid = true;
+
+	node = get_node(data->local_node_id, true);
+
+	oldctx = MemoryContextSwitchTo(target);
+	list_free(data->skip_schema);
+	data->skip_schema = NIL;
+	if (node != NULL)
+	{
+		foreach(lc, node->skip_schema)
+		{
+			Oid			nspoid = get_namespace_oid((char *) lfirst(lc), true);
+
+			/* Absent schema: drop it; a later CREATE invalidates and re-resolves. */
+			if (OidIsValid(nspoid))
+				data->skip_schema = lappend_oid(data->skip_schema, nspoid);
+		}
+	}
+	MemoryContextSwitchTo(oldctx);
+}
+
+/*
+ * Is relation in a schema the local node never replicates?  Consulted for both
+ * row changes and TRUNCATE, so such changes are dropped at the publisher even
+ * for tables already in a replication set.  Reloads the cache lazily when
+ * skip_schema_valid has been cleared.
+ */
+static bool
+spock_relation_schema_skipped(SpockOutputData *data, Relation relation)
+{
+	if (!skip_schema_valid)
+		spock_output_reload_skip_schema(data);
+
+	if (data->skip_schema == NIL)
+		return false;
+
+	return list_member_oid(data->skip_schema, RelationGetNamespace(relation));
+}
+
 /* initialize this plugin */
 static void
 pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt,
@@ -276,6 +370,9 @@ pg_decode_startup(LogicalDecodingContext *ctx, OutputPluginOptions *opt,
 		}
 		node = get_local_node(false, false);
 		data->local_node_id = node->node->id;
+
+		/* Seed the never-replicate schema OID set for this decoding session. */
+		spock_output_reload_skip_schema(data);
 
 		/*
 		 * Remember our own node.name for quick access out write_origin().
@@ -841,92 +938,122 @@ spock_change_filter(SpockOutputData *data, Relation relation,
 			RelationGetNamespace(relation) ==
 			get_namespace_oid(data->replicate_only_table->schemaname, true);
 	}
-	else if (RelationGetRelid(relation) == get_queue_table_oid())
+
+	/*
+	 * Spock's catalogs all live in the spock schema; gate their per-table
+	 * checks on the namespace so an ordinary user-table change rules them all
+	 * out with one comparison.
+	 */
+	else if (RelationGetNamespace(relation) == get_spock_schema_oid())
 	{
-		/* Special case - queue table */
-		if (change->action == REORDER_BUFFER_CHANGE_INSERT)
+		Oid			relid = RelationGetRelid(relation);
+
+		if (relid == get_queue_table_oid())
 		{
-			HeapTuple	tup = ReorderBufferChangeHeapTuple(change, newtuple);
-			QueuedMessage *q;
-			ListCell   *qlc;
-
-			LockRelation(relation, AccessShareLock);
-			q = queued_message_from_tuple(tup);
-			UnlockRelation(relation, AccessShareLock);
-
-			/*
-			 * No replication set means global message, those are always
-			 * replicated.
-			 */
-			if (q->replication_sets == NULL)
-				return true;
-
-			foreach(qlc, q->replication_sets)
+			/* Special case - queue table */
+			if (change->action == REORDER_BUFFER_CHANGE_INSERT)
 			{
-				char	   *queue_set = (char *) lfirst(qlc);
-				ListCell   *plc;
+				HeapTuple	tup = ReorderBufferChangeHeapTuple(change, newtuple);
+				QueuedMessage *q;
+				ListCell   *qlc;
 
-				foreach(plc, data->replication_sets)
+				LockRelation(relation, AccessShareLock);
+				q = queued_message_from_tuple(tup);
+				UnlockRelation(relation, AccessShareLock);
+
+				/*
+				 * No replication set means global message, those are always
+				 * replicated.
+				 */
+				if (q->replication_sets == NULL)
+					return true;
+
+				foreach(qlc, q->replication_sets)
 				{
-					SpockRepSet *rs = lfirst(plc);
+					char	   *queue_set = (char *) lfirst(qlc);
+					ListCell   *plc;
 
-					/* TODO: this is somewhat ugly. */
-					if (strcmp(queue_set, rs->name) == 0)
-						return true;
+					foreach(plc, data->replication_sets)
+					{
+						SpockRepSet *rs = lfirst(plc);
+
+						/* TODO: this is somewhat ugly. */
+						if (strcmp(queue_set, rs->name) == 0)
+							return true;
+					}
 				}
 			}
-		}
 
-		return false;
-	}
-	else if (RelationGetRelid(relation) == get_replication_set_rel_oid())
-	{
-		/*
-		 * Special case - replication set table.
-		 *
-		 * We can use this to update our cached replication set info, without
-		 * having to deal with cache invalidation callbacks.
-		 */
-		HeapTuple	tup;
-		SpockRepSet *replicated_set;
-		ListCell   *plc;
-
-		if (change->action == REORDER_BUFFER_CHANGE_UPDATE)
-			tup = ReorderBufferChangeHeapTuple(change, newtuple);
-		else if (change->action == REORDER_BUFFER_CHANGE_DELETE)
-			tup = ReorderBufferChangeHeapTuple(change, oldtuple);
-		else
 			return false;
-
-		replicated_set = replication_set_from_tuple(tup);
-		foreach(plc, data->replication_sets)
+		}
+		else if (relid == get_replication_set_rel_oid())
 		{
-			SpockRepSet *rs = lfirst(plc);
+			/*
+			 * Special case - replication set table.
+			 *
+			 * We can use this to update our cached replication set info,
+			 * without having to deal with cache invalidation callbacks.
+			 */
+			HeapTuple	tup;
+			SpockRepSet *replicated_set;
+			ListCell   *plc;
 
-			/* Check if the changed repset is used by us. */
-			if (rs->id == replicated_set->id)
-			{
-				/*
-				 * In case this was delete, somebody deleted one of our rep
-				 * sets, bail here and let reconnect logic handle any
-				 * potential issues.
-				 */
-				if (change->action == REORDER_BUFFER_CHANGE_DELETE)
-					elog(ERROR, "replication set \"%s\" used by this connection was deleted, existing",
-						 rs->name);
-
-				/* This was update of our repset, update the cache. */
-				rs->replicate_insert = replicated_set->replicate_insert;
-				rs->replicate_update = replicated_set->replicate_update;
-				rs->replicate_delete = replicated_set->replicate_delete;
-				rs->replicate_truncate = replicated_set->replicate_truncate;
-
+			if (change->action == REORDER_BUFFER_CHANGE_UPDATE)
+				tup = ReorderBufferChangeHeapTuple(change, newtuple);
+			else if (change->action == REORDER_BUFFER_CHANGE_DELETE)
+				tup = ReorderBufferChangeHeapTuple(change, oldtuple);
+			else
 				return false;
+
+			replicated_set = replication_set_from_tuple(tup);
+			foreach(plc, data->replication_sets)
+			{
+				SpockRepSet *rs = lfirst(plc);
+
+				/* Check if the changed repset is used by us. */
+				if (rs->id == replicated_set->id)
+				{
+					/*
+					 * In case this was delete, somebody deleted one of our rep
+					 * sets, bail here and let reconnect logic handle any
+					 * potential issues.
+					 */
+					if (change->action == REORDER_BUFFER_CHANGE_DELETE)
+						elog(ERROR, "replication set \"%s\" used by this connection was deleted, existing",
+							 rs->name);
+
+					/* This was update of our repset, update the cache. */
+					rs->replicate_insert = replicated_set->replicate_insert;
+					rs->replicate_update = replicated_set->replicate_update;
+					rs->replicate_delete = replicated_set->replicate_delete;
+					rs->replicate_truncate = replicated_set->replicate_truncate;
+
+					return false;
+				}
 			}
+
+			return false;
+		}
+		else if (relid == get_node_table_oid())
+		{
+			/*
+			 * Node table: never replicated, but a row change may alter our
+			 * skip list.  Mark the cache stale so a later change reloads it
+			 * from the catalog (cheaper and safer than parsing the decoded
+			 * tuple, whose info jsonb could be an unreadable external TOAST
+			 * datum).
+			 */
+			skip_schema_valid = false;
+
+			return false;
 		}
 
-		return false;
+		/* Any other spock-schema relation falls through to the normal path. */
 	}
+
+	/* Drop changes in a never-replicate schema (catches tables already in a repset). */
+	if (spock_relation_schema_skipped(data, relation))
+		return false;
 
 	/* Normal case - use replication set membership. */
 	tblinfo = get_table_replication_info(data->local_node_id, relation,
@@ -1162,7 +1289,13 @@ pg_decode_truncate(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
 	{
 		Relation	relation = relations[i];
 		Oid			relid = RelationGetRelid(relation);
-		List	   *repsets = get_table_replication_sets(data->local_node_id, relid);
+		List	   *repsets;
+
+		/* Drop TRUNCATEs for tables in a never-replicate schema. */
+		if (spock_relation_schema_skipped(data, relation))
+			continue;
+
+		repsets = get_table_replication_sets(data->local_node_id, relid);
 
 		if (!can_replicate_truncate(repsets))
 			continue;
@@ -1483,6 +1616,9 @@ relmetacache_invalidation_cb(Datum arg, Oid relid)
 		hentry->is_valid = false;
 		InvalidRelMetaCacheCnt++;
 	}
+
+	/* A namespace change may alter name->OID resolution; invalidate (lazy reload). */
+	skip_schema_valid = false;
 }
 
 /*

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -157,9 +157,9 @@ get_pg_executable(char *cmdname, char *cmdbuf)
 static List *
 build_exclude_extension_string(void)
 {
-	List   *lst = NIL;
-	char   *arg;
-	int		i;
+	List	   *lst = NIL;
+	char	   *arg;
+	int			i;
 
 	for (i = 0; skip_extension[i] != NULL; i++)
 	{
@@ -192,6 +192,19 @@ build_exclude_schema_string(SpockSubscription *sub)
 
 	if (sub)
 	{
+		/*
+		 * Exclude schemas the local node registered as skipped (sub->target is
+		 * the local node).  No local-existence test as below: the schema lives
+		 * on the provider and usually does not exist here yet - the point.
+		 */
+		foreach(lc, sub->target->skip_schema)
+		{
+			const char *schema_name = (const char *) lfirst(lc);
+
+			arg = psprintf("--exclude-schema=%s", schema_name);
+			lst = lappend(lst, arg);
+		}
+
 		foreach(lc, sub->skip_schema)
 		{
 			const char   *schema_name = (const char *) lfirst(lc);
@@ -238,6 +251,13 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 	args = list_concat(args, build_exclude_schema_string(sub));
 #if PG_VERSION_NUM >= 170000
 	args = list_concat(args, build_exclude_extension_string());
+
+	/*
+	 * XXX an extension in a skipped schema is still dumped as a global
+	 * "CREATE EXTENSION ... WITH SCHEMA <skipped>", recreating the schema on the
+	 * target.  Excluding it needs --exclude-extension for extensions found in
+	 * those schemas on the provider.  Not handled yet.
+	 */
 #endif
 
 	/* destination file */

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -48,6 +48,7 @@ test: 022_rmgr_progress_post_checkpoint_crash
 test: 022_apply_mem_context
 test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
+test: 031_node_skip_schema
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match
 #

--- a/tests/tap/t/031_node_skip_schema.pl
+++ b/tests/tap/t/031_node_skip_schema.pl
@@ -1,0 +1,111 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster system_or_bail get_test_config scalar_query);
+
+# =============================================================================
+# Test: 031_node_skip_schema.pl - node-level skip-schema exclusion
+# =============================================================================
+# Exercises the "skip_schema" list stored in the local node's info jsonb:
+#   1. Structure sync excludes a skipped schema (a plain, populated schema that
+#      pg_dump would otherwise copy).
+#   2. repset_add_table refuses a table in a skipped schema.
+#   3. The walsender filter drops changes for a schema that was skipped *after*
+#      its table was already a replication-set member.
+# An ordinary public table must keep replicating throughout.
+#
+# A plain schema (not an extension) is used on purpose.  Excluding an extension
+# that lives in a skipped schema - pg_dump still emits "CREATE EXTENSION ...
+# WITH SCHEMA <skipped>" - is a known unhandled corner case; see the XXX in
+# dump_structure().
+
+create_cluster(2, 'Create 2-node skip-schema test cluster');
+
+my $config    = get_test_config();
+my $ports     = $config->{node_ports};
+my $host      = $config->{host};
+my $dbname    = $config->{db_name};
+my $db_user   = $config->{db_user};
+my $db_pass   = $config->{db_password};
+my $pg_bin    = $config->{pg_bin};
+
+my $provider = $ports->[0];
+
+# Poll a scalar query on a node until it equals $want or we time out.
+sub wait_for {
+    my ($node, $sql, $want) = @_;
+    for (1 .. 100) {
+        return 1 if scalar_query($node, $sql) eq $want;
+        select(undef, undef, undef, 0.1);
+    }
+    return 0;
+}
+
+# Provider (n1): a populated schema to be skipped (structure-sync case); an
+# ordinary table; and later_tbl in its own schema, added to the repset now so
+# it replicates before its schema is skipped.
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "CREATE SCHEMA skip_ns; CREATE TABLE skip_ns.bookkeeping (id int primary key, v text); INSERT INTO skip_ns.bookkeeping VALUES (1, 'node-local')";
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "CREATE TABLE public.normal_tbl (id int primary key, v text)";
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "CREATE SCHEMA later_ns; CREATE TABLE later_ns.later_tbl (id int primary key)";
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "SELECT spock.repset_create('test_repset')";
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "SELECT spock.repset_add_table('test_repset', 'public.normal_tbl')";
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "SELECT spock.repset_add_table('test_repset', 'later_ns.later_tbl')";
+
+# Subscriber (n2): register skip_ns as never-replicated.
+system_or_bail "$pg_bin/psql", '-q', '-p', $ports->[1], '-d', $dbname, '-c',
+    "UPDATE spock.node SET info = jsonb_set(coalesce(info, '{}'::jsonb), '{skip_schema}', '[\"skip_ns\"]'::jsonb, true) WHERE node_id = (SELECT node_id FROM spock.local_node)";
+
+# Subscribe with structure + data sync.
+system_or_bail "$pg_bin/psql", '-q', '-p', $ports->[1], '-d', $dbname, '-c',
+    "SELECT spock.sub_create('sub1', 'host=$host port=$provider dbname=$dbname user=$db_user password=$db_pass', ARRAY['test_repset'], true, true)";
+system_or_bail "$pg_bin/psql", '-q', '-p', $ports->[1], '-d', $dbname, '-c',
+    "SELECT spock.sub_enable('sub1')";
+system_or_bail "$pg_bin/psql", '-q', '-p', $ports->[1], '-d', $dbname, '-c',
+    "SELECT spock.sub_wait_for_sync('sub1')";
+
+# --- 1. Structure sync skipped the registered schema. ------------------------
+is(scalar_query(2, "SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'skip_ns'"),
+   '0', 'structure sync skipped the registered schema on the subscriber');
+is(scalar_query(2, "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'normal_tbl'"),
+   '1', 'ordinary table still synced by structure sync');
+
+# --- 2. repset_add_table refuses a table in a skipped schema. ----------------
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "CREATE TABLE skip_ns.local_t (id int primary key)";
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "UPDATE spock.node SET info = jsonb_set(coalesce(info, '{}'::jsonb), '{skip_schema}', '[\"skip_ns\"]'::jsonb, true) WHERE node_id = (SELECT node_id FROM spock.local_node)";
+my $rc = system("$pg_bin/psql", '-q', '-v', 'ON_ERROR_STOP=1', '-p', $provider, '-d', $dbname, '-c',
+    "SELECT spock.repset_add_table('test_repset', 'skip_ns.local_t')");
+isnt($rc, 0, 'repset_add_table refuses a table in a skipped schema');
+
+# --- 3. Walsender filter drops a schema skipped after it was replicating. ----
+# Baseline: later_tbl replicates while later_ns is not skipped.
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "INSERT INTO later_ns.later_tbl VALUES (1)";
+ok(wait_for(2, "SELECT count(*) FROM later_ns.later_tbl", '1'),
+   'table replicates before its schema is skipped');
+
+# Now skip later_ns on the provider; the node-row change refreshes the
+# walsender's cache in-stream.
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "UPDATE spock.node SET info = jsonb_set(coalesce(info, '{}'::jsonb), '{skip_schema}', '[\"skip_ns\",\"later_ns\"]'::jsonb, true) WHERE node_id = (SELECT node_id FROM spock.local_node)";
+
+# A change to the now-skipped table plus a fence row in an ordinary table.
+system_or_bail "$pg_bin/psql", '-q', '-p', $provider, '-d', $dbname, '-c',
+    "INSERT INTO later_ns.later_tbl VALUES (2); INSERT INTO public.normal_tbl VALUES (99, 'fence')";
+
+# Once the fence row arrives, the skipped table's second row must be absent.
+ok(wait_for(2, "SELECT count(*) FROM public.normal_tbl WHERE id = 99", '1'),
+   'fence row on the ordinary table replicated');
+is(scalar_query(2, "SELECT count(*) FROM later_ns.later_tbl"), '1',
+   'change to a schema skipped after replication started was filtered');
+
+destroy_cluster();
+done_testing();


### PR DESCRIPTION
## Summary
Adds a node-level "skip schema" facility: a node lists schema names in its `spock.node.info->'skip_schema'` jsonb array, and those schemas are never replicated to or from that node. This is meant for node-local bookkeeping schemas (e.g. ACE's) that exist on a node but must stay out of replication, regardless of replication-set configuration.
The list is enforced at the three points where a schema's objects could otherwise enter replication.
## What changes
**Parse + repset gate** (`spock_node.c`, `spock_node.h`)
- `SpockNode.skip_schema` is populated from `info->'skip_schema'` when a node row is loaded.
- `EnsureRelationNotIgnored()` refuses to add a table in a skipped schema to any replication set. Because the output plugin already drops anything not in a replication set, this alone keeps new objects out.
**Structure sync** (`spock_sync.c`)
- `dump_structure()` passes `--exclude-schema` for each schema the local node (`sub->target`) has registered as skipped, so a fresh subscriber never recreates them from the provider's dump. The skip list rides in with the subscription, so no extra catalog lookup is needed.
**Publisher filter** (`spock_output_plugin.c`, `spock_output_plugin.h`)
- The output plugin drops row changes and TRUNCATEs whose relation lives in a skipped schema. This catches the transition case the repset gate cannot: a table already in a replication set when its schema is later skipped.
- The skip set is cached as resolved namespace OIDs, so the per-change test is a plain OID membership check — no syscache lookup or allocation in the hot path.
- The cache is reloaded lazily when it may have gone stale: a `spock.node` row change seen in the decoded stream (the list may differ), or a relcache invalidation (a namespace create/drop/rename/OID-reuse may change name→OID resolution). Reloads read only `spock.node` (a `user_catalog_table`, safe under the historic snapshot) rather than parsing the decoded tuple.
- The per-change special-case catalog checks (queue / replication_set / node) are gated behind a single spock-schema namespace comparison, so an ordinary user-table change rules them all out at once.

## Known limitation
`--exclude-schema` does not fully cover extensions: an extension living in a skipped schema is dumped as a global `CREATE EXTENSION ... WITH SCHEMA <skipped>`, which would recreate the schema on the target. Excluding it requires discovering the extension on the provider and emitting `--exclude-extension`. This is documented as an `XXX` in `dump_structure()` and intentionally not handled here.