### PR TITLE
ACE schema handling

### DIFF
--- a/include/spock.h
+++ b/include/spock.h
@@ -117,6 +117,8 @@ extern void gen_slot_name(Name slot_name, char *dbname,
 						  const char *subscriber_name);
 
 extern List *textarray_to_list(ArrayType *textarray);
+extern List *spock_skip_schemas_list(void);
+extern bool spock_schema_is_skipped(const char *nspname);
 extern bool parsePGArray(const char *atext, char ***itemarray, int *nitems);
 
 extern Oid	get_spock_table_oid(const char *table);

--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -61,8 +61,8 @@ typedef struct SpockSubscription
 } SpockSubscription;
 
 /* NULL-terminated arrays */
-extern const char *const skip_schema[];
-extern const char *const skip_extension[];
+extern const char *const nodump_schema[];
+extern const char *const nodump_extension[];
 
 extern void create_node(SpockNode *node);
 extern void drop_node(Oid nodeid);

--- a/src/spock.c
+++ b/src/spock.c
@@ -858,6 +858,62 @@ spock_supervisor_main(Datum main_arg)
 	proc_exit(0);
 }
 
+/*
+ * Built-in never-replicate schemas, returned by spock_skip_schemas_list().
+ * pgEdge tooling (ACE) keeps node-local state in pgedge_ace using plain
+ * Postgres DDL; spock must let that DDL succeed while keeping the schema
+ * and its changes off the wire.  Distinct from the lists in spock_node.c:
+ * nodump_schema[] only excludes from the structure-sync dump, and
+ * norepset_schema[] only refuses replication set membership.  Membership
+ * here means DDL and DML stay local, silently.
+ */
+static const char *const builtin_skip_schemas[] = {
+	"pgedge_ace",
+	NULL	/* sentinel */
+};
+
+/*
+ * The node's never-replicate schemas, as a list of palloc'd names.
+ */
+List *
+spock_skip_schemas_list(void)
+{
+	List	   *result = NIL;
+	int			i;
+
+	for (i = 0; builtin_skip_schemas[i] != NULL; i++)
+		result = lappend(result, pstrdup(builtin_skip_schemas[i]));
+
+	return result;
+}
+
+/*
+ * Is nspname never replicated on this node?  For occasional callers;
+ * rebuilds the list on each call.
+ */
+bool
+spock_schema_is_skipped(const char *nspname)
+{
+	List	   *skiplist;
+	ListCell   *lc;
+	bool		result = false;
+
+	if (nspname == NULL)
+		return false;
+
+	skiplist = spock_skip_schemas_list();
+	foreach(lc, skiplist)
+	{
+		if (strcmp((char *) lfirst(lc), nspname) == 0)
+		{
+			result = true;
+			break;
+		}
+	}
+	list_free_deep(skiplist);
+	return result;
+}
+
 static void
 spock_temp_directory_assing_hook(const char *newval, void *extra)
 {

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -355,6 +355,18 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
 
 	targetrel = RelationIdGetRelation(reloid);
 
+	/*
+	 * Never track tables from never-replicate schemas in a replication set.
+	 * This also catches relations reached indirectly (e.g. a partition
+	 * living in such a schema under a replicated parent).
+	 */
+	if (spock_schema_is_skipped(
+			get_namespace_name(RelationGetNamespace(targetrel))))
+	{
+		table_close(targetrel, NoLock);
+		return;
+	}
+
 	/* UNLOGGED and TEMP relations cannot be part of replication set. */
 	if (!RelationNeedsWAL(targetrel))
 	{

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -13,6 +13,7 @@
 #include "postgres.h"
 
 #include "access/commit_ts.h"
+#include "access/relation.h"
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
@@ -2419,8 +2420,10 @@ query_temp_like_source(const char *query)
  * Is the relation named by rv in a never-replicate schema?
  *
  * Runs after the DDL executed, so for CREATE/ALTER the relation exists and an
- * unqualified name can be resolved by opening it.  A missing relation (e.g. a
- * dropped one) can be classified only when the name is schema-qualified.
+ * unqualified name can be resolved by opening it.  relation_openrv, not
+ * table_openrv: rv may name any relation kind (table_open errors on
+ * indexes).  A missing relation (e.g. a dropped one) can be classified only
+ * when the name is schema-qualified.
  */
 static bool
 rangevar_in_skipped_schema(RangeVar *rv)
@@ -2434,12 +2437,12 @@ rangevar_in_skipped_schema(RangeVar *rv)
 	if (rv->schemaname != NULL)
 		return spock_schema_is_skipped(rv->schemaname);
 
-	rel = table_openrv_extended(rv, AccessShareLock, true);
+	rel = relation_openrv_extended(rv, AccessShareLock, true);
 	if (rel == NULL)
 		return false;
 	skipped = spock_schema_is_skipped(
 		get_namespace_name(RelationGetNamespace(rel)));
-	table_close(rel, AccessShareLock);
+	relation_close(rel, AccessShareLock);
 
 	return skipped;
 }
@@ -2467,20 +2470,24 @@ stmt_in_skipped_schema(Node *stmt)
 				((CreateStmt *) stmt)->relation);
 
 		case T_CreateTableAsStmt:
-			{
-				CreateTableAsStmt *ctas = (CreateTableAsStmt *) stmt;
-
-				return ctas->objtype == OBJECT_TABLE &&
-					rangevar_in_skipped_schema(ctas->into->rel);
-			}
+			/* Covers CREATE MATERIALIZED VIEW too (objtype OBJECT_MATVIEW). */
+			return rangevar_in_skipped_schema(
+				((CreateTableAsStmt *) stmt)->into->rel);
 
 		case T_AlterTableStmt:
-			{
-				AlterTableStmt *atstmt = (AlterTableStmt *) stmt;
+			/*
+			 * Covers ALTER INDEX/VIEW/MATERIALIZED VIEW/FOREIGN TABLE too;
+			 * for all of them ->relation names the target relation.
+			 */
+			return rangevar_in_skipped_schema(
+				((AlterTableStmt *) stmt)->relation);
 
-				return atstmt->objtype == OBJECT_TABLE &&
-					rangevar_in_skipped_schema(atstmt->relation);
-			}
+		case T_ViewStmt:
+			return rangevar_in_skipped_schema(((ViewStmt *) stmt)->view);
+
+		case T_CreateSeqStmt:
+			return rangevar_in_skipped_schema(
+				((CreateSeqStmt *) stmt)->sequence);
 
 		case T_IndexStmt:
 			return rangevar_in_skipped_schema(

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2416,6 +2416,125 @@ query_temp_like_source(const char *query)
 }
 
 /*
+ * Is the relation named by rv in a never-replicate schema?
+ *
+ * Runs after the DDL executed, so for CREATE/ALTER the relation exists and an
+ * unqualified name can be resolved by opening it.  A missing relation (e.g. a
+ * dropped one) can be classified only when the name is schema-qualified.
+ */
+static bool
+rangevar_in_skipped_schema(RangeVar *rv)
+{
+	Relation	rel;
+	bool		skipped;
+
+	if (rv == NULL)
+		return false;
+
+	if (rv->schemaname != NULL)
+		return spock_schema_is_skipped(rv->schemaname);
+
+	rel = table_openrv_extended(rv, AccessShareLock, true);
+	if (rel == NULL)
+		return false;
+	skipped = spock_schema_is_skipped(
+		get_namespace_name(RelationGetNamespace(rel)));
+	table_close(rel, AccessShareLock);
+
+	return skipped;
+}
+
+/*
+ * Does this DDL statement target only never-replicate schemas?  Such DDL is
+ * node-local and must not be queued.
+ *
+ * Only statement types whose target schema is identifiable are classified;
+ * anything else keeps replicating as before.  Known gap: dropping a
+ * never-replicate relation by an unqualified name cannot be classified here
+ * (the relation is already gone when this hook runs).
+ */
+static bool
+stmt_in_skipped_schema(Node *stmt)
+{
+	switch (nodeTag(stmt))
+	{
+		case T_CreateSchemaStmt:
+			return spock_schema_is_skipped(
+				((CreateSchemaStmt *) stmt)->schemaname);
+
+		case T_CreateStmt:
+			return rangevar_in_skipped_schema(
+				((CreateStmt *) stmt)->relation);
+
+		case T_CreateTableAsStmt:
+			{
+				CreateTableAsStmt *ctas = (CreateTableAsStmt *) stmt;
+
+				return ctas->objtype == OBJECT_TABLE &&
+					rangevar_in_skipped_schema(ctas->into->rel);
+			}
+
+		case T_AlterTableStmt:
+			{
+				AlterTableStmt *atstmt = (AlterTableStmt *) stmt;
+
+				return atstmt->objtype == OBJECT_TABLE &&
+					rangevar_in_skipped_schema(atstmt->relation);
+			}
+
+		case T_IndexStmt:
+			return rangevar_in_skipped_schema(
+				((IndexStmt *) stmt)->relation);
+
+		case T_DropStmt:
+			{
+				DropStmt   *drop = (DropStmt *) stmt;
+				ListCell   *cell;
+
+				if (drop->objects == NIL)
+					return false;
+
+				if (drop->removeType == OBJECT_SCHEMA)
+				{
+					foreach(cell, drop->objects)
+					{
+						if (!spock_schema_is_skipped(strVal(lfirst(cell))))
+							return false;
+					}
+					return true;
+				}
+
+				if (drop->removeType != OBJECT_TABLE &&
+					drop->removeType != OBJECT_INDEX &&
+					drop->removeType != OBJECT_SEQUENCE &&
+					drop->removeType != OBJECT_VIEW &&
+					drop->removeType != OBJECT_MATVIEW &&
+					drop->removeType != OBJECT_FOREIGN_TABLE)
+					return false;
+
+				/*
+				 * The relations are already dropped; only schema-qualified
+				 * names can be classified.  Suppress replication only when
+				 * every dropped object is in a never-replicate schema.
+				 */
+				foreach(cell, drop->objects)
+				{
+					RangeVar   *rv =
+						makeRangeVarFromNameList((List *) lfirst(cell));
+
+					if (rv->schemaname == NULL ||
+						!spock_schema_is_skipped(rv->schemaname))
+						return false;
+				}
+				return true;
+			}
+
+		default:
+			return false;
+	}
+}
+
+/*
  * spock_auto_replicate_ddl
  *
  * Add the DDL statement to the spock.queue table so it can
@@ -2450,6 +2569,14 @@ spock_auto_replicate_ddl(const char *query, List *replication_sets,
 
 		(void) get_replication_set_by_name(node->node->id, setname, false);
 	}
+
+	/*
+	 * DDL targeting only never-replicate schemas is node-local: skipping it
+	 * here also keeps the affected tables out of the replication sets (the
+	 * caller adds them only when we return true).
+	 */
+	if (stmt_in_skipped_schema(stmt))
+		goto skip_ddl;
 
 	/*
 	 * Filter local commands and decide on search path setting.

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -1343,6 +1343,15 @@ EnsureRelationNotIgnored(Relation rel)
 				 errhint("Move this relation to a schema allowed for replication")));
 	}
 
+	if (spock_schema_is_skipped(nspname))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("relation %s cannot be added to any replication set",
+						RelationGetRelationName(rel)),
+				 errdetail("schema %s is never replicated by this node",
+						   nspname),
+				 errhint("Move this relation to a schema allowed for replication")));
+
 	extoid = getExtensionOfObject(RelationRelationId, RelationGetRelid(rel));
 	if (!OidIsValid(extoid))
 		return;

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -113,18 +113,21 @@ typedef struct SubscriptionTuple
 #define Anum_sub_created_at			15
 
 /*
- * Schemas and extensions excluded from the structure-sync dump. Restoring
- * these on a subscriber that already has them fails, so keep them out of the
- * dump. Kept separate from the subscription-specific skip list to avoid cases
- * when user drops 'sub->skip_schema' and violates these restrictions.
+ * Schemas and extensions excluded from the structure-sync pg_dump only.
+ * Restoring these on a subscriber that already has them fails, so keep them
+ * out of the dump.  Unlike norepset_schema below, membership here does not
+ * prevent replication: lolor is dump-excluded but its tables must replicate
+ * so large objects survive a DROP EXTENSION on every node.  Kept separate
+ * from the subscription-specific skip list ('sub->skip_schema') so a user
+ * cannot drop these built-in exclusions.
  */
-const char *const skip_schema[] = {
+const char *const nodump_schema[] = {
 	"lolor",
 	"snowflake",
 	"spock",
 	NULL  /* sentinel */
 };
-const char *const skip_extension[] = {
+const char *const nodump_extension[] = {
 	"lolor",
 	"snowflake",
 	"spock",

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -161,12 +161,12 @@ build_exclude_extension_string(void)
 	char   *arg;
 	int		i;
 
-	for (i = 0; skip_extension[i] != NULL; i++)
+	for (i = 0; nodump_extension[i] != NULL; i++)
 	{
-		if (!OidIsValid(get_extension_oid(skip_extension[i], true)))
+		if (!OidIsValid(get_extension_oid(nodump_extension[i], true)))
 			continue;
 
-		arg = psprintf("--exclude-extension=%s", skip_extension[i]);
+		arg = psprintf("--exclude-extension=%s", nodump_extension[i]);
 		lst = lappend(lst, arg);
 	}
 	return lst;
@@ -181,12 +181,12 @@ build_exclude_schema_string(SpockSubscription *sub)
 	int			i;
 	ListCell   *lc;
 
-	for (i = 0; skip_schema[i] != NULL; i++)
+	for (i = 0; nodump_schema[i] != NULL; i++)
 	{
-		if (!OidIsValid(LookupExplicitNamespace(skip_schema[i], true)))
+		if (!OidIsValid(LookupExplicitNamespace(nodump_schema[i], true)))
 			continue;
 
-		arg = psprintf("--exclude-schema=%s", skip_schema[i]);
+		arg = psprintf("--exclude-schema=%s", nodump_schema[i]);
 		lst = lappend(lst, arg);
 	}
 

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -190,6 +190,20 @@ build_exclude_schema_string(SpockSubscription *sub)
 		lst = lappend(lst, arg);
 	}
 
+	/*
+	 * Schemas this node never replicates (spock_skip_schemas_list()).
+	 * Added unconditionally, unlike the nodump entries above: pg_dump
+	 * ignores exclude patterns that match nothing, and the schema may not
+	 * exist locally yet.
+	 */
+	foreach(lc, spock_skip_schemas_list())
+	{
+		const char *schema_name = (const char *) lfirst(lc);
+
+		arg = psprintf("--exclude-schema=%s", schema_name);
+		lst = lappend(lst, arg);
+	}
+
 	if (sub)
 	{
 		foreach(lc, sub->skip_schema)

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -50,6 +50,7 @@ test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
 test: 030_autoddl_repset_stickiness
 test: 032_lolor_largeobject_repset
+test: 033_skip_schemas
 test: 044_apply_change_logging
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match

--- a/tests/tap/t/033_skip_schemas.pl
+++ b/tests/tap/t/033_skip_schemas.pl
@@ -1,0 +1,91 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster get_test_config
+                 scalar_query psql_or_bail);
+
+# =============================================================================
+# Test: 033_skip_schemas.pl - built-in never-replicate schemas
+# =============================================================================
+# A node never replicates its built-in skip schemas (pgedge_ace).  This is
+# the ACE scenario: a tool using plain Postgres DDL must be able to create
+# and use node-local tables without those statements failing and without
+# anything leaking to peer nodes.  Exercised here:
+#   1. With AutoDDL on (this harness enables it), CREATE TABLE in pgedge_ace
+#      succeeds and is not auto-added to any replication set.
+#   2. repset_add_table refuses a pgedge_ace table.
+#   3. Structure sync excludes pgedge_ace.
+#   4. DDL against pgedge_ace does not replicate to a live subscriber (and
+#      does not disable the subscription by failing to apply there).
+# An ordinary public table must keep replicating throughout.
+
+create_cluster(2, 'Create 2-node skip-schemas test cluster');
+
+my $config    = get_test_config();
+my $ports     = $config->{node_ports};
+my $host      = $config->{host};
+my $dbname    = $config->{db_name};
+my $db_user   = $config->{db_user};
+my $db_pass   = $config->{db_password};
+my $pg_bin    = $config->{pg_bin};
+
+my $provider = $ports->[0];
+
+# Poll a scalar query on a node until it equals $want or we time out.
+sub wait_for {
+    my ($node, $sql, $want) = @_;
+    for (1 .. 100) {
+        return 1 if scalar_query($node, $sql) eq $want;
+        select(undef, undef, undef, 0.1);
+    }
+    return 0;
+}
+
+# --- 1. AutoDDL tolerates pgedge_ace (pre-subscription part). ----------------
+# The harness runs with spock.enable_ddl_replication=on and
+# spock.include_ddl_repset=on, so plain DDL below goes through AutoDDL.
+psql_or_bail(1, "CREATE SCHEMA pgedge_ace");
+psql_or_bail(1, "CREATE TABLE pgedge_ace.ace_state (id int primary key, v text)");
+psql_or_bail(1, "INSERT INTO pgedge_ace.ace_state VALUES (1, 'node-local')");
+is(scalar_query(1, "SELECT count(*) FROM spock.tables WHERE nspname = 'pgedge_ace' AND set_name IS NOT NULL"),
+   '0', 'AutoDDL did not add a pgedge_ace table to any repset');
+
+# --- 2. repset_add_table refuses a pgedge_ace table. -------------------------
+my $rc = system("$pg_bin/psql", '-q', '-v', 'ON_ERROR_STOP=1', '-p', $provider, '-d', $dbname, '-c',
+    "SELECT spock.repset_add_table('default', 'pgedge_ace.ace_state')");
+isnt($rc, 0, 'repset_add_table refuses a pgedge_ace table');
+
+# An ordinary table that must replicate throughout.
+psql_or_bail(1, "CREATE TABLE public.normal_tbl (id int primary key, v text)");
+psql_or_bail(1, "SELECT spock.repset_create('test_repset')");
+psql_or_bail(1, "SELECT spock.repset_add_table('test_repset', 'public.normal_tbl')");
+
+# Subscribe with structure + data sync, including the DDL repsets so AutoDDL
+# leakage would be visible on the subscriber.
+psql_or_bail(2, "SELECT spock.sub_create('sub1', 'host=$host port=$provider dbname=$dbname user=$db_user password=$db_pass', ARRAY['test_repset','default','default_insert_only','ddl_sql'], true, true)");
+psql_or_bail(2, "SELECT spock.sub_enable('sub1', true)");
+psql_or_bail(2, "SELECT spock.sub_wait_for_sync('sub1')");
+
+# --- 3. Structure sync skipped pgedge_ace. -----------------------------------
+is(scalar_query(2, "SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'pgedge_ace'"),
+   '0', 'structure sync skipped pgedge_ace on the subscriber');
+is(scalar_query(2, "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'normal_tbl'"),
+   '1', 'ordinary table still synced by structure sync');
+
+# --- 4. AutoDDL in pgedge_ace does not replicate (live subscription). --------
+psql_or_bail(1, "CREATE TABLE pgedge_ace.local_t (id int primary key)");
+is(scalar_query(1, "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'pgedge_ace' AND c.relname = 'local_t'"),
+   '1', 'CREATE TABLE in pgedge_ace succeeds with AutoDDL on');
+
+# Fence: once a replicated row arrives, any DDL queued before it would have
+# been applied (and would have failed on the subscriber, which lacks the
+# schema, disabling the subscription).
+psql_or_bail(1, "INSERT INTO public.normal_tbl VALUES (1, 'fence1')");
+ok(wait_for(2, "SELECT count(*) FROM public.normal_tbl WHERE id = 1", '1'),
+   'ordinary table replicates alongside pgedge_ace activity');
+is(scalar_query(2, "SELECT count(*) FROM information_schema.schemata WHERE schema_name = 'pgedge_ace'"),
+   '0', 'DDL against pgedge_ace did not replicate');
+
+destroy_cluster();
+done_testing();

--- a/tests/tap/t/033_skip_schemas.pl
+++ b/tests/tap/t/033_skip_schemas.pl
@@ -78,6 +78,21 @@ psql_or_bail(1, "CREATE TABLE pgedge_ace.local_t (id int primary key)");
 is(scalar_query(1, "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'pgedge_ace' AND c.relname = 'local_t'"),
    '1', 'CREATE TABLE in pgedge_ace succeeds with AutoDDL on');
 
+# Other relation kinds in pgedge_ace must also succeed locally and stay
+# local: matview/view/sequence creation and ALTER INDEX (classified via the
+# same code paths).
+psql_or_bail(1, "CREATE MATERIALIZED VIEW pgedge_ace.mv AS SELECT 1 AS x");
+psql_or_bail(1, "CREATE VIEW pgedge_ace.v AS SELECT 1 AS x");
+psql_or_bail(1, "CREATE SEQUENCE pgedge_ace.seq");
+psql_or_bail(1, "CREATE INDEX ace_state_v_idx ON pgedge_ace.ace_state (v)");
+psql_or_bail(1, "ALTER INDEX pgedge_ace.ace_state_v_idx SET (fillfactor = 90)");
+
+# Regression guard: an unqualified ALTER INDEX on an ordinary index must not
+# trip the classifier (it resolves the name by opening the relation, which
+# must tolerate non-table relkinds).
+psql_or_bail(1, "CREATE INDEX normal_tbl_v_idx ON public.normal_tbl (v)");
+psql_or_bail(1, "ALTER INDEX normal_tbl_v_idx SET (fillfactor = 90)");
+
 # Fence: once a replicated row arrives, any DDL queued before it would have
 # been applied (and would have failed on the subscriber, which lacks the
 # schema, disabling the subscription).


### PR DESCRIPTION
ACE keeps node-local state in the pgedge_ace schema using plain Postgres DDL, with no Spock awareness. On a cluster with default AutoDDL settings (spock.enable_ddl_replication=on, spock.include_ddl_repset=on), that breaks both ways:

- ACE's tables get auto-added to a replication set and their contents replicate to peers, or
- once excluded from replication sets, ACE's CREATE TABLE aborts outright on the automatic repset-add, and its DDL text replicates to peers that don't have the schema, failing on apply and (depending on spock.exception_behaviour) disabling the subscription.

A node-local tool must be able to create, modify, and drop its own tables without those statements failing and without anything leaking to peers.

What this PR does

Introduces a built-in never-replicate schema list (builtin_skip_schemas[] = pgedge_ace, exposed via spock_skip_schemas_list() / spock_schema_is_skipped()), enforced at every point where a table can enter replication:

1. AutoDDL — DDL whose identifiable target is a never-replicate schema is not queued for replication, and its tables are not auto-added to any replication set. The statement succeeds locally, silently.
2. Replication set membership — repset_add_table/repset_add_seq refuse relations in such a schema (EnsureRelationNotIgnored), covering repset_add_all_tables and per-partition adds.
3. Indirect repset routing — apply_repset_policy_for_reloid() skips such relations reached indirectly (e.g. a partition under a replicated parent).
4. Structure sync — --exclude-schema is passed unconditionally (pg_dump documents that exclude patterns matching nothing are not an error, and the schema may not exist on the subscriber yet).

No walsender/decode-path changes are needed: because these tables can never enter a replication set, the existing repset gating already suppresses everything — row changes via get_table_replication_info(), TRUNCATE via can_replicate_truncate().

A preparatory commit renames the skip_sys to
nodump_schema[]/nodump_extension[]: tho from the structure-sync dump and do not
prevent replication (lolor is dump-excl the old name collided with the
unrelated per-subscription sub->skip_scvisible names change.

Testing

New TAP test 033_skip_schemas.pl (added to the schedule), 2-node cluster with AutoDDL on:

- CREATE TABLE pgedge_ace.* succeeds an
- repset_add_table on a pgedge_ace tabl
- structure sync excludes pgedge_ace onles still sync)
- DDL against pgedge_ace after the subslicate and does not disable the
subscription (fence-row check)

001_basic, 002_create_subscriber, and 0pass unchanged.

Known limitations (documented in the fe

- A DROP of a never-replicate relation be classified after execution and still
replicates; schema-qualify drops.
- A statement mixing never-replicate an as before.
- Repset memberships that predate this . SET SCHEMA pgedge_ace on a replicated
table — keep replicating until removed SET SCHEMA semantics are tracked
separately.

Out of scope / follow-ups

- User definable custom skip schemas (ex: a future spock.skip_schemas)
- ALTER TABLE ... SET SCHEMA into/out oeparate ticket