### PR TITLE
Fix SUB_DISABLE reconnect retransmission

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -264,6 +264,7 @@ static void spock_apply_worker_attach(void);
 static void spock_apply_worker_detach(void);
 
 static bool should_log_exception(bool failed);
+static void clear_transient_exception_state_on_connection_loss(void);
 
 static ApplyReplayEntry * apply_replay_entry_create(int r, char *buf);
 static void apply_replay_entry_free(ApplyReplayEntry * entry);
@@ -359,6 +360,47 @@ should_log_exception(bool failed)
 	}
 
 	return false;
+}
+
+/*
+ * Forget the in-flight transaction marker after a transport failure on the
+ * normal apply path.
+ *
+ * handle_begin() records commit_lsn in shared memory before any changes are
+ * applied.  That marker normally lets a restarted worker recognize a
+ * transaction which failed during apply and replay it under the configured
+ * exception policy.  A provider disconnect is different: PostgreSQL aborts
+ * the local transaction and the replication origin is deliberately left at
+ * the last durable commit so the provider can send the transaction again.
+ *
+ * Leaving commit_lsn behind makes the replacement worker misclassify that
+ * retransmitted transaction as an apply failure.  In SUB_DISABLE mode it then
+ * performs a read-only exception replay and disables the subscription instead
+ * of applying the transaction.  Clear the marker only for a first-pass
+ * transport failure.  Genuine apply failures and failures during exception
+ * replay retain their state.
+ */
+static void
+clear_transient_exception_state_on_connection_loss(void)
+{
+	SpockExceptionLog *exception_log;
+
+	if (!in_remote_transaction ||
+		MyApplyWorker == NULL ||
+		MyApplyWorker->use_try_block ||
+		xact_had_exception ||
+		exception_log_ptr == NULL ||
+		my_exception_log_index < 0)
+		return;
+
+	exception_log = &exception_log_ptr[my_exception_log_index];
+	exception_log->commit_lsn = InvalidXLogRecPtr;
+	exception_log->local_tuple = NULL;
+	exception_log->initial_error_message[0] = '\0';
+	exception_log->failed_action = 0;
+
+	elog(DEBUG1, "SPOCK %s: cleared transient exception state after provider connection loss",
+		 MySubscription->name);
 }
 
 /*
@@ -3692,6 +3734,7 @@ stream_replay:
 			edata->sqlerrcode == ERRCODE_ADMIN_SHUTDOWN ||
 			(applyconn != NULL && PQstatus(applyconn) == CONNECTION_BAD))
 		{
+			clear_transient_exception_state_on_connection_loss();
 			elog(LOG, "SPOCK %s: connection error during apply, exiting via rethrow: %s",
 				 MySubscription->name, edata->message);
 			PG_RE_THROW();

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -57,3 +57,4 @@ test: 044_apply_change_logging
 
 # Regression tests
 test: 103_manager_worker_dboid_race
+test: 105_sub_disable_retransmit_after_disconnect

--- a/tests/tap/t/105_sub_disable_retransmit_after_disconnect.pl
+++ b/tests/tap/t/105_sub_disable_retransmit_after_disconnect.pl
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query psql_or_bail
+    wait_for_sub_status
+);
+
+# A connection-class error after BEGIN aborts the local transaction and makes
+# the provider retransmit it.  The exception marker recorded by handle_begin()
+# must not make the replacement worker treat that valid retransmission as
+# exception replay under SUB_DISABLE.
+
+create_cluster(2, 'Create 2-node reconnect retransmission test cluster');
+
+my $config = get_test_config();
+my $p1 = $config->{node_ports}->[0];
+my $p2 = $config->{node_ports}->[1];
+my $conn = "host=$config->{host} dbname=$config->{db_name} port=$p1 " .
+           "user=$config->{db_user} password=$config->{db_password}";
+my $subscriber_log = "$config->{log_dir}/00${p2}.log";
+
+psql_or_bail(2, "ALTER SYSTEM SET spock.exception_behaviour = sub_disable");
+psql_or_bail(2, "SELECT pg_reload_conf()");
+
+psql_or_bail(1, "CREATE TABLE reconnect_retransmit (id int PRIMARY KEY, val text)");
+psql_or_bail(2, "CREATE TABLE reconnect_retransmit (id int PRIMARY KEY, val text)");
+
+# Sequence increments are non-transactional, so SQLSTATE 08006 is raised only
+# on the first apply attempt.  ENABLE REPLICA restricts the trigger to apply.
+psql_or_bail(2, q{
+    CREATE SEQUENCE reconnect_fail_once;
+    CREATE FUNCTION reconnect_fail_once() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+        IF nextval('reconnect_fail_once') = 1 THEN
+            RAISE EXCEPTION 'injected provider connection loss'
+                USING ERRCODE = '08006';
+        END IF;
+        RETURN NEW;
+    END $$;
+    CREATE TRIGGER reconnect_fail_once_trg
+        BEFORE INSERT ON reconnect_retransmit
+        FOR EACH ROW EXECUTE FUNCTION reconnect_fail_once();
+    ALTER TABLE reconnect_retransmit
+        ENABLE REPLICA TRIGGER reconnect_fail_once_trg;
+});
+
+psql_or_bail(2,
+    "SELECT spock.sub_create('sub_n1_n2', '$conn', " .
+    "ARRAY['default', 'default_insert_only', 'ddl_sql'], false, false)");
+ok(wait_for_sub_status(2, 'sub_n1_n2', 'replicating', 30),
+    'subscription starts in replicating state');
+
+my $log_offset = -s $subscriber_log // 0;
+psql_or_bail(1, "INSERT INTO reconnect_retransmit VALUES (1, 'must survive reconnect')");
+
+my $applied = 0;
+for (1 .. 60) {
+    $applied = scalar_query(2,
+        "SELECT count(*) FROM reconnect_retransmit WHERE id = 1");
+    last if defined $applied && $applied eq '1';
+    sleep(1);
+}
+is($applied, '1', 'retransmitted transaction is applied after worker restart');
+
+is(scalar_query(2,
+       "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n1_n2'"),
+   't', 'SUB_DISABLE subscription remains enabled');
+ok(wait_for_sub_status(2, 'sub_n1_n2', 'replicating', 30),
+    'subscription returns to replicating state');
+is(scalar_query(2, "SELECT last_value FROM reconnect_fail_once"),
+   '2', 'replica trigger proves the transaction was attempted twice');
+
+my $new_log = '';
+if (open(my $lf, '<', $subscriber_log)) {
+    seek($lf, $log_offset, 0);
+    local $/;
+    $new_log = <$lf> // '';
+    close($lf);
+}
+
+like($new_log,
+     qr/cleared transient exception state after provider connection loss/,
+     'connection-loss path clears transient exception state');
+unlike($new_log,
+       qr/exception handling had no exception.*replay/,
+       'retransmission does not enter empty exception replay');
+
+destroy_cluster('Destroy reconnect retransmission test cluster');
+done_testing();

--- a/tests/tap/t/105_sub_disable_retransmit_after_disconnect.pl
+++ b/tests/tap/t/105_sub_disable_retransmit_after_disconnect.pl
@@ -85,8 +85,8 @@ like($new_log,
      qr/cleared transient exception state after provider connection loss/,
      'connection-loss path clears transient exception state');
 unlike($new_log,
-       qr/exception handling had no exception.*replay/,
-       'retransmission does not enter empty exception replay');
+       qr/Transaction failed, subscription will be disabled/,
+       'retransmission does not enter SUB_DISABLE exception replay');
 
 destroy_cluster('Destroy reconnect retransmission test cluster');
 done_testing();


### PR DESCRIPTION
## Summary

Fixes #520.

When a provider connection fails after `handle_begin()` records the incoming transaction's `commit_lsn`, the replacement apply worker can mistake the retransmitted transaction for exception replay. Under `spock.exception_behaviour = sub_disable`, that path can skip the transaction and later disable the subscription.

This change clears only the transient shared exception marker before rethrowing a first-pass connection-class error. It also adds a deterministic TAP regression that injects SQLSTATE `08006` once during replica apply and proves the retransmitted transaction is applied normally.

## Root cause

1. `handle_begin()` stores the remote transaction's `commit_lsn` in `exception_log_ptr` before applying changes.
2. A connection-class error aborts the local PostgreSQL transaction and exits the apply worker. Replication-origin progress correctly remains at the last durable commit, so the provider retransmits the transaction.
3. The shared `commit_lsn` survives the worker exit.
4. On reconnect, `handle_begin()` finds the same LSN and sets `use_try_block = true`, misclassifying transport recovery as exception replay.
5. In `SUB_DISABLE` mode, the worker uses read-only replay instead of normally reapplying the transaction.

The unpatched 5.0.10 reproduction described in #520 commits the source row but leaves the subscriber row count at zero. A SIGKILL reproduction with a 16 MiB transaction applied `0/512` rows without the cleanup and `512/512` with it.

## Fix safety

`clear_transient_exception_state_on_connection_loss()` returns without changing state unless all of the following are true:

- a remote transaction is in flight;
- the apply worker and exception slot are valid;
- this is the normal first-pass apply path (`use_try_block == false`); and
- no genuine apply exception has been recorded (`xact_had_exception == false`).

Therefore genuine DML apply failures and failures during exception replay retain their state and continue through the configured exception policy.

## Regression coverage

The new TAP test:

1. configures `spock.exception_behaviour = sub_disable`;
2. uses an `ENABLE REPLICA` trigger and a non-transactional sequence to raise SQLSTATE `08006` only on the first apply attempt;
3. verifies the transaction is attempted twice and reaches the subscriber;
4. verifies the subscription remains enabled and returns to `replicating`; and
5. verifies the transient-state cleanup log is present and empty exception replay is absent.

## Validation

- `git diff --check` — passed.
- The patched 5.0.10 reproducer reported in #520 passed five consecutive runs.
- PostgreSQL 16 Docker compile and install from this exact PR checkout — passed (`make -j4`; `make install with_llvm=no`).
- Targeted Docker TAP command — passed five consecutive runs, with all 13 assertions passing each time:

  ```shell
  env PROVE_TESTS="t/105_sub_disable_retransmit_after_disconnect.pl" make check_prove
  ```

  Each run proved that the transaction was attempted twice, reached the subscriber, left the subscription enabled and replicating, logged transient-state cleanup, and did not emit the real SUB_DISABLE replay message.

## Feedback requested

- Is clearing the subscription-owned shared exception slot in the connection-error branch the preferred ownership boundary?
- Should this cleanup be folded into an existing exception-state reset helper instead?
- Is the deterministic SQLSTATE `08006` injection suitable for the regular TAP schedule, or should it be kept as a targeted/nightly regression?

