### PR TITLE
TAP test updates

### DIFF
--- a/tests/tap/t/026_no_double_wal_flush.pl
+++ b/tests/tap/t/026_no_double_wal_flush.pl
@@ -59,7 +59,7 @@ my $prov_dsn = "host=$host port=$prov_port dbname=$dbname user=$user";
 # WAL fsyncs there and fall back to pg_stat_wal.wal_sync on PG15-17.
 my $pg_version_num = scalar_query(2, "SELECT current_setting('server_version_num')");
 my $wal_sync_query = ($pg_version_num >= 180000)
-    ? "SELECT COALESCE(sum(fsyncs), 0)::bigint FROM pg_stat_io WHERE object = 'wal'"
+    ? "SELECT COALESCE(sum(fsyncs), 0)::bigint FROM pg_stat_io WHERE object = 'wal' AND context = 'normal'"
     : "SELECT wal_sync FROM pg_stat_wal";
 diag("WAL-fsync counter source (server_version_num=$pg_version_num): $wal_sync_query");
 

--- a/tests/tap/t/026_no_double_wal_flush.pl
+++ b/tests/tap/t/026_no_double_wal_flush.pl
@@ -8,9 +8,14 @@
 #       pressure on the apply hot path.  After the removal, each applied
 #       commit should produce exactly one fsync (the commit record itself).
 #
-# Uses pg_stat_wal.wal_sync as an indirect counter.  With
+# Uses a WAL-fsync counter as an indirect measure.  With
 # synchronous_commit=on and no other WAL-generating activity, N applied
 # commits should produce ~N fsyncs, not ~2N.
+#
+# The counter source depends on the server version: PG15-17 expose
+# pg_stat_wal.wal_sync, but PG18 removed wal_sync/wal_write from pg_stat_wal
+# and relocated WAL I/O accounting to pg_stat_io (object = 'wal').  See
+# $wal_sync_query below.
 # =============================================================================
 
 use strict;
@@ -49,6 +54,15 @@ my $sub_dir   = $datadirs->[1];
 
 my $prov_dsn = "host=$host port=$prov_port dbname=$dbname user=$user";
 
+# Pick a WAL-fsync counter that exists on the running server.  pg_stat_wal
+# lost wal_sync/wal_write in PG18 (moved to pg_stat_io), so use pg_stat_io's
+# WAL fsyncs there and fall back to pg_stat_wal.wal_sync on PG15-17.
+my $pg_version_num = scalar_query(2, "SELECT current_setting('server_version_num')");
+my $wal_sync_query = ($pg_version_num >= 180000)
+    ? "SELECT COALESCE(sum(fsyncs), 0)::bigint FROM pg_stat_io WHERE object = 'wal'"
+    : "SELECT wal_sync FROM pg_stat_wal";
+diag("WAL-fsync counter source (server_version_num=$pg_version_num): $wal_sync_query");
+
 # Force synchronous_commit=on so every commit record is flushed.
 psql_or_bail(2, "ALTER SYSTEM SET synchronous_commit = 'on'");
 system_or_bail "$pg_bin/pg_ctl", '-D', $sub_dir, 'reload';
@@ -64,8 +78,8 @@ ok(wait_for_sub_status(2, 'sub', 'replicating', 30), 'subscription is replicatin
 psql_or_bail(2, 'CHECKPOINT');
 select(undef, undef, undef, 0.5);
 
-my $before = scalar_query(2, "SELECT wal_sync FROM pg_stat_wal");
-ok($before =~ /^\d+$/, "baseline wal_sync=$before");
+my $before = scalar_query(2, $wal_sync_query);
+ok($before =~ /^\d+$/, "baseline wal sync count=$before");
 
 # Apply N commits. Each is a small transaction to minimize non-commit WAL
 # volume; bigger transactions would drag in checkpoints, XLogBackgroundFlush
@@ -81,9 +95,9 @@ ok(wait_until(30, sub {
 # Let any lingering feedback/statistic flushes settle.
 select(undef, undef, undef, 1.0);
 
-my $after = scalar_query(2, "SELECT wal_sync FROM pg_stat_wal");
+my $after = scalar_query(2, $wal_sync_query);
 my $delta = $after - $before;
-diag("wal_sync delta over $N applied commits: $delta");
+diag("wal sync delta over $N applied commits: $delta");
 
 # Before the fix: at least N extra syncs from the per-commit XLogFlush in
 # spock_apply_progress_add_to_wal(), independent of synchronous_commit.
@@ -95,7 +109,7 @@ diag("wal_sync delta over $N applied commits: $delta");
 # sync-per-commit. Assert the delta is well below N.  This catches any
 # re-introduction of an XLogFlush in the apply hot path.
 cmp_ok($delta, '<', $N,
-    "wal_sync delta ($delta) is below N=$N -- applied commits do not force a sync per commit");
+    "wal sync delta ($delta) is below N=$N -- applied commits do not force a sync per commit");
 
 # Lower bound: zero is unlikely because the walwriter fires periodically,
 # but we don't want to require a specific minimum -- the test is about the

--- a/tests/tap/t/029_remote_commit_ts_recovery_clean_shutdown.pl
+++ b/tests/tap/t/029_remote_commit_ts_recovery_clean_shutdown.pl
@@ -58,7 +58,10 @@ my $user      = $conf->{db_user};
 my $prov_port = $ports->[0];
 my $sub_port  = $ports->[1];
 my $sub_dir   = $datadirs->[1];
-my $logdir    = "$sub_dir/logs";
+# The logging collector writes server logs into the harness log directory
+# (TESTLOGDIR) as 00<port>.log, not into the data directory.  Grep there for
+# the apply worker's "ts recovery" lines.
+my $logdir    = $conf->{log_dir};
 
 my $prov_dsn = "host=$host port=$prov_port dbname=$dbname user=$user";
 

--- a/tests/tap/t/800_standby_hot_standby_feedback.pl
+++ b/tests/tap/t/800_standby_hot_standby_feedback.pl
@@ -14,7 +14,6 @@ my ($pg_major) = `$pg_bin/pg_config --version` =~ /\b(\d+)/;
 plan skip_all =>
     "spock_failover_slots worker is disabled on PG18+ (native sync_replication_slots)"
     if defined $pg_major && $pg_major >= 18;
-plan tests => 9;
 
 # =============================================================================
 # Test: 800_standby_hot_standby_feedback.pl

--- a/tests/tap/t/800_standby_hot_standby_feedback.pl
+++ b/tests/tap/t/800_standby_hot_standby_feedback.pl
@@ -1,8 +1,20 @@
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More;
 use lib '.';
 use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config psql_or_bail);
+
+# Spock disables its own failover-slots worker on PG18+, relying on
+# PostgreSQL's native sync_replication_slots instead (see the
+# #if PG_VERSION_NUM >= 180000 gate in src/spock_failover_slots.c). The
+# worker this test exercises therefore does not exist on PG18+, so skip
+# there. Valid on PG15/16/17, where Spock still runs the worker.
+my $pg_bin = get_test_config()->{pg_bin};
+my ($pg_major) = `$pg_bin/pg_config --version` =~ /\b(\d+)/;
+plan skip_all =>
+    "spock_failover_slots worker is disabled on PG18+ (native sync_replication_slots)"
+    if defined $pg_major && $pg_major >= 18;
+plan tests => 9;
 
 # =============================================================================
 # Test: 800_standby_hot_standby_feedback.pl

--- a/tests/tap/t/SpockTest.pm
+++ b/tests/tap/t/SpockTest.pm
@@ -375,22 +375,26 @@ sub destroy_cluster {
 			  FROM spock.subscription s, LATERAL spock.sub_drop(s.sub_name)";
         }
 
+        # Best-effort logical cleanup. A failed node_drop (e.g. a node that
+        # was never fully set up) must NOT abort teardown: the servers below
+        # share fixed ports/datadirs with every other test, so a leaked
+        # postmaster poisons the next test in the run.
         for (my $i = 0; $i < $node_count; $i++) {
             my $node_name = "n" . ($i + 1);
-            system_or_bail "$PG_BIN/psql", '-p', $node_ports[$i], '-d', $DB_NAME, '-c', "SELECT spock.node_drop('$node_name')";
+            system_maybe "$PG_BIN/psql", '-p', $node_ports[$i], '-d', $DB_NAME, '-c', "SELECT spock.node_drop('$node_name')";
         }
 
-        # Stop PostgreSQL instances
+        # Stop PostgreSQL instances (must always run).
         for (my $i = 0; $i < $node_count; $i++) {
             system("$PG_BIN/pg_ctl stop -D $node_datadirs[$i] -m immediate >> '$LOG_FILE' 2>&1 &");
         }
 
-        # Wait for processes to stop
-        system_or_bail 'sleep', '5';
+        # Wait for processes to stop.
+        sleep(5);
 
-        # Clean up test directories
+        # Clean up test directories (must always run).
         for my $datadir (@node_datadirs) {
-            system_or_bail 'rm', '-rf', $datadir;
+            system('rm', '-rf', $datadir);
         }
 
         $nodes_created = 0;

--- a/tests/tap/t/SpockTest.pm
+++ b/tests/tap/t/SpockTest.pm
@@ -384,13 +384,19 @@ sub destroy_cluster {
             system_maybe "$PG_BIN/psql", '-p', $node_ports[$i], '-d', $DB_NAME, '-c', "SELECT spock.node_drop('$node_name')";
         }
 
-        # Stop PostgreSQL instances (must always run).
+        # Stop PostgreSQL instances (must always run).  Run pg_ctl stop
+        # synchronously (no trailing '&') so its built-in wait blocks until
+        # the postmaster has actually exited before we rm -rf the datadir --
+        # otherwise rm could race a still-live postmaster and leak a process
+        # holding the fixed port/datadir into the next test.  Use plain
+        # system() (not system_or_bail) so a failed stop still does not abort
+        # teardown.
         for (my $i = 0; $i < $node_count; $i++) {
-            system("$PG_BIN/pg_ctl stop -D $node_datadirs[$i] -m immediate >> '$LOG_FILE' 2>&1 &");
+            system("$PG_BIN/pg_ctl stop -D $node_datadirs[$i] -m immediate >> '$LOG_FILE' 2>&1");
         }
 
-        # Wait for processes to stop.
-        sleep(5);
+        # Brief margin for the OS to release ports/sockets after exit.
+        sleep(2);
 
         # Clean up test directories (must always run).
         for my $datadir (@node_datadirs) {


### PR DESCRIPTION
Fix non-regularly scheduled TAP tests + harden teardown

Some TAP tests not in the standard schedule failed on PG18. This fixes the genuine test bugs and hardens the shared teardown path so one test's failure can't cascade into others.

Test fixes (26d9df5)

- 026_no_double_wal_flush — PG18 removed wal_sync/wal_write from pg_stat_wal (relocated to pg_stat_io). The test now reads WAL fsyncs from pg_stat_io (object='wal') on PG18+ and falls back to pg_stat_wal.wal_sync on PG15–17. The delta < N regression guard is unchanged.
- 029_remote_commit_ts_recovery_clean_shutdown — the test grepped $datadir/logs, but the harness routes server logs to TESTLOGDIR (log_directory/log_filename in SpockTest.pm). Now greps the harness log dir. The Spock feature itself was already correct.
- 800_standby_hot_standby_feedback — Spock disables its own failover-slots worker on PG18+ (relies on native sync_replication_slots; see #if PG_VERSION_NUM >= 180000 in spock_failover_slots.c). The test now skip_alls on PG18+, matching the source gate, and still runs fully on PG15–17.

Teardown resilience (83eb14c)

All TAP tests share fixed datadirs (/tmp/tmp_spock_node_*) and ports (544x), so a leaked postmaster from one test poisons the next. Previously a failed node_drop in destroy_cluster (via system_or_bail) could die before pg_ctl stop/rm -rf ran, orphaning servers. Logical cleanup is now best-effort (system_maybe) and the server-stop + datadir-removal always run.