### PR TITLE
spock_sync: always exclude pgedge_ace schema from node sync

### DIFF
--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -164,7 +164,6 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 	char		pg_dump[MAXPGPATH];
 	char	   *cmdargv[20];
 	int			cmdargc = 0;
-	bool		has_spk_origin;
 	bool		has_snowflake;
 	StringInfoData	s;
 
@@ -194,19 +193,20 @@ dump_structure(SpockSubscription *sub, const char *destfile,
 	cmdargv[cmdargc++] = pstrdup(s.data);
 	resetStringInfo(&s);
 
-	/* Skip the spock_origin and snowflake if it exists locally. */
+	/*
+	 * Always exclude the pgedge_ace schema. ACE state is node-local, so a
+	 * joining node must never inherit the source's ACE objects, whether or not
+	 * it already has a pgedge_ace schema of its own.
+	 */
+	appendStringInfo(&s, "--exclude-schema=%s", "pgedge_ace");
+	cmdargv[cmdargc++] = pstrdup(s.data);
+	resetStringInfo(&s);
+
+	/* Skip snowflake if it exists locally. */
 	StartTransactionCommand();
-	has_spk_origin = OidIsValid(LookupExplicitNamespace("spock_origin",
-														true));
 	has_snowflake = OidIsValid(LookupExplicitNamespace("snowflake",
 														true));
 	CommitTransactionCommand();
-	if (has_spk_origin)
-	{
-		appendStringInfo(&s, "--exclude-schema=%s", "spock_origin");
-		cmdargv[cmdargc++] = pstrdup(s.data);
-		resetStringInfo(&s);
-	}
 
 	if (has_snowflake)
 	{
@@ -918,8 +918,14 @@ copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 	tables = spock_get_remote_repset_tables(origin_conn,
 												 replication_sets);
 
-	/* Filter out tables from schemas that should be skipped */
-	if (sub->skip_schema && list_length(sub->skip_schema) > 0)
+	/*
+	 * Filter out tables that must not be data-synced:
+	 *   - the pgedge_ace schema is always excluded, mirroring the
+	 *     structure-sync exclusion in dump_structure(); ACE state is
+	 *     node-local, so its tables are never copied to a joining node even
+	 *     when they are members of a replication set.
+	 *   - any schema listed in the subscription's skip_schema.
+	 */
 	{
 		List	   *filtered_tables = NIL;
 		ListCell   *lc_filter;
@@ -927,17 +933,25 @@ copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 		foreach (lc_filter, tables)
 		{
 			SpockRemoteRel	*remoterel = lfirst(lc_filter);
-			ListCell   *lc_skip;
 			bool		skip_table = false;
 
-			/* Check if this table's schema should be skipped */
-			foreach (lc_skip, sub->skip_schema)
+			/* Always skip the pgedge_ace schema. */
+			if (strcmp(remoterel->nspname, "pgedge_ace") == 0)
+				skip_table = true;
+
+			/* Check if this table's schema is in the skip_schema list. */
+			if (!skip_table && sub->skip_schema)
 			{
-				char	   *skip_schema_name = (char *) lfirst(lc_skip);
-				if (strcmp(remoterel->nspname, skip_schema_name) == 0)
+				ListCell   *lc_skip;
+
+				foreach (lc_skip, sub->skip_schema)
 				{
-					skip_table = true;
-					break;
+					char	   *skip_schema_name = (char *) lfirst(lc_skip);
+					if (strcmp(remoterel->nspname, skip_schema_name) == 0)
+					{
+						skip_table = true;
+						break;
+					}
 				}
 			}
 

--- a/tests/tap/t/009_zodan_add_remove_nodes.pl
+++ b/tests/tap/t/009_zodan_add_remove_nodes.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 40;  # Fixed test count to match actual tests
+use Test::More tests => 43;  # Fixed test count to match actual tests
 use lib '.';
 use lib 't';
 use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe);
@@ -88,6 +88,21 @@ if ($data_on_n2 eq '3') {
 } else {
     fail("Data replication failed: expected 3 rows, got $data_on_n2");
 }
+
+# Step 2b: Create a pgedge_ace schema with a table on n1.
+#
+# spock excludes the pgedge_ace schema from the schema-sync pg_dump when a new
+# node joins (see --exclude-schema=pgedge_ace in src/spock_sync.c). Create the
+# schema and table here, BEFORE n3 exists or subscribes, so the only path by
+# which n3 could acquire it is the add_node schema copy. This isolates the
+# exclusion logic from DDL replication.
+system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "
+    CREATE SCHEMA pgedge_ace;
+    CREATE TABLE pgedge_ace.ace_meta (id INTEGER PRIMARY KEY, note TEXT);
+    INSERT INTO pgedge_ace.ace_meta VALUES (1, 'alpha'), (2, 'beta');
+";
+
+pass('Created pgedge_ace schema and table on n1');
 
 # Step 3: Create n3 database instance
 pass('Creating n3 database instance');
@@ -310,6 +325,26 @@ if ($table_exists_n3 eq 't') {
     }
 } else {
     fail('Test table does not exist on n3');
+}
+
+# Verify the pgedge_ace schema was NOT copied to n3 by add_node.
+# spock's schema-sync pg_dump uses --exclude-schema=pgedge_ace, so neither the
+# schema nor its tables should exist on the joining node.
+my $ace_schema_on_n3 = `$pg_bin/psql -p $n3_port -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgedge_ace')"`;
+chomp($ace_schema_on_n3);
+$ace_schema_on_n3 =~ s/\s+//g;
+if ($ace_schema_on_n3 eq 'f') {
+    pass('pgedge_ace schema was not copied to n3 (excluded from add_node sync)');
+} else {
+    fail('pgedge_ace schema exists on n3 but should have been excluded from add_node sync');
+}
+
+# Explicit control: the public-schema table copied to n3 while pgedge_ace did
+# not. This confirms the exclusion is targeted, not a wholesale sync failure.
+if ($table_exists_n3 eq 't' && $ace_schema_on_n3 eq 'f') {
+    pass('Exclusion is targeted: public test table copied, pgedge_ace did not');
+} else {
+    fail("Unexpected sync result on n3: test_zodan_table exists=$table_exists_n3, pgedge_ace exists=$ace_schema_on_n3");
 }
 
 # Verify n3 has subscriptions that reference the default replication sets


### PR DESCRIPTION
ACE state is node-local and must never be copied to a joining node. Exclude pgedge_ace unconditionally from both the structure dump and the data-sync table list (repset membership no longer drags its tables in). Drop the dead spock_origin exclusion while here.

Add coverage in 009 tap test: a pgedge_ace table on the source is not copied to the new node, while a public table still is.