### PR TITLE
sql: chain 5.0.8→5.0.9->5.0.10→6.0.0 

### DIFF
--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -388,7 +388,7 @@ AutoDDL has been refactored and hardened:
 
 ### Bug fixes carried forward from the 5.0.x line
 
-These shipped in 5.0.6 – 5.0.8 and are included in 6.0.0:
+These shipped in 5.0.6 – 5.0.10 and are included in 6.0.0:
 
 * Handle upstream connection loss cleanly without replication-origin
   advance leak.  Previously a stale libpq socket fd produced an
@@ -410,10 +410,6 @@ These shipped in 5.0.6 – 5.0.8 and are included in 6.0.0:
   workers during slot creation to prevent data loss when adding a new
   node; align Phase 3 catch-up wait and parameterise
   `spock.sync_event()` to avoid the Phase 9 handshake deadlock.
-* Spock now registers its own `pg_seclabel` provider (added in 5.0.8).
-  The new `spock.delta_apply(rel, att_name, to_drop)` plpgsql wrapper in
-  6.0.0 uses it to attach and clear the `spock.delta_apply` label on
-  individual columns.
 * Prevent data loss on `resync_table` when the subscriber is read-only
   (SPOC-440).
 * Fix stale `local_tuple` pointer in the INSERT exception path for a
@@ -427,7 +423,7 @@ These shipped in 5.0.6 – 5.0.8 and are included in 6.0.0:
 
 ### Upgrading
 
-The upgrade from 5.0.8 to 6.0.0 is a single `ALTER EXTENSION spock UPDATE`
+The upgrade from 5.0.10 to 6.0.0 is a single `ALTER EXTENSION spock UPDATE`
 once the binaries are swapped.  The upgrade:
 
 * drops the legacy `spock.progress` table and recreates it as a view,
@@ -436,6 +432,64 @@ once the binaries are swapped.  The upgrade:
 * adds the new functions and the `sub_id_generator` sequence,
 * refreshes the parallel-safety attributes on `spock.md5_agg_sfunc` and
   `spock.spock_gen_slot_name`.
+
+## Spock 5.0.10
+
+### Bug Fixes
+* Improve apply performance on tables with a unique index over a frequently
+  NULL column. Rows with a NULL in such a key are now recognized as
+  non-conflicting without an unnecessary index scan, avoiding a slowdown that
+  grew with table size.
+* Correctly handle conflicts on `NULLS NOT DISTINCT` unique indexes.
+  On these indexes (PostgreSQL 15+) two NULL values are treated as equal, so
+  matching NULL-keyed rows are now resolved through normal conflict resolution
+  (last-update-wins) instead of failing with a duplicate-key error.
+* Fix a `could not open relation` error in the apply worker when an index is
+  dropped while replication is running. The worker now refreshes its cached
+  view of a table's indexes before using it.
+* Fix gradual memory growth during a transaction that logs to
+  `spock.exception_log`. Memory used while recording exceptions is now released
+  per row instead of accumulating until the transaction commits.
+* Record the real cause of a discarded transaction in `spock.exception_log`
+  instead of the opaque placeholder `unavailable`. The failing command's
+  message is now stored (prefixed with its SQLSTATE where informative), and the
+  other rows of the transaction note that they were discarded as collateral,
+  making it possible to provide the root cause of the exception.
+* Fix ZODAN (`add_node`) version checking. Spock versions were compared as
+  text, so `5.0.10` sorted below `5.0.4` and a valid node was wrongly rejected.
+  Versions are now compared numerically, and nodes may differ in patch level as
+  long as their major.minor matches, allowing rolling upgrades.
+
+## Spock 5.0.9
+
+### New Features
+* Initial PostgreSQL 19 support. Adds the server-side patches required to build
+  and run Spock against PostgreSQL 19.
+
+### Bug Fixes
+* Fix silently dropped writes after a synchronous-standby failover.
+  Spock could report an incorrect replication position to the publisher, so a
+  promoted standby resumed from the wrong point and lost the changes in
+  between. The position reported to the publisher is now always taken from the
+  publisher's own WAL stream.
+* Fix `spock_failover_slots` stalling on PG17+ standbys. Slot
+  synchronization could hold replication-slot and proc-array locks
+  exclusively long enough to block every backend trying to start up on the
+  standby, freezing the worker and any new connections. The sync path now
+  uses shorter, shared locks matching PostgreSQL's own slot code.
+* Fix manager-worker respawn loop when databases are dropped or have
+  connections disabled (`datconnlimit = -2`) concurrently with Spock
+  starting a per-database worker. The database OID is now revalidated
+  immediately before the worker is registered to avoid race.
+* Reduce per-row work and memory growth in the apply path. Replicated
+  changes no longer re-open a table's indexes for every row, and transient
+  memory is freed per row instead of building up over the transaction.
+
+### Performance
+* Skip building conflict log messages that would not be logged. When the log
+  level is suppressed, Spock no longer formats the conflicting rows for an
+  `ereport()` that would be discarded, speeding up apply on high-conflict
+  workloads. Recording conflicts in `spock.resolutions` is unaffected.
 
 ## Spock 5.0.8
 

--- a/sql/spock--5.0.10--6.0.0.sql
+++ b/sql/spock--5.0.10--6.0.0.sql
@@ -1,4 +1,4 @@
-/* spock--5.0.8--6.0.0.sql */
+/* spock--5.0.10--6.0.0.sql */
 
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION spock UPDATE TO '6.0.0'" to load this file. \quit

--- a/sql/spock--5.0.8--5.0.9.sql
+++ b/sql/spock--5.0.8--5.0.9.sql
@@ -1,0 +1,6 @@
+/* spock--5.0.8--5.0.9.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION spock UPDATE TO '5.0.9'" to load this file. \quit
+
+-- No schema changes in 5.0.9.

--- a/sql/spock--5.0.9--5.0.10.sql
+++ b/sql/spock--5.0.9--5.0.10.sql
@@ -1,0 +1,6 @@
+/* spock--5.0.9--5.0.10.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION spock UPDATE TO '5.0.10'" to load this file. \quit
+
+-- No schema changes in 5.0.10.

--- a/tests/tap/t/018_upgrade_schema_match.pl
+++ b/tests/tap/t/018_upgrade_schema_match.pl
@@ -11,7 +11,7 @@ use SpockTest qw(system_or_bail system_maybe wait_for_pg_ready psql_or_bail scal
 # =============================================================================
 # Test: 018_upgrade_schema_match.pl
 #
-# Verify that upgrading Spock from 5.0.8 -> 6.0.0 produces a schema that is
+# Verify that upgrading Spock from 5.x -> 6.0.0 produces a schema that is
 # identical to a fresh 6.0.0 installation.
 #
 # Each Spock version requires PostgreSQL built with that branch's patches:
@@ -28,7 +28,7 @@ use SpockTest qw(system_or_bail system_maybe wait_for_pg_ready psql_or_bail scal
 # for caching across runs (only datadirs and source trees are cleaned up).
 #
 # Environment variables:
-#   V5_PG_INSTALL   pre-built PG+Spock 5.0.8 dir  (default: $TEMP_BASE/pg_v5)
+#   V5_PG_INSTALL   pre-built PG+Spock 5.x dir  (default: $TEMP_BASE/pg_v5)
 #   V60_PG_INSTALL  pre-built PG+Spock 6.0.0 dir  (default: $TEMP_BASE/pg_v60)
 #   PG_TAG          git tag for PG source          (default: REL_18_2)
 #   PG_REPO         git URL for PG source          (default: github postgres mirror)
@@ -75,7 +75,7 @@ my $V5_BIN  = "$V5_PG_INSTALL/bin";
 my $V60_BIN = "$V60_PG_INSTALL/bin";
 my $PG_BIN  = $V60_BIN;   # client tools (psql, pg_ctl) use v60 binary
 
-my $DATADIR_UPG = "$TEMP_BASE/datadir_upgraded";   # starts at 5.0.8, upgraded
+my $DATADIR_UPG = "$TEMP_BASE/datadir_upgraded";   # starts at 5.x, upgraded
 my $DATADIR_NEW = "$TEMP_BASE/datadir_fresh";       # fresh 6.0.0 install
 my $PORT_UPG    = 5441;
 my $PORT_NEW    = 5442;
@@ -352,11 +352,11 @@ sub compare_category {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# PHASE 1 – Ensure v5_STABLE environment (PG + Spock 5.0.8)
+# PHASE 1 – Ensure v5_STABLE environment (PG + Spock 5.x)
 # ─────────────────────────────────────────────────────────────────────────────
-diag("PHASE 1: Ensuring Spock 5.0.8 environment ($V5_BRANCH)");
+diag("PHASE 1: Ensuring Spock 5.x environment ($V5_BRANCH)");
 ok(ensure_version_ready($V5_BRANCH, $V5_PG_INSTALL, 'v5'),
-   "Spock 5.0.8 environment ready");
+   "Spock 5.x environment ready");
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PHASE 2 – Ensure current environment (PG + Spock 6.0.0)
@@ -366,11 +366,11 @@ ok(ensure_version_ready($V60_BRANCH, $V60_PG_INSTALL, 'v60'),
    "Spock 6.0.0 environment ready");
 
 # ─────────────────────────────────────────────────────────────────────────────
-# PHASE 3 – Start upgrade node (Spock 5.0.8)
+# PHASE 3 – Start upgrade node (Spock 5.x)
 # ─────────────────────────────────────────────────────────────────────────────
-diag("PHASE 3: Initialising upgrade node (Spock 5.0.8)...");
+diag("PHASE 3: Initialising upgrade node (Spock 5.x)...");
 ok(init_and_start_node($DATADIR_UPG, $PORT_UPG, $V5_PG_INSTALL),
-   'Upgrade node started (5.0.8)');
+   'Upgrade node started (5.x)');
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PHASE 4 – Start fresh node (Spock 6.0.0)
@@ -394,7 +394,7 @@ psql_or_bail($NODE_UPG, 'CREATE EXTENSION spock');
 my $ver_upg = scalar_query($NODE_UPG,
     "SELECT extversion FROM pg_extension WHERE extname = 'spock'");
 diag("Upgrade node extension version after CREATE: $ver_upg");
-like($ver_upg, qr/^5\.0\.8/, 'Upgrade node starts at 5.0.8');
+like($ver_upg, qr/^5\./, 'Upgrade node starts at 5.x');
 
 psql_or_bail($NODE_NEW, 'CREATE EXTENSION spock');
 my $ver_new = scalar_query($NODE_NEW,


### PR DESCRIPTION
Backport the 5.0.9 and 5.0.10 upgrade stubs from v5_STABLE and re-anchor the 6.0.0 upgrade script so the extension updates continuously: 5.0.7 → 5.0.8 → 5.0.9 → 5.0.10 → 6.0.0.

- Add sql/spock--5.0.8--5.0.9.sql and sql/spock--5.0.9--5.0.10.sql (version markers; no schema changes in either release).
- Rename sql/spock--5.0.8--6.0.0.sql → sql/spock--5.0.10--6.0.0.sql so the jump to 6.0.0 starts from the latest 5.0.x patch level.
- Add 5.0.9 and 5.0.10 sections to docs/spock_release_notes.md.
- 018_upgrade_schema_match: assert the upgrade node starts at 5.x (was pinned to 5.0.8) since v5_STABLE now builds as 5.0.10.

- Add release notes from the 5.0.x versions.
- Remove delta apply release note from 6.0.0 