### PR TITLE
Pin CI PostgreSQL 19 builds to release tags instead of branch tip.

### DIFF
--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -63,6 +63,17 @@
 #define WORKER_NAP_TIME 60000L
 #define WORKER_WAIT_FEEDBACK 10000L
 
+/*
+ * PostgreSQL 19 replaced ReplicationSlot.active_pid (an int pid, 0 when the
+ * slot is unused) with active_proc (a ProcNumber, INVALID_PROC_NUMBER when
+ * unused).  SlotIsActive() hides that difference.
+ */
+#if PG_VERSION_NUM >= 190000
+#define SlotIsActive(s) ((s)->active_proc != INVALID_PROC_NUMBER)
+#else
+#define SlotIsActive(s) ((s)->active_pid != 0)
+#endif
+
 typedef struct RemoteSlot
 {
 	char	   *name;
@@ -1083,7 +1094,7 @@ synchronize_failover_slots(long sleep_time)
 			bool		active;
 			bool		found = false;
 
-			active = (s->active_pid != 0);
+			active = SlotIsActive(s);
 
 			/* Only check inactive slots. */
 			if (!s->in_use || active)
@@ -1688,7 +1699,7 @@ spock_slot_enable_failover(PG_FUNCTION_ARGS)
 		if (s->data.invalidated != RS_INVAL_NONE)
 			continue;
 		/* skip slots held by a walsender so we never block the upgrade */
-		if (s->active_pid != 0)
+		if (SlotIsActive(s))
 		{
 			ereport(NOTICE,
 					(errmsg("spock: replication slot \"%s\" is active; "

--- a/tests/docker/Dockerfile-step-1.el9
+++ b/tests/docker/Dockerfile-step-1.el9
@@ -127,24 +127,21 @@ WORKDIR /home/pgedge
 # Clone PostgreSQL Source
 # ==============================================================================
 
-# Determine the PostgreSQL source ref for the requested major version.
-# Normally the latest stable *tag* (REL_${PGVER}_x).  PostgreSQL 19 has no GA
-# tag yet, so temporarily track the tip of REL_19_STABLE instead; revert to
-# tag resolution once PG19 ships a GA release.
+# Determine the PostgreSQL source ref for the requested major version:
+# the latest REL_${PGVER}_* tag.  Version sort places BETA/RC tags before
+# numeric point releases, so a pre-GA major resolves to its newest beta/RC
+# tag (currently REL_19_BETA1 for PG19) and switches to GA point releases
+# automatically once they are tagged.  Building from a tag instead of a
+# branch tip keeps CI reproducible between runs.
 RUN set -eux && \
-	if [ "${PGVER}" -ge 19 ]; then \
-		PG_REF="REL_${PGVER}_STABLE"; \
-		echo "Cloning PostgreSQL branch HEAD (pre-GA): ${PG_REF}"; \
-	else \
-		PG_REF=$(git ls-remote --tags https://github.com/postgres/postgres.git | \
-		grep "refs/tags/REL_${PGVER}_" | \
-		sed 's|.*refs/tags/||' | \
-		tr '_' '.' | \
-		sort -V | \
-		tail -n 1 | \
-		tr '.' '_'); \
-		echo "Cloning PostgreSQL tag: ${PG_REF}"; \
-	fi && \
+	PG_REF=$(git ls-remote --tags https://github.com/postgres/postgres.git | \
+	grep "refs/tags/REL_${PGVER}_" | \
+	sed 's|.*refs/tags/||' | \
+	tr '_' '.' | \
+	sort -V | \
+	tail -n 1 | \
+	tr '.' '_') && \
+	echo "Cloning PostgreSQL tag: ${PG_REF}" && \
 	git clone --branch "${PG_REF}" --depth 1 \
 	https://github.com/postgres/postgres.git /home/pgedge/postgres && \
 	echo "export PG_SRCDIR=/home/pgedge/postgres" >> /home/pgedge/.bashrc


### PR DESCRIPTION
Resolve the newest REL_19_* tag (currently REL_19_BETA1) like the other majors rather than tracking REL_19_STABLE, so CI runs are reproducible. GA point releases will win the version sort automatically once tagged.