### PR TITLE
Cherry-picks from v5_STABLE (v5.0.10)

### DIFF
--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -1,7 +1,7 @@
 -- ============================================================================
 -- ZODAN (Zero Downtime Add Node) - Spock Extension
 -- Version: 1.0.0
--- Required Spock Version: 5.0.4 or later
+-- Required Spock Version: 5.0.9 or later
 -- ============================================================================
 -- Adds a new node to the cluster of Spock.
 -- NOTE: Run the add_node procedure on the new node you are adding, not on an existing cluster node.
@@ -60,6 +60,21 @@ RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
 $$;
 
 -- ============================================================================
+-- Function: version_major_minor
+-- Purpose : Extract the {major, minor} components of a Spock version string as
+--           an int[] (e.g. '5.0.10' and '5.0.4' both yield {5,0}). Used to
+--           allow rolling upgrades: nodes may differ in patch level as long as
+--           their major.minor matches.
+-- Arguments:
+--   v - The version string. Any non-numeric suffix (such as '-devel') is ignored.
+-- Returns  : int[] of length up to 2, the major and minor components.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.version_major_minor(v text)
+RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
+    SELECT (spock.version_to_array(v))[1:2];
+$$;
+
+-- ============================================================================
 -- Procedure: check_spock_version_compatibility
 -- Purpose: Verify all nodes have the same Spock version before adding a node
 -- ============================================================================
@@ -69,7 +84,7 @@ CREATE OR REPLACE PROCEDURE spock.check_spock_version_compatibility(
     verb boolean DEFAULT false
 ) LANGUAGE plpgsql AS $$
 DECLARE
-    min_required_version text := '5.0.4';
+    min_required_version text := '5.0.9';
     src_version text;
     new_version text;
     node_rec RECORD;
@@ -110,8 +125,9 @@ BEGIN
             new_version, min_required_version, min_required_version;
     END IF;
 
-    IF regexp_replace(new_version, '-devel$', '') != regexp_replace(src_version, '-devel$', '') THEN
-        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Please ensure that they match.',
+    -- Allow rolling upgrades: patch differences are fine, but major.minor must match
+    IF spock.version_major_minor(new_version) IS DISTINCT FROM spock.version_major_minor(src_version) THEN
+        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Major.minor versions must match (patch differences are allowed).',
             new_version, src_version;
     END IF;
 
@@ -134,8 +150,9 @@ BEGIN
                 node_rec.node_name, node_version, min_required_version, min_required_version;
         END IF;
 
-        IF regexp_replace(node_version, '-devel$', '') != regexp_replace(new_version, '-devel$', '') THEN
-            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Please ensure that they match.',
+        -- Allow rolling upgrades: patch differences are fine, but major.minor must match
+        IF spock.version_major_minor(node_version) IS DISTINCT FROM spock.version_major_minor(new_version) THEN
+            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Major.minor versions must match (patch differences are allowed).',
                 new_version, node_version;
         END IF;
     END LOOP;

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -45,6 +45,21 @@ CREATE OR REPLACE FUNCTION spock.gen_sub_name(
 $$;
 
 -- ============================================================================
+-- Function: version_to_array
+-- Purpose : Convert a Spock version string (e.g. '5.0.10', '5.0.4-devel') into
+--           an integer array (e.g. {5,0,10}) so versions can be compared
+--           numerically. A plain text comparison is wrong because it orders
+--           versions lexically (e.g. '5.0.10' < '5.0.4').
+-- Arguments:
+--   v - The version string. Any non-numeric suffix (such as '-devel') is ignored.
+-- Returns  : int[], the dotted numeric components in order.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.version_to_array(v text)
+RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
+    SELECT string_to_array((regexp_match(v, '[0-9]+(?:\.[0-9]+)*'))[1], '.')::int[];
+$$;
+
+-- ============================================================================
 -- Procedure: check_spock_version_compatibility
 -- Purpose: Verify all nodes have the same Spock version before adding a node
 -- ============================================================================
@@ -73,8 +88,8 @@ BEGIN
         RAISE EXCEPTION 'Spock extension not found on source node';
     END IF;
 
-    -- Check source node has required version (strip -devel suffix for comparison)
-    IF regexp_replace(src_version, '-devel$', '') < min_required_version THEN
+    -- Check source node has required version (compare numerically, not lexically)
+    IF spock.version_to_array(src_version) < spock.version_to_array(min_required_version) THEN
         RAISE EXCEPTION 'Spock version mismatch: source node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
             src_version, min_required_version, min_required_version;
     END IF;
@@ -89,8 +104,8 @@ BEGIN
         RAISE EXCEPTION 'Spock extension not found on new node';
     END IF;
 
-    -- Check new node has required version (strip -devel suffix for comparison)
-    IF regexp_replace(new_version, '-devel$', '') < min_required_version THEN
+    -- Check new node has required version (compare numerically, not lexically)
+    IF spock.version_to_array(new_version) < spock.version_to_array(min_required_version) THEN
         RAISE EXCEPTION 'Spock version mismatch: new node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
             new_version, min_required_version, min_required_version;
     END IF;
@@ -113,7 +128,7 @@ BEGIN
             RAISE EXCEPTION 'Spock extension not found on node %', node_rec.node_name;
         END IF;
 
-        IF regexp_replace(node_version, '-devel$', '') < min_required_version THEN
+        IF spock.version_to_array(node_version) < spock.version_to_array(min_required_version) THEN
             version_mismatch := true;
             RAISE EXCEPTION 'Spock version mismatch: node % has version %, but required version is at least %. All nodes must have version % or later.',
                 node_rec.node_name, node_version, min_required_version, min_required_version;

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1269,6 +1269,40 @@ discard_collateral_message(const char *what)
 }
 
 /*
+ * Format an error message with its SQLSTATE prefix so the root cause recorded
+ * in spock.exception_log (and the apply log) is unambiguous.  exception_log has
+ * no dedicated sqlstate column, so we carry it inline in the message text.
+ *
+ * The SQLSTATE prefix is omitted when the code is the uninformative
+ * ERRCODE_INTERNAL_ERROR (XX000): a bare elog(ERROR) -- e.g. spock's own
+ * "did not find row to update" -- defaults to it, and the prefix is just noise.
+ * Real errors (constraint violations, deadlocks, connection failures) keep
+ * their code, which is what makes the cause unambiguous.
+ *
+ * The result is allocated in ApplyOperationContext (reset per row/message)
+ * rather than the long-lived TopTransactionContext that is current on the
+ * exception path, so repeated logging within one large transaction does not
+ * accumulate.  Callers copy it into the durable tuple immediately.
+ */
+static char *
+errmsg_with_sqlstate(ErrorData *edata)
+{
+	MemoryContext	oldctx = MemoryContextSwitchTo(ApplyOperationContext);
+	char		   *msg;
+	int				sqlerrcode = edata ? edata->sqlerrcode : ERRCODE_INTERNAL_ERROR;
+	const char	   *detail = (edata && edata->message) ? edata->message
+													   : "(no error detail captured)";
+
+	if (sqlerrcode == ERRCODE_INTERNAL_ERROR)
+		msg = pstrdup(detail);
+	else
+		msg = psprintf("[SQLSTATE %s] %s", unpack_sql_state(sqlerrcode), detail);
+
+	MemoryContextSwitchTo(oldctx);
+	return msg;
+}
+
+/*
  * Log a replication exception to spock.exception_log.
  *
  * Called for INSERT, UPDATE, DELETE, and TRUNCATE operations.  'failed'
@@ -1465,7 +1499,7 @@ handle_insert(StringInfo s)
 				 * Need to keep this database operation out of the CATCH section
 				 * to avoid FATAL error in case if an ERROR happens there.
 				 */
-				log_insert_exception(true, edata->message, rel,
+				log_insert_exception(true, errmsg_with_sqlstate(edata), rel,
 									 NULL, &newtup, "INSERT");
 			}
 		}
@@ -1630,7 +1664,7 @@ handle_update(StringInfo s)
 
 			if (failed)
 			{
-				log_insert_exception(true, edata->message, rel,
+				log_insert_exception(true, errmsg_with_sqlstate(edata), rel,
 									 hasoldtup ? &oldtup : NULL, &newtup,
 									 "UPDATE");
 			}
@@ -1758,7 +1792,7 @@ handle_delete(StringInfo s)
 
 			if (failed)
 			{
-				log_insert_exception(true, edata->message, rel,
+				log_insert_exception(true, errmsg_with_sqlstate(edata), rel,
 									 &oldtup, NULL, "DELETE");
 			}
 		}
@@ -1978,7 +2012,7 @@ handle_truncate(StringInfo s)
 			else
 			{
 				exception_log_ptr[my_exception_log_index].local_tuple = NULL;
-				log_insert_exception(true, edata->message, NULL, NULL, NULL,
+				log_insert_exception(true, errmsg_with_sqlstate(edata), NULL, NULL, NULL,
 									 "TRUNCATE");
 			}
 		}
@@ -2553,7 +2587,7 @@ handle_sql_or_exception(QueuedMessage *queued_message, bool tx_just_started)
 			Assert(my_exception_log_index >= 0);
 
 			if (failed)
-				error_msg = edata->message;
+				error_msg = errmsg_with_sqlstate(edata);
 			else if (xact_action_counter ==
 					 exception_log_ptr[my_exception_log_index].failed_action &&
 					 exception_log_ptr[my_exception_log_index].initial_error_message[0] != '\0')
@@ -3698,7 +3732,7 @@ stream_replay:
 		AbortOutOfAnyTransaction();
 
 		MemoryContextSwitchTo(MessageContext);
-		elog(LOG, "SPOCK: caught initial exception - %s", edata->message);
+		elog(LOG, "SPOCK: caught initial exception - %s", errmsg_with_sqlstate(edata));
 
 		/*
 		 * Save the initial exception message and operation type so we can
@@ -3709,7 +3743,7 @@ stream_replay:
 		{
 			snprintf(exception_log_ptr[my_exception_log_index].initial_error_message,
 					 sizeof(exception_log_ptr[my_exception_log_index].initial_error_message),
-					 "%s", edata->message);
+					 "%s", errmsg_with_sqlstate(edata));
 
 			/*
 			 * Remember which action in the transaction triggered the error.

--- a/src/spock_exception_handler.c
+++ b/src/spock_exception_handler.c
@@ -188,8 +188,12 @@ add_entry_to_exception_log(Oid remote_origin, TimestampTz remote_commit_ts,
 		values[Anum_exception_log_ddl_user - 1] = CStringGetTextDatum(ddl_user);
 	}
 
-	Assert(error_message != NULL);
-
+	/*
+	 * All callers now build an informative message (the failing command's
+	 * error, or a collateral-discard message) before reaching here.  Keep a
+	 * defensive fallback so a future caller passing NULL degrades to a
+	 * placeholder rather than crashing.
+	 */
 	values[Anum_exception_log_error_message - 1] =
 		CStringGetTextDatum(error_message != NULL ? error_message : "unavailable");
 	values[Anum_exception_log_retry_errored_at - 1] = TimestampTzGetDatum(GetCurrentTimestamp());

--- a/tests/tap/t/104_iptables_conn_block.pl
+++ b/tests/tap/t/104_iptables_conn_block.pl
@@ -1,0 +1,237 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    system_maybe
+    get_test_config scalar_query psql_or_bail
+    wait_for_sub_status
+);
+
+# =============================================================================
+# Test 104: Connection block via iptables (firewall-style outage)
+# =============================================================================
+# Reproduces the customer scenario: a firewall briefly blocks the replication
+# connection, a transaction is committed on the provider during the outage, and
+# the connection is then restored.
+#
+# Exercises the b75cb4fc connection-loss handling together with the
+# exception_log message backport (ed17523 + b32ef95).  Asserts that:
+#
+#   1. The block stops replication: rows committed during the outage do not
+#      reach the subscriber while blocked.
+#   2. In SUB_DISABLE mode the outage does NOT disable the subscription (a
+#      connection error rethrows before the disable path; a stall just waits).
+#   3. After the block is lifted the subscription returns to 'replicating' and
+#      the during-outage transaction is applied with NO row loss.
+#   4. The connection blip produces NO spurious spock.exception_log entries.
+#      (Any that appear are dumped; their messages now carry [SQLSTATE ...].)
+#
+# Whether iptables tears the connection down or merely stalls it is host
+# dependent (over loopback it often stalls); both are safe and the test reports
+# which occurred as diag rather than asserting a specific teardown.
+#
+# Mechanics: the harness's control psql connects over the unix socket (no -h),
+# while spock's replication connection uses host=127.0.0.1 (TCP).  So we sever
+# replication with iptables on TCP to/from 127.0.0.1:<provider-port> while still
+# driving the provider over the socket.  We use REJECT --reject-with tcp-reset
+# (not DROP) so the broken connection is detected immediately and reconnect
+# attempts fail fast, rather than silently stalling.
+#
+# Detection is proved via an observable, log-independent signal (the walsender
+# PID change), because the harness's server-log location is environment
+# dependent (logging_collector with a relative log_directory lands under each
+# node's datadir).  A best-effort log scrape is emitted as diag only.
+#
+# Requires iptables usable as root or via passwordless sudo; otherwise skipped.
+# Not in the schedule -- run manually:
+#   PERL5LIB=t prove -v t/104_iptables_conn_block.pl
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Probe for a usable iptables before any expensive setup.
+# ---------------------------------------------------------------------------
+chomp(my $ipt_bin = `command -v iptables 2>/dev/null`);
+plan skip_all => 'iptables not found in PATH' unless $ipt_bin;
+
+my @IPT;
+if ($> == 0) {
+    @IPT = ($ipt_bin);
+}
+elsif (system("sudo -n $ipt_bin -S OUTPUT >/dev/null 2>&1") == 0) {
+    @IPT = ('sudo', '-n', $ipt_bin);
+}
+else {
+    plan skip_all =>
+        'iptables requires root or passwordless sudo (neither available)';
+}
+
+# Lexicals the helper subs close over; filled in after create_cluster().
+my (@RULES, %installed, $node_datadirs);
+
+sub block_conn {
+    for my $r (@RULES) {
+        my ($chain, @spec) = @$r;
+        my $rc = system(@IPT, '-I', $chain, @spec);
+        $installed{"@$r"} = $r if $rc == 0;
+    }
+    return scalar keys %installed;
+}
+
+sub unblock_conn {
+    for my $key (keys %installed) {
+        my ($chain, @spec) = @{ $installed{$key} };
+        system(@IPT, '-D', $chain, @spec);
+        delete $installed{$key};
+    }
+}
+
+# Safety net: remove our rules even if the test dies or bails out.
+END { unblock_conn() if %installed; }
+
+sub set_guc_n2 {
+    my ($kv) = @_;
+    open(my $fh, '>>', "$node_datadirs->[1]/postgresql.conf")
+        or die "cannot append to n2 postgresql.conf: $!";
+    print $fh "$kv\n";
+    close($fh);
+    psql_or_bail(2, "SELECT pg_reload_conf()");
+}
+
+# ---------------------------------------------------------------------------
+create_cluster(2, 'Create 2-node cluster for iptables connection-block test');
+
+my $config      = get_test_config();
+my $node_ports  = $config->{node_ports};
+my $host        = $config->{host};
+my $dbname      = $config->{db_name};
+my $db_user     = $config->{db_user};
+my $db_password = $config->{db_password};
+my $pg_bin      = $config->{pg_bin};
+$node_datadirs  = $config->{node_datadirs};
+
+my $p1 = $node_ports->[0];   # n1 — provider
+my $p2 = $node_ports->[1];   # n2 — subscriber
+
+my $conn_n1 = "host=$host dbname=$dbname port=$p1 user=$db_user password=$db_password";
+
+# REJECT both directions of the apply<->walsender TCP flow with a TCP reset so
+# the connection breaks immediately and reconnects fail fast.  Control psql
+# uses the unix socket and is unaffected.
+@RULES = (
+    ['OUTPUT', '-p', 'tcp', '-d', $host, '--dport', $p1, '-j', 'REJECT', '--reject-with', 'tcp-reset'],
+    ['INPUT',  '-p', 'tcp', '-s', $host, '--sport', $p1, '-j', 'REJECT', '--reject-with', 'tcp-reset'],
+);
+
+# Low ping timeout as a backstop in case a direction goes quiet rather than
+# resetting.
+set_guc_n2('wal_sender_timeout = 5s');
+set_guc_n2("spock.exception_behaviour = 'sub_disable'");
+sleep(1);
+
+psql_or_bail(1, "CREATE TABLE t_ipt (id INT PRIMARY KEY, v TEXT)");
+psql_or_bail(2, "CREATE TABLE t_ipt (id INT PRIMARY KEY, v TEXT)");
+
+psql_or_bail(2,
+    "SELECT spock.sub_create('sub_ipt', '$conn_n1', " .
+    "ARRAY['default', 'default_insert_only'], false, false)");
+
+ok(wait_for_sub_status(2, 'sub_ipt', 'replicating', 30),
+    'sub_ipt reaches replicating state');
+
+# Baseline rows must replicate before we cut the connection.
+psql_or_bail(1, "INSERT INTO t_ipt SELECT g, 'pre_' || g FROM generate_series(1, 50) g");
+
+my $baseline_ok = 0;
+for (1 .. 15) {
+    last if ($baseline_ok = (scalar_query(2, "SELECT count(*) FROM t_ipt") == 50));
+    sleep 1;
+}
+ok($baseline_ok, 'baseline 50 rows replicated n1->n2 before block');
+
+# Capture the provider's walsender PID for this subscription before the block.
+my $wal_pid_before =
+    scalar_query(1, "SELECT pid FROM pg_stat_replication WHERE state = 'streaming' LIMIT 1");
+ok($wal_pid_before =~ /^\d+$/,
+    "provider has a streaming walsender before the block (pid $wal_pid_before)");
+
+# ---------------------------------------------------------------------------
+# Block the replication connection.
+# ---------------------------------------------------------------------------
+is(block_conn(), scalar(@RULES),
+    'iptables REJECT rules installed on both directions of provider TCP port');
+
+# Commit a transaction on the provider DURING the outage (over the unix
+# socket, which iptables does not touch).  The walsender's attempt to ship it
+# triggers the reset.
+psql_or_bail(1,
+    "INSERT INTO t_ipt SELECT g, 'mid_' || g FROM generate_series(51, 100) g");
+
+# Whether the connection is torn down or merely stalls is host dependent
+# (over loopback, iptables often stalls rather than resets the established
+# connection).  Report which happened -- both are safe outcomes -- but do not
+# gate the test on it.
+sleep 8;
+my $still = scalar_query(1,
+    "SELECT count(*) FROM pg_stat_replication WHERE pid = $wal_pid_before");
+diag($still eq '0'
+    ? "connection TORN DOWN during block (old walsender pid $wal_pid_before gone)"
+    : "connection STALLED during block (old walsender pid $wal_pid_before still present)");
+
+# During-outage rows must NOT have reached the subscriber.
+is(scalar_query(2, "SELECT count(*) FROM t_ipt WHERE v LIKE 'mid_%'"), '0',
+    'during-outage rows are not on n2 while blocked');
+
+# A *connection* error must not disable the subscription in SUB_DISABLE mode.
+isnt(scalar_query(2,
+        "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_ipt'"),
+    'f',
+    'SUB_DISABLE: connection error did NOT disable the subscription');
+
+# ---------------------------------------------------------------------------
+# Restore the connection.
+# ---------------------------------------------------------------------------
+unblock_conn();
+pass('iptables rules removed (connection restored)');
+
+ok(wait_for_sub_status(2, 'sub_ipt', 'replicating', 60),
+    'sub_ipt returns to replicating after the block is lifted');
+
+# Report the post-recovery walsender (new PID => reconnected; same => stalled
+# connection resumed).  Informational -- the row-count check below is the real
+# proof that replication recovered.
+my $wal_pid_after = scalar_query(1,
+    "SELECT pid FROM pg_stat_replication WHERE state = 'streaming' LIMIT 1");
+diag(($wal_pid_after =~ /^\d+$/ && $wal_pid_after ne $wal_pid_before)
+    ? "RECONNECTED after unblock (new walsender pid $wal_pid_after, was $wal_pid_before)"
+    : "stalled connection RESUMED after unblock (walsender pid $wal_pid_after)");
+
+# All 100 rows (50 pre + 50 mid) must eventually be present -- no loss.
+my $final_count = 0;
+for (1 .. 30) {
+    $final_count = scalar_query(2, "SELECT count(*) FROM t_ipt");
+    last if $final_count == 100;
+    sleep 2;
+}
+is($final_count, '100',
+    'all 100 rows present on n2 after recovery (no row loss across disconnect)');
+
+# The connection blip should not have produced spurious exception_log entries.
+my $exc_cnt = scalar_query(2, "SELECT count(*) FROM spock.exception_log");
+is($exc_cnt, '0',
+    'no spock.exception_log entries produced by the connection blip');
+if ($exc_cnt ne '0') {
+    diag("Unexpected exception_log entries after connection blip:");
+    my $dump = `$pg_bin/psql -X -p $p2 -d $dbname -t -A -F'|' -c ` .
+               "\"SELECT table_name, operation, error_message FROM spock.exception_log ORDER BY retry_errored_at\"";
+    diag("  $_") for split /\n/, ($dump // '');
+}
+
+# ---------------------------------------------------------------------------
+system_maybe("$pg_bin/psql", '-p', $p2, '-d', $dbname,
+    '-c', "SELECT spock.sub_drop('sub_ipt')");
+
+destroy_cluster('Destroy iptables connection-block test cluster');
+
+done_testing();


### PR DESCRIPTION
Pulls in changes from the v5_STABLE line that are missing on main.

ZODAN version checking

- Compare versions numerically, not lexically. check_spock_version_compatibility compared extversion strings with text operators, so 5.0.10 sorted below 5.0.4 and a valid node was wrongly rejected. Adds spock.version_to_array() and uses it at all three minimum-version checks.
- Allow rolling upgrades within a major.minor. Nodes previously had to run a byte-identical version. Raises the minimum to 5.0.9. Will test and adapt for 6, but getting in the cherry-pick now.

Exception-log diagnostics

- Tag captured exception_log messages with their SQLSTATE. Forward-port of the SQLSTATE work from v5_STABLE (the underlying informative-discard-message work is already on main). Adds errmsg_with_sqlstate(), which prefixes captured errors with [SQLSTATE xxxxx] so a real constraint violation or deadlock is distinguishable from a transient conflict. The uninformative XX000 (bare elog(ERROR)) is omitted. Messages are allocated in ApplyOperationContext so logging a large transaction's rows doesn't accumulate. Diagnostic change only — discard/disable/LSN behaviour is unchanged.

Test

- Add 104_iptables_conn_block.pl (manual): reproduces a firewall-style replication outage via iptables and asserts no row loss or spurious exception_log entries across the blip. Not in the schedule; run manually.

Notes

- No expected-output changes: the spock-internal messages asserted in replication_set.out are XX000 (no prefix), and other tests assert message text by substring.
- Release notes are intentionally not touched here — handled in a separate PR.