### PR TITLE
Enable failover on existing logical slots when upgrading to 6.0.0.

### DIFF
--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -8,8 +8,8 @@ standby so that replication can resume without data loss after a failover.
 
 When a primary server fails and a physical standby is promoted, any active
 logical subscribers must be able to continue replicating from the new primary.
-This requires the logical replication slots — which track each subscriber's
-replication position — to be present and up to date on the standby before the
+This requires the logical replication slots, which track each subscriber's
+replication position, to be present and up to date on the standby before the
 failover occurs.
 
 Without slot synchronization, a failover would require manual slot recreation
@@ -30,7 +30,76 @@ them up automatically.
 On **PostgreSQL 18+**, Spock's own failover worker is not registered at all.
 The native slotsync worker is the only mechanism.
 
-## Setup: PostgreSQL 18+ (Native)
+## Which settings you need
+
+There are two sync paths, and each needs a different set of settings. Both paths
+also assume the base Spock settings are already in place.
+
+### Base settings (all versions, every node)
+
+These are the settings Spock needs to replicate at all. They are covered in
+[Installing and Configuring Spock](install_spock.md).
+
+```ini
+wal_level = logical
+shared_preload_libraries = 'spock'
+track_commit_timestamp = on
+max_worker_processes = 10
+max_replication_slots = 10
+max_wal_senders = 10
+```
+
+On PostgreSQL 18, also size `max_active_replication_origins` (default 10) to at
+least the number of subscriptions plus some headroom.
+
+### Native path (PostgreSQL 17 with `sync_replication_slots = on`, and PostgreSQL 18)
+
+Core PostgreSQL copies the slots. Set these in addition to the base settings.
+
+| Setting | Node | Value | Purpose |
+|---|---|---|---|
+| `sync_replication_slots` | standby | `on` | Turns on the core slot sync worker. Required on 18, optional on 17. |
+| `hot_standby_feedback` | standby | `on` | Stops the primary from removing catalog rows the slots still need. |
+| `primary_slot_name` | standby | physical slot name | The physical slot the standby streams through. |
+| `primary_conninfo` | standby | connection string with `dbname` | How the standby reaches the primary. |
+| `synchronized_standby_slots` | primary | physical slot name | Holds logical walsenders back until the standby has the changes. |
+| slot `failover = true` | primary | per slot | Only slots with this flag are synced. Spock 6.0.0 sets it at creation; older slots are handled during upgrade. |
+
+The physical slot must exist on the primary before the standby connects:
+
+```sql
+SELECT pg_create_physical_replication_slot('spock_standby_slot');
+```
+
+### Spock worker path (PostgreSQL 15, 16, and 17 when `sync_replication_slots` is off)
+
+The Spock background worker on the standby copies the slots. Set these in
+addition to the base settings.
+
+| Setting | Node | Default | Purpose |
+|---|---|---|---|
+| `hot_standby_feedback` | standby | `on` (you set it) | Required for the worker to run, and stops the primary from removing needed catalog rows. |
+| `primary_slot_name` | standby | physical slot name | The physical slot the standby streams through. |
+| `primary_conninfo` | standby | connection string | How the standby reaches the primary. |
+| `spock.synchronize_slot_names` | standby | `name_like:%%` | Which slots to sync. All by default. |
+| `spock.drop_extra_slots` | standby | `on` | Drop standby slots that no longer exist on the primary. |
+| `spock.primary_dsn` | standby | `''` | Connection to the primary. Falls back to `primary_conninfo` when empty. |
+| `spock.pg_standby_slot_names` | primary | `''` | Physical slots that must confirm an LSN before logical replication advances. Optional. |
+| `spock.standby_slots_min_confirmed` | primary | `-1` | How many of those slots must confirm. `-1` means all. |
+
+`hot_standby_feedback = on` plus a physical slot named by `primary_slot_name` is
+the important pair. Without both, the primary can remove catalog rows a slot
+still needs, and the slot is invalidated with a message about conflicting with
+recovery.
+
+## Setup: PostgreSQL 17 and 18 (Native)
+
+This is the native slot sync path. It is the only option on PostgreSQL 18. On
+PostgreSQL 17 it is optional: the Spock worker runs by default, and setting
+`sync_replication_slots = on` on the standby tells Spock to step aside and let
+core PostgreSQL do the sync instead. Native sync only copies slots that have
+`failover = true`. Spock 6.0.0 sets that flag when it creates a slot. If you
+have slots from an older Spock release, see the upgrade section below.
 
 ### 1. Create a physical replication slot on the primary
 
@@ -104,6 +173,64 @@ spock.drop_extra_slots = on
 # (set this on the PRIMARY, not the standby)
 # spock.pg_standby_slot_names = 'physical_slot_name'
 ```
+
+## Upgrading Spock to 6.0.0
+
+New slots created by Spock 6.0.0 already have `failover = true`. Slots created
+by an older Spock release do not, and native slot sync on PostgreSQL 17 and 18
+ignores slots that do not have the flag. The upgrade turns the flag on for those
+existing slots.
+
+This section covers only the failover part of the upgrade. For the full
+procedure (disabling auto-DDL, installing the new binaries, and restarting each
+node), follow [Upgrading the Spock Extension](upgrading_spock.md) first. The
+steps below run after the 6.0.0 binaries are installed.
+
+### 1. Run the extension update
+
+```sql
+ALTER EXTENSION spock UPDATE TO '6.0.0';
+```
+
+PostgreSQL walks the version chain (5.0.8 to 5.0.9 to 5.0.10 to 6.0.0) and runs
+each step in order. The 5.0.10 to 6.0.0 step calls
+`spock.slot_enable_failover()` for you.
+
+`spock.slot_enable_failover()` behaves as follows:
+
+- On PostgreSQL 16 and older it does nothing, because the flag does not exist.
+- On a standby it does nothing, because the flag can only be set on a primary.
+- It sets `failover = true` on each Spock logical slot that does not already
+  have it.
+- It skips any slot that is in use at that moment and prints a NOTICE naming
+  the slot.
+- It returns the number of slots it changed.
+
+### 2. Handle any skipped slots
+
+A slot that is actively streaming to a subscriber cannot be changed while it is
+held, so the function leaves it alone and tells you which one. To set the flag
+on those slots, pause the subscribers that hold them and run the function again
+on the primary:
+
+```sql
+SELECT spock.slot_enable_failover();
+```
+
+### 3. Verify
+
+On the primary, every Spock slot should now show `failover` as true:
+
+```sql
+SELECT slot_name, failover
+FROM pg_replication_slots
+WHERE plugin = 'spock_output';
+```
+
+The upgrade does not change any PostgreSQL settings. If you are switching to the
+native path on PostgreSQL 17, or you are on PostgreSQL 18, set
+`sync_replication_slots = on` on the standby yourself and confirm the primary
+lists the physical slot in `synchronized_standby_slots`.
 
 ## Monitoring
 

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -462,7 +462,13 @@ once the binaries are swapped.  The upgrade:
 * migrates `spock.resolutions.conflict_type` values,
 * adds the new functions and the `sub_id_generator` sequence,
 * refreshes the parallel-safety attributes on `spock.md5_agg_sfunc` and
-  `spock.spock_gen_slot_name`.
+  `spock.spock_gen_slot_name`,
+* turns on the `failover` flag for existing logical slots by calling
+  `spock.slot_enable_failover()`, so PostgreSQL 17 and 18 slot synchronization
+  picks them up. This is a no-op on PostgreSQL 16 and older and on a standby,
+  and it skips slots that are in use at the time. See
+  [Logical Slot Failover](logical_slot_failover.md) for how to handle any
+  skipped slots.
 
 ## Spock 5.0.10
 

--- a/sql/spock--5.0.10--6.0.0.sql
+++ b/sql/spock--5.0.10--6.0.0.sql
@@ -324,3 +324,25 @@ RETURNS boolean
 AS 'MODULE_PATHNAME', 'spock_alter_subscription_options'
 LANGUAGE C STRICT VOLATILE;
 
+-- ----
+-- Enable the "failover" flag on spock's existing logical replication slots.
+--
+-- PostgreSQL 17 and newer can synchronize a logical slot to a physical standby
+-- (natively on 18 through sync_replication_slots, and on 17 when that setting
+-- is turned on), but only slots that have failover = true are synchronized.
+-- Slots created by spock 6.0.0 set the flag when the slot is created, but slots
+-- created by earlier releases do not have it, so turn it on for the existing
+-- ones during the upgrade.
+--
+-- The function is a no-op on PostgreSQL 16 and older and on a standby, and it
+-- skips slots that are currently in use (it prints a NOTICE for those so the
+-- operator can rerun it after pausing replication).
+-- ----
+CREATE FUNCTION spock.slot_enable_failover()
+RETURNS integer
+AS 'MODULE_PATHNAME', 'spock_slot_enable_failover'
+LANGUAGE C VOLATILE;
+REVOKE ALL ON FUNCTION spock.slot_enable_failover() FROM PUBLIC;
+
+SELECT spock.slot_enable_failover();
+

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -270,6 +270,16 @@ RETURNS boolean
 AS 'MODULE_PATHNAME', 'spock_alter_subscription_options'
 LANGUAGE C STRICT VOLATILE;
 
+-- Turn on the "failover" flag for spock's existing logical replication slots
+-- so PostgreSQL 17+ slot synchronization picks them up.  New 6.0.0 slots set
+-- the flag at creation time; this helper exists for slots made by older
+-- releases and for manual use after pausing replication.
+CREATE FUNCTION spock.slot_enable_failover()
+RETURNS integer
+AS 'MODULE_PATHNAME', 'spock_slot_enable_failover'
+LANGUAGE C VOLATILE;
+REVOKE ALL ON FUNCTION spock.slot_enable_failover() FROM PUBLIC;
+
 CREATE FUNCTION spock.sub_show_status(
   subscription_name     name DEFAULT NULL,
   OUT subscription_name text,

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -1604,6 +1604,165 @@ attach_to_walsender(Port *port, int status)
 }
 #endif							/* PG_VERSION_NUM < 180000 */
 
+/*
+ * spock_slot_enable_failover
+ *
+ * SQL-callable maintenance helper used by the 5.0.10 -> 6.0.0 upgrade.
+ *
+ * PostgreSQL 17+ can synchronize a logical replication slot to a physical
+ * standby (natively on 18 via sync_replication_slots, and on 17 when that GUC
+ * is enabled), but only slots whose "failover" flag is set are synchronized.
+ * Slots created by spock 6.0.0 already set the flag at CREATE time (see
+ * ensure_replication_slot_snapshot() in spock_sync.c), but slots created by
+ * earlier releases predate that logic.  This function marks every existing
+ * spock logical slot as failover-enabled so it participates in slot sync.
+ *
+ * There is no SQL to alter the flag on an existing slot -- the walsender
+ * ALTER_REPLICATION_SLOT command and pg_create_logical_replication_slot()'s
+ * failover argument are the only in-tree ways to set it -- so we flip it here
+ * the same way ReplicationSlotAlter() does, but acquiring the slot with
+ * nowait = true so a busy walsender never blocks the upgrade transaction.
+ *
+ * Behaviour:
+ *   - no-op (returns 0) on PostgreSQL 16 and older, where the flag doesn't exist;
+ *   - no-op on a standby, where failover cannot be enabled;
+ *   - skips slots that are already enabled, temporary, synced from a primary,
+ *     invalidated, or currently held by a walsender (a NOTICE is emitted for
+ *     active slots so the operator can rerun after pausing replication);
+ *   - returns the number of slots whose failover flag was turned on.
+ */
+PG_FUNCTION_INFO_V1(spock_slot_enable_failover);
+Datum
+spock_slot_enable_failover(PG_FUNCTION_ARGS)
+{
+	int			n_enabled = 0;
+#if PG_VERSION_NUM >= 170000
+	int			i;
+	List	   *targets = NIL;
+	ListCell   *lc;
+	MemoryContext caller_ctx = CurrentMemoryContext;
+
+	if (!superuser())
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser to call spock.slot_enable_failover()")));
+
+	/* Failover can only be enabled on a primary. */
+	if (RecoveryInProgress())
+	{
+		ereport(NOTICE,
+				(errmsg("spock: not enabling slot failover on a standby server")));
+		PG_RETURN_INT32(0);
+	}
+
+	/*
+	 * Collect the names of spock's persistent logical slots that don't yet
+	 * have the failover flag set and aren't currently in use.  We only read
+	 * shared slot state under the control lock here; the actual acquire/alter
+	 * happens afterwards because ReplicationSlotAcquire() must not run while
+	 * ReplicationSlotControlLock is held.
+	 */
+	LWLockAcquire(ReplicationSlotControlLock, LW_SHARED);
+	for (i = 0; i < max_replication_slots; i++)
+	{
+		ReplicationSlot *s = &ReplicationSlotCtl->replication_slots[i];
+
+		if (!s->in_use)
+			continue;
+		/* logical slots only (physical slots have no database) */
+		if (s->data.database == InvalidOid)
+			continue;
+		/* spock's own slots only */
+		if (strcmp(NameStr(s->data.plugin), "spock_output") != 0)
+			continue;
+		/* only persistent slots can carry the failover flag */
+		if (s->data.persistency != RS_PERSISTENT)
+			continue;
+		/* already enabled */
+		if (s->data.failover)
+			continue;
+		/* never touch a slot being synced from a primary */
+		if (s->data.synced)
+			continue;
+		/* an invalidated slot cannot be altered or reused */
+		if (s->data.invalidated != RS_INVAL_NONE)
+			continue;
+		/* skip slots held by a walsender so we never block the upgrade */
+		if (s->active_pid != 0)
+		{
+			ereport(NOTICE,
+					(errmsg("spock: replication slot \"%s\" is active; "
+							"rerun spock.slot_enable_failover() after pausing replication",
+							NameStr(s->data.name))));
+			continue;
+		}
+
+		targets = lappend(targets, pstrdup(NameStr(s->data.name)));
+	}
+	LWLockRelease(ReplicationSlotControlLock);
+
+	foreach(lc, targets)
+	{
+		char	   *slot_name = (char *) lfirst(lc);
+
+		/*
+		 * Isolate each slot in a subtransaction so a race (the slot turning
+		 * active or being dropped after our scan) is skipped with a WARNING
+		 * instead of aborting the whole upgrade.
+		 */
+		BeginInternalSubTransaction("spock_slot_enable_failover");
+		PG_TRY();
+		{
+#if PG_VERSION_NUM >= 180000
+			ReplicationSlotAcquire(slot_name, true, true);
+#else
+			ReplicationSlotAcquire(slot_name, true);
+#endif
+			SpinLockAcquire(&MyReplicationSlot->mutex);
+			MyReplicationSlot->data.failover = true;
+			SpinLockRelease(&MyReplicationSlot->mutex);
+			ReplicationSlotMarkDirty();
+			ReplicationSlotSave();
+			ReplicationSlotRelease();
+
+			ReleaseCurrentSubTransaction();
+			MemoryContextSwitchTo(caller_ctx);
+			n_enabled++;
+
+			ereport(NOTICE,
+					(errmsg("spock: enabled failover on replication slot \"%s\"",
+							slot_name)));
+		}
+		PG_CATCH();
+		{
+			ErrorData  *edata;
+
+			MemoryContextSwitchTo(caller_ctx);
+			edata = CopyErrorData();
+			FlushErrorState();
+
+			/* release the slot if we acquired it before failing */
+			if (MyReplicationSlot != NULL)
+				ReplicationSlotRelease();
+
+			RollbackAndReleaseCurrentSubTransaction();
+			MemoryContextSwitchTo(caller_ctx);
+
+			ereport(WARNING,
+					(errmsg("spock: could not enable failover on replication slot \"%s\": %s",
+							slot_name, edata->message)));
+			FreeErrorData(edata);
+		}
+		PG_END_TRY();
+	}
+#else
+	ereport(NOTICE,
+			(errmsg("spock: replication slot failover requires PostgreSQL 17 or newer; nothing to do")));
+#endif
+
+	PG_RETURN_INT32(n_enabled);
+}
+
 void
 spock_init_failover_slot(void)
 {


### PR DESCRIPTION
PostgreSQL 17 and 18 only synchronize logical slots that carry the failover flag. New 6.0.0 slots set it at creation, but slots made by earlier releases do not, so add spock.slot_enable_failover() and call it from the 5.0.10 to 6.0.0 upgrade. Document the two sync paths, their per-version GUCs, and the upgrade steps in logical_slot_failover.md.