### PR TITLE
Allow zodan add_node to work with lolor large object data.

### DIFF
--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -284,10 +284,13 @@ BEGIN
 
     IF synchronize_structure THEN
         BEGIN
-            -- Query existing schemas on the new node (excluding system schemas)
+            -- Query existing schemas on the new node (excluding system schemas).
+            -- lolor is excluded here: Spock already keeps it out of the
+            -- structure dump globally, and putting it into skip_schema would
+            -- also exclude the lolor tables from the initial data sync.
             remotesql_schema := 'SELECT string_agg(schema_name, '','') as schemas
                                 FROM information_schema.schemata
-                                WHERE schema_name NOT IN (''information_schema'', ''pg_catalog'', ''pg_toast'', ''spock'', ''public'')
+                                WHERE schema_name NOT IN (''information_schema'', ''pg_catalog'', ''pg_toast'', ''spock'', ''public'', ''lolor'')
                                 AND schema_name NOT LIKE ''pg_temp_%''
                                 AND schema_name NOT LIKE ''pg_toast_temp_%''';
 
@@ -1143,20 +1146,41 @@ BEGIN
             RAISE EXCEPTION 'Exiting add_node: Database % does not exist on new node. Please create it first.', new_db_name;
     END;
 
-    -- Check if they previously installed lolor on the destination.
-    -- They should not have run CREATE EXTENSION yet
+    -- Check lolor state on the destination. Having the lolor extension
+    -- installed is fine (and required when the source replicates lolor
+    -- tables), but pre-existing large object data would conflict with the
+    -- data synchronized from the source.
     DECLARE
-        user_table_count integer;
+        new_lolor_installed boolean;
+        lolor_row_count bigint;
+        src_lolor_repset_tables integer;
         remotesql text;
     BEGIN
-        remotesql := 'SELECT count(*) FROM pg_tables WHERE schemaname = ''lolor''';
-        SELECT * FROM dblink(new_node_dsn, remotesql) AS t(count integer) INTO user_table_count;
+        remotesql := 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_extension WHERE extname = ''lolor'')';
+        SELECT * FROM dblink(new_node_dsn, remotesql) AS t(installed boolean) INTO new_lolor_installed;
 
-        IF user_table_count > 0 THEN
-            RAISE NOTICE '    [FAILED] %', rpad('Database ' || new_db_name || ' has the lolor extension installed or remaining lolor data.', 120, ' ');
-            RAISE EXCEPTION 'Exiting add_node: Database % has the lolor extension installed or remaining lolor user data.', new_db_name;
+        IF new_lolor_installed THEN
+            remotesql := 'SELECT (SELECT count(*) FROM lolor.pg_largeobject) + (SELECT count(*) FROM lolor.pg_largeobject_metadata)';
+            SELECT * FROM dblink(new_node_dsn, remotesql) AS t(row_count bigint) INTO lolor_row_count;
+
+            IF lolor_row_count > 0 THEN
+                RAISE NOTICE '    [FAILED] %', rpad('Database ' || new_db_name || ' has pre-existing large object data in the lolor tables', 120, ' ');
+                RAISE EXCEPTION 'Exiting add_node: Database % on new node has pre-existing large object data in the lolor tables. The lolor tables must be empty so the large object data from the source node can be synchronized.', new_db_name;
+            ELSE
+                RAISE NOTICE '    OK: %', rpad('Checking database ' || new_db_name || ' lolor tables are empty', 120, ' ');
+            END IF;
+        END IF;
+
+        -- If the source node replicates lolor tables, the new node must have
+        -- lolor installed or the initial data synchronization will fail.
+        remotesql := 'SELECT count(*) FROM spock.tables WHERE nspname = ''lolor'' AND set_name IS NOT NULL';
+        SELECT * FROM dblink(src_dsn, remotesql) AS t(count integer) INTO src_lolor_repset_tables;
+
+        IF src_lolor_repset_tables > 0 AND NOT new_lolor_installed THEN
+            RAISE NOTICE '    [FAILED] %', rpad('Source node replicates lolor tables but database ' || new_db_name || ' does not have lolor installed', 120, ' ');
+            RAISE EXCEPTION 'Exiting add_node: Source node replicates lolor tables but database % on new node does not have the lolor extension installed. Please run CREATE EXTENSION lolor on the new node first.', new_db_name;
         ELSE
-            RAISE NOTICE '    OK: %', rpad('Checking database ' || new_db_name || ' to ensure lolor is not installed', 120, ' ');
+            RAISE NOTICE '    OK: %', rpad('Checking lolor requirements for database ' || new_db_name, 120, ' ');
         END IF;
     END;
 
@@ -1165,7 +1189,9 @@ BEGIN
         user_table_count integer;
         remotesql text;
     BEGIN
-        remotesql := 'SELECT count(*) FROM pg_tables WHERE schemaname NOT IN (''information_schema'', ''pg_catalog'', ''pg_toast'', ''spock'') AND schemaname NOT LIKE ''pg_temp_%'' AND schemaname NOT LIKE ''pg_toast_temp_%''';
+        -- lolor tables are excluded: they belong to the lolor extension and
+        -- their emptiness is enforced by the lolor check above.
+        remotesql := 'SELECT count(*) FROM pg_tables WHERE schemaname NOT IN (''information_schema'', ''pg_catalog'', ''pg_toast'', ''spock'', ''lolor'') AND schemaname NOT LIKE ''pg_temp_%'' AND schemaname NOT LIKE ''pg_toast_temp_%''';
         SELECT * FROM dblink(new_node_dsn, remotesql) AS t(count integer) INTO user_table_count;
 
         IF user_table_count > 0 THEN
@@ -2539,6 +2565,9 @@ DECLARE
     new_version text;
     sub_count text;
     user_table_count text;
+    new_lolor_installed boolean;
+    lolor_row_count bigint;
+    src_lolor_repset_tables integer;
 BEGIN
     RAISE NOTICE '';
     RAISE NOTICE '================================================================================';
@@ -2668,20 +2697,35 @@ BEGIN
     -- Check 8: Database prerequisites (pre-check only)
     -- ========================================================================
     IF check_type = 'pre' AND new_node_dsn IS NOT NULL THEN
-        -- Check 8a: Verify lolor extension is not installed
+        -- Check 8a: lolor state. Having lolor installed is OK, but the lolor
+        -- tables must be empty, and if the source replicates lolor tables the
+        -- new node must have lolor installed.
         BEGIN
-            remotesql := 'SELECT count(*) FROM pg_tables WHERE schemaname = ''lolor''';
-            SELECT * FROM dblink(new_node_dsn, remotesql) AS t(table_count text) INTO user_table_count;
+            remotesql := 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_extension WHERE extname = ''lolor'')';
+            SELECT * FROM dblink(new_node_dsn, remotesql) AS t(installed boolean) INTO new_lolor_installed;
 
-            IF user_table_count IS NOT NULL AND user_table_count::integer = 0 THEN
-                RAISE NOTICE 'PASS: Destination database does not have signs of lolor being installed';
-                checks_passed := checks_passed + 1;
+            IF new_lolor_installed THEN
+                remotesql := 'SELECT (SELECT count(*) FROM lolor.pg_largeobject) + (SELECT count(*) FROM lolor.pg_largeobject_metadata)';
+                SELECT * FROM dblink(new_node_dsn, remotesql) AS t(row_count bigint) INTO lolor_row_count;
             ELSE
-                RAISE NOTICE 'FAIL: Destination database has the lolor extension installed or remaining lolor user data in the lolor schema';
+                lolor_row_count := 0;
+            END IF;
+
+            remotesql := 'SELECT count(*) FROM spock.tables WHERE nspname = ''lolor'' AND set_name IS NOT NULL';
+            SELECT * FROM dblink(src_dsn, remotesql) AS t(count integer) INTO src_lolor_repset_tables;
+
+            IF lolor_row_count > 0 THEN
+                RAISE NOTICE 'FAIL: Destination database has pre-existing large object data in the lolor tables';
                 checks_failed := checks_failed + 1;
+            ELSIF src_lolor_repset_tables > 0 AND NOT new_lolor_installed THEN
+                RAISE NOTICE 'FAIL: Source node replicates lolor tables but the destination database does not have the lolor extension installed';
+                checks_failed := checks_failed + 1;
+            ELSE
+                RAISE NOTICE 'PASS: Destination database lolor state is compatible with add_node';
+                checks_passed := checks_passed + 1;
             END IF;
         EXCEPTION WHEN OTHERS THEN
-            RAISE NOTICE 'FAIL: lolor extension check - %', SQLERRM;
+            RAISE NOTICE 'FAIL: lolor check - %', SQLERRM;
             checks_failed := checks_failed + 1;
         END;
 
@@ -2689,7 +2733,7 @@ BEGIN
         BEGIN
             remotesql := $pg_tables$
                 SELECT count(*) FROM pg_tables
-                WHERE schemaname NOT IN ('information_schema', 'pg_catalog', 'pg_toast', 'spock')
+                WHERE schemaname NOT IN ('information_schema', 'pg_catalog', 'pg_toast', 'spock', 'lolor')
                 AND schemaname NOT LIKE 'pg_temp_%'
                 AND schemaname NOT LIKE 'pg_toast_temp_%'
             $pg_tables$;

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -50,6 +50,7 @@ test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
 test: 030_autoddl_repset_stickiness
 test: 032_lolor_largeobject_repset
+test: 033_zodan_lolor_add_node
 test: 044_apply_change_logging
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match

--- a/tests/tap/t/032_lolor_largeobject_repset.pl
+++ b/tests/tap/t/032_lolor_largeobject_repset.pl
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 use lib '.';
 use SpockTest qw(create_cluster destroy_cluster system_maybe get_test_config
-                 scalar_query wait_for_sub_status);
+                 scalar_query wait_for_sub_status ensure_lolor);
 
 # lolor stores large objects in ordinary tables in the "lolor" schema. Those
 # tables must be allowed into a replication set, otherwise a DROP EXTENSION
@@ -12,14 +12,11 @@ use SpockTest qw(create_cluster destroy_cluster system_maybe get_test_config
 # that other protected schemas (spock) stay blocked, and that add-node
 # structure sync still works when lolor is present on both ends.
 
-my $LOLOR_URL = 'https://github.com/pgEdge/lolor.git';
-
 my $cfg   = get_test_config();
 my $PG    = $cfg->{pg_bin};
 my $DB    = $cfg->{db_name};
 my $USER  = $cfg->{db_user};
 my $HOST  = $cfg->{host};
-my $LOGD  = $cfg->{log_dir};
 
 # psql helper: 1-based node index, returns true on success (output goes to log).
 sub psql_ok {
@@ -27,23 +24,6 @@ sub psql_ok {
     my $port = $cfg->{node_ports}[$node - 1];
     return system_maybe("$PG/psql", '-X', '-p', $port, '-d', $DB,
                         '-v', 'ON_ERROR_STOP=1', '-c', $sql);
-}
-
-# Build and install lolor if it is not already present. Skip the whole test
-# (rather than fail) when it cannot be fetched or built, e.g. no network.
-sub ensure_lolor {
-    my $sharedir = `$PG/pg_config --sharedir`;
-    chomp $sharedir;
-    return 1 if $sharedir && -f "$sharedir/extension/lolor.control";
-
-    my $build = "/tmp/spock_lolor_build";
-    my $log   = "$LOGD/032_lolor_build.log";
-    system('rm', '-rf', $build);
-    my $rc = system("git clone --depth 1 $LOLOR_URL $build >> '$log' 2>&1");
-    return 0 if $rc != 0;
-    $rc = system("make -C $build USE_PGXS=1 PG_CONFIG='$PG/pg_config' install >> '$log' 2>&1");
-    return 0 if $rc != 0;
-    return ($sharedir && -f "$sharedir/extension/lolor.control") ? 1 : 0;
 }
 
 plan skip_all => "lolor extension unavailable (clone/build failed)"

--- a/tests/tap/t/033_zodan_lolor_add_node.pl
+++ b/tests/tap/t/033_zodan_lolor_add_node.pl
@@ -1,0 +1,156 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(create_cluster destroy_cluster system_or_bail system_maybe
+                 get_test_config cross_wire scalar_query ensure_lolor);
+
+# Zodan add_node with lolor large objects. The source cluster replicates the
+# lolor tables (lolor.pg_largeobject, lolor.pg_largeobject_metadata) in the
+# default replication set. Adding a node through zodan's add_node() must:
+#   - reject a new node that lacks the lolor extension (data sync would fail),
+#   - reject a new node whose lolor tables already contain data,
+#   - accept a new node with lolor installed and empty, and copy the large
+#     object data from the source during the initial data sync,
+#   - stream large objects created after the join.
+
+my $cfg   = get_test_config();
+my $PG    = $cfg->{pg_bin};
+my $DB    = $cfg->{db_name};
+my $USER  = $cfg->{db_user};
+my $PASS  = $cfg->{db_password};
+my $HOST  = $cfg->{host};
+
+plan skip_all => "lolor extension unavailable (clone/build failed)"
+    unless ensure_lolor();
+
+# psql helper: 1-based node index, returns true on success (output to log).
+sub psql_ok {
+    my ($node, $sql) = @_;
+    my $port = $cfg->{node_ports}[$node - 1];
+    return system_maybe("$PG/psql", '-X', '-p', $port, '-d', $DB,
+                        '-v', 'ON_ERROR_STOP=1', '-c', $sql);
+}
+
+# Run SQL and capture combined stdout/stderr without going through a shell,
+# so quoting inside the SQL is preserved. Returns (exit_code, output).
+sub psql_capture {
+    my ($node, $sql) = @_;
+    my $port = $cfg->{node_ports}[$node - 1];
+    my $pid = open(my $fh, '-|');
+    die "fork failed: $!" unless defined $pid;
+    if ($pid == 0) {
+        open(STDERR, '>&', \*STDOUT) or die "cannot dup STDERR: $!";
+        exec("$PG/psql", '-X', '-p', $port, '-d', $DB,
+             '-v', 'ON_ERROR_STOP=1', '-c', $sql);
+        exit 127;
+    }
+    my $out = do { local $/; <$fh> } // '';
+    close($fh);
+    return ($? >> 8, $out);
+}
+
+# Poll a scalar query on a node until it returns $expected.
+sub wait_for_scalar {
+    my ($node, $sql, $expected, $timeout) = @_;
+    $timeout //= 60;
+    for (1 .. $timeout) {
+        my $v = scalar_query($node, $sql);
+        return 1 if defined $v && $v eq $expected;
+        sleep(1);
+    }
+    return 0;
+}
+
+sub dsn {
+    my ($node) = @_;
+    my $port = $cfg->{node_ports}[$node - 1];
+    return "host=$HOST dbname=$DB port=$port user=$USER password=$PASS";
+}
+
+# --- Cluster setup: n1/n2 cross-wired, n3 is a blank target for zodan -------
+
+create_cluster(3, 'Create 3 instances for zodan lolor test');
+cross_wire(2, ['n1', 'n2'], 'Cross-wire nodes n1 and n2');
+
+# create_cluster registered a spock node on n3; drop it so n3 looks like a
+# freshly prepared instance (spock + dblink installed, no node/repsets).
+ok(psql_ok(3, "SELECT spock.node_drop('n3')"), 'n3 spock node registration dropped');
+ok(psql_ok(3, "CREATE EXTENSION IF NOT EXISTS dblink"), 'dblink installed on n3');
+
+# lolor on the source cluster, its tables in the default replication set.
+# n1 and n2 are cross-wired with automatic DDL replication, so CREATE
+# EXTENSION on n1 arrives on n2 by itself.
+ok(psql_ok(1, "CREATE EXTENSION lolor"), 'lolor installed on n1');
+ok(wait_for_scalar(2, "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '1'),
+   'lolor arrived on n2 via DDL replication');
+for my $node (1, 2) {
+    ok(psql_ok($node, "SELECT spock.repset_add_table('default', 'lolor.pg_largeobject')"),
+       "lolor.pg_largeobject in default repset on n$node");
+    ok(psql_ok($node, "SELECT spock.repset_add_table('default', 'lolor.pg_largeobject_metadata')"),
+       "lolor.pg_largeobject_metadata in default repset on n$node");
+}
+
+# Large object on n1; sanity-check it reaches n2 before involving zodan.
+ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xdeadbeefcafe')"),
+   'large object created on n1');
+ok(wait_for_scalar(2, "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'deadbeefcafe'", '1'),
+   'large object replicated from n1 to n2');
+
+# Load the zodan procedures on the node being added.
+system_or_bail("$PG/psql", '-X', '-p', $cfg->{node_ports}[2], '-d', $DB,
+               '-v', 'ON_ERROR_STOP=1', '-f', '../../samples/Z0DAN/zodan.sql');
+pass('zodan procedures loaded on n3');
+
+my $add_node_sql =
+    "CALL spock.add_node('n1', '" . dsn(1) . "', 'n3', '" . dsn(3) . "', " .
+    "true, 'CA', 'USA', '{}'::jsonb)";
+
+# --- Negative: source replicates lolor but n3 has no lolor extension --------
+
+my ($rc, $out) = psql_capture(3, $add_node_sql);
+ok($rc != 0, 'add_node rejected while n3 lacks the lolor extension');
+like($out, qr/does not have the lolor extension installed/,
+     'rejection message asks for CREATE EXTENSION lolor');
+
+# --- Negative: n3 has lolor installed but with pre-existing data ------------
+
+ok(psql_ok(3, "CREATE EXTENSION lolor"), 'lolor installed on n3');
+ok(psql_ok(3, "SET lolor.node=3; SELECT lo_from_bytea(0, '\\x0bad0bad')"),
+   'pre-existing large object created on n3');
+
+($rc, $out) = psql_capture(3, $add_node_sql);
+ok($rc != 0, 'add_node rejected while n3 has pre-existing lolor data');
+like($out, qr/pre-existing large object data/,
+     'rejection message mentions pre-existing large object data');
+
+# health_check 'pre' must report the same problem without raising.
+($rc, $out) = psql_capture(3,
+    "CALL spock.health_check('n1', '" . dsn(1) . "', 'n3', '" . dsn(3) . "', 'pre', false)");
+like($out, qr/FAIL: Destination database has pre-existing large object data/,
+     'health_check pre-check flags pre-existing lolor data');
+
+# --- Positive: empty lolor tables, add_node copies the data -----------------
+
+ok(psql_ok(3, "DELETE FROM lolor.pg_largeobject; DELETE FROM lolor.pg_largeobject_metadata"),
+   'pre-existing lolor data cleared on n3');
+
+($rc, $out) = psql_capture(3, $add_node_sql);
+is($rc, 0, 'add_node succeeded with lolor installed and empty') or diag($out);
+
+ok(wait_for_scalar(3, "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'deadbeefcafe'", '1'),
+   'existing large object data copied to n3 by initial sync');
+ok(wait_for_scalar(3, "SELECT count(*) FROM lolor.pg_largeobject_metadata", '1'),
+   'large object metadata copied to n3');
+
+# --- Streaming: a large object created after the join reaches n3 ------------
+
+ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xfeedface')"),
+   'second large object created on n1 after join');
+ok(wait_for_scalar(3, "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'feedface'", '1'),
+   'post-join large object streamed to n3');
+
+destroy_cluster('Destroy zodan lolor test cluster');
+
+done_testing();

--- a/tests/tap/t/SpockTest.pm
+++ b/tests/tap/t/SpockTest.pm
@@ -23,6 +23,7 @@ our @EXPORT_OK = qw(
     wait_for_sub_status
     wait_for_exception_log
     wait_for_pg_ready
+    ensure_lolor
 );
 
 # Test configuration
@@ -147,6 +148,24 @@ sub system_maybe {
     my @cmd = @_;
     my $rc = _run_cmd_logged_wait(@cmd);
     return $rc == 0;
+}
+
+# Build and install the lolor extension if it is not already present.
+# Returns true when lolor is available. Callers should skip_all (rather
+# than fail) when this returns false, e.g. no network to clone the repo.
+sub ensure_lolor {
+    my $sharedir = `$PG_BIN/pg_config --sharedir`;
+    chomp $sharedir;
+    return 1 if $sharedir && -f "$sharedir/extension/lolor.control";
+
+    my $build = "/tmp/spock_lolor_build";
+    my $log   = "$LOG_DIR/lolor_build.log";
+    system('rm', '-rf', $build);
+    my $rc = system("git clone --depth 1 https://github.com/pgEdge/lolor.git $build >> '$log' 2>&1");
+    return 0 if $rc != 0;
+    $rc = system("make -C $build USE_PGXS=1 PG_CONFIG='$PG_BIN/pg_config' install >> '$log' 2>&1");
+    return 0 if $rc != 0;
+    return ($sharedir && -f "$sharedir/extension/lolor.control") ? 1 : 0;
 }
 
 # Create PostgreSQL configuration file


### PR DESCRIPTION
Permit the new node to have lolor installed as long as its tables are empty, and require it when the source replicates lolor tables. Keep lolor out of create_sub's auto-detected skip_schema so the initial data sync copies the large object data. Add a TAP test covering the rejection cases and end-to-end sync.