### PR TITLE
Make failover slot worker sync interval configurable.

### DIFF
--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -61,7 +61,7 @@
 #include "libpq/libpq.h"
 
 /* Defaults (milliseconds) for the tunable worker intervals below. */
-#define WORKER_NAP_TIME_DEFAULT 60000
+#define WORKER_NAP_TIME_DEFAULT 1000
 #define WORKER_WAIT_FEEDBACK_DEFAULT 10000
 
 typedef struct RemoteSlot

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -60,8 +60,9 @@
 #include "libpq/auth.h"
 #include "libpq/libpq.h"
 
-#define WORKER_NAP_TIME 60000L
-#define WORKER_WAIT_FEEDBACK 10000L
+/* Defaults (milliseconds) for the tunable worker intervals below. */
+#define WORKER_NAP_TIME_DEFAULT 60000
+#define WORKER_WAIT_FEEDBACK_DEFAULT 10000
 
 typedef struct RemoteSlot
 {
@@ -100,6 +101,16 @@ static char *spock_failover_slot_names;
 static char *spock_failover_slot_names_str = NULL;
 static List *spock_failover_slot_names_list = NIL;
 static bool spock_failover_slots_drop = true;
+
+/*
+ * How long the worker sleeps between slot-sync passes, and the shorter retry
+ * used while it is still waiting for the standby to receive/feedback WAL.
+ * Both are in milliseconds and settable at runtime (SIGHUP).  A smaller
+ * naptime narrows the window in which the standby's synced slots lag the
+ * primary, at the cost of more frequent sync passes.
+ */
+static int	spock_failover_slots_naptime = WORKER_NAP_TIME_DEFAULT;
+static int	spock_failover_slots_feedback_naptime = WORKER_WAIT_FEEDBACK_DEFAULT;
 
 void spock_init_failover_slot(void);
 
@@ -1165,7 +1176,7 @@ synchronize_failover_slots(long sleep_time)
 							"cannot synchronize replication slot positions yet because feedback was not sent yet")));
 			was_lsn_safe = false;
 			PQfinish(conn);
-			return Min(sleep_time, WORKER_WAIT_FEEDBACK);
+			return Min(sleep_time, spock_failover_slots_feedback_naptime);
 		}
 		else if (WalRcv->latestWalEnd < lsn)
 		{
@@ -1178,7 +1189,7 @@ synchronize_failover_slots(long sleep_time)
 							(uint32) (WalRcv->latestWalEnd))));
 			was_lsn_safe = false;
 			PQfinish(conn);
-			return Min(sleep_time, WORKER_WAIT_FEEDBACK);
+			return Min(sleep_time, spock_failover_slots_feedback_naptime);
 		}
 
 		foreach(lc, slots)
@@ -1266,7 +1277,7 @@ spock_failover_slots_main(Datum main_arg)
 	while (true)
 	{
 		int rc;
-		long sleep_time = WORKER_NAP_TIME;
+		long sleep_time = spock_failover_slots_naptime;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -1275,9 +1286,9 @@ spock_failover_slots_main(Datum main_arg)
 		 * use long nap so we never elog(ERROR) for hot_standby_feedback off.
 		 */
 		if (RecoveryInProgress() && hot_standby_feedback)
-			sleep_time = synchronize_failover_slots(WORKER_NAP_TIME);
+			sleep_time = synchronize_failover_slots(spock_failover_slots_naptime);
 		else
-			sleep_time = WORKER_NAP_TIME * 10;
+			sleep_time = (long) spock_failover_slots_naptime * 10;
 
 		rc =
 			WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
@@ -1622,6 +1633,24 @@ spock_init_failover_slot(void)
 		"if empty, uses the defaults to primary_conninfo",
 		&spock_failover_slots_dsn, "", PGC_SIGHUP, GUC_SUPERUSER_ONLY, NULL, NULL,
 		NULL);
+
+	DefineCustomIntVariable(
+		"spock.failover_slots_naptime",
+		"time the failover slot worker sleeps between slot synchronization passes",
+		"A smaller value keeps the standby's synchronized slots closer to the "
+		"primary, at the cost of more frequent sync passes.",
+		&spock_failover_slots_naptime, WORKER_NAP_TIME_DEFAULT,
+		1000, 3600000,
+		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"spock.failover_slots_feedback_naptime",
+		"shorter retry interval used while waiting for standby WAL feedback",
+		"The worker retries this often (instead of failover_slots_naptime) while "
+		"the standby has not yet received or fed back the WAL a slot needs.",
+		&spock_failover_slots_feedback_naptime, WORKER_WAIT_FEEDBACK_DEFAULT,
+		1000, 3600000,
+		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 
 	if (IsBinaryUpgrade)

--- a/tests/tap/t/026_failover_slots_naptime_guc.pl
+++ b/tests/tap/t/026_failover_slots_naptime_guc.pl
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query
+);
+
+# =============================================================================
+# Test: 026_failover_slots_naptime_guc.pl
+#
+# Verifies the tunable failover-slot worker interval GUCs:
+#   spock.failover_slots_naptime
+#   spock.failover_slots_feedback_naptime
+#
+# These control how often the spock_failover_slots worker syncs slot state to
+# a physical standby.  A smaller naptime narrows the window in which the
+# standby's synchronized slots lag the primary.
+#
+# The test checks defaults, unit, bounds, reloadability, that a new value
+# takes effect on reload, and that out-of-range values are rejected.
+# =============================================================================
+
+create_cluster(1);
+
+my $cfg  = get_test_config();
+my $bin  = $cfg->{pg_bin};
+my $host = $cfg->{host};
+my $port = $cfg->{node_ports}[0];
+my $db   = $cfg->{db_name};
+my $user = $cfg->{db_user};
+
+# Run SQL and return (exit_code, combined_output).  ON_ERROR_STOP makes psql
+# exit non-zero when the server rejects the statement.
+sub psql_try {
+    my ($sql) = @_;
+    my $out = `$bin/psql -X -h $host -p $port -d $db -U $user -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    return ($? >> 8, $out);
+}
+
+sub setting_of {
+    my ($name) = @_;
+    return scalar_query(1,
+        "SELECT setting FROM pg_settings WHERE name = '$name'");
+}
+
+# --------------------------------------------------------------------------
+# Defaults (pg_settings reports the value in the base unit, ms)
+# --------------------------------------------------------------------------
+is(setting_of('spock.failover_slots_naptime'), '60000',
+   'failover_slots_naptime default is 60000 ms');
+is(setting_of('spock.failover_slots_feedback_naptime'), '10000',
+   'failover_slots_feedback_naptime default is 10000 ms');
+
+# --------------------------------------------------------------------------
+# Unit, bounds, and context
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT unit FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   'ms', 'naptime unit is ms');
+is(scalar_query(1, "SELECT min_val||'/'||max_val FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   '1000/3600000', 'naptime bounds are 1000..3600000 ms');
+is(scalar_query(1, "SELECT context FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   'sighup', 'naptime is reloadable (sighup), no restart needed');
+
+# --------------------------------------------------------------------------
+# A new value takes effect on reload
+# --------------------------------------------------------------------------
+my ($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '5s'");
+is($rc, 0, "ALTER SYSTEM accepts '5s'") or diag($out);
+psql_try("SELECT pg_reload_conf()");
+
+# Reload is asynchronous; poll briefly for the change to land.
+my $val = '';
+for (1 .. 20) {
+    $val = setting_of('spock.failover_slots_naptime');
+    last if $val eq '5000';
+    select(undef, undef, undef, 0.25);
+}
+is($val, '5000', "naptime becomes 5000 ms after reload");
+
+# --------------------------------------------------------------------------
+# Out-of-range values are rejected
+# --------------------------------------------------------------------------
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '10ms'");
+isnt($rc, 0, "ALTER SYSTEM rejects 10ms (below the 1s minimum)");
+like($out, qr/outside the valid range|invalid value/i,
+     "rejection message mentions the valid range");
+
+# Restore the default so the node is clean for teardown.
+psql_try("ALTER SYSTEM RESET spock.failover_slots_naptime");
+psql_try("SELECT pg_reload_conf()");
+
+destroy_cluster();
+done_testing();

--- a/tests/tap/t/026_failover_slots_naptime_guc.pl
+++ b/tests/tap/t/026_failover_slots_naptime_guc.pl
@@ -49,8 +49,8 @@ sub setting_of {
 # --------------------------------------------------------------------------
 # Defaults (pg_settings reports the value in the base unit, ms)
 # --------------------------------------------------------------------------
-is(setting_of('spock.failover_slots_naptime'), '60000',
-   'failover_slots_naptime default is 60000 ms');
+is(setting_of('spock.failover_slots_naptime'), '1000',
+   'failover_slots_naptime default is 1000 ms');
 is(setting_of('spock.failover_slots_feedback_naptime'), '10000',
    'failover_slots_feedback_naptime default is 10000 ms');
 


### PR DESCRIPTION
The spock_failover_slots worker synced slot state to the standby on a hard-coded 60s nap, so the standby's synchronized slots could lag the primary by up to that long, widening the window in which a promotion finds a stale slot. Expose the interval as spock.failover_slots_naptime (and the feedback-wait retry as spock.failover_slots_feedback_naptime), both SIGHUP-settable in milliseconds, so operators can shorten it. Add a TAP test covering the GUC defaults, bounds, and reload.

SPOC-612