### PR TITLE
Make the set of reserved schemas and extensions configurable.

### DIFF
--- a/docs/spock_functions/repset_mgmt.md
+++ b/docs/spock_functions/repset_mgmt.md
@@ -96,19 +96,36 @@ source of truth for two behaviours:
   that already has them would fail.
 - `block_in_repset`: a table in this schema, or belonging to this extension,
   may not be added to a replication set.
+- `replicate_ddl`: applies to schemas only. When `false`, AutoDDL does not
+  ship DDL that targets only this schema to other nodes -- the schema is
+  node-local. It is not meaningful for extensions, so it is required for
+  `schema` rows and is `NULL` for `extension` rows (a `CHECK` enforces this,
+  and `reserved_object_add` sets it to `NULL` automatically for an extension).
 
 Spock seeds the following built-in rows, and they cannot be removed or
 modified:
 
-| Object            | exclude_from_dump | block_in_repset |
-|-------------------|-------------------|-----------------|
-| `spock`           | yes               | yes             |
-| `snowflake`       | yes               | yes             |
-| `lolor`           | yes               | no              |
+| Object            | exclude_from_dump | block_in_repset | replicate_ddl |
+|-------------------|-------------------|-----------------|---------------|
+| `spock`           | yes               | yes             | yes           |
+| `snowflake`       | yes               | yes             | yes           |
+| `lolor`           | yes               | no              | yes           |
+| `pgedge_ace` (schema only) | yes      | yes             | no            |
+
+`spock`, `snowflake`, and `lolor` each have both a `schema` and an
+`extension` row. The `replicate_ddl` column above is the value on the
+`schema` row; the `extension` row carries `replicate_ddl = NULL` (not
+applicable), while `exclude_from_dump`/`block_in_repset` apply to both.
 
 `lolor` is excluded from the dump but is intentionally allowed in replication
 sets: its tables must replicate so that large objects survive a
 `DROP EXTENSION` on every node, not only where the drop was issued.
+
+`pgedge_ace` is the schema used by the pgEdge ACE utility. It is node-local
+configuration/state, not application data: its DDL is never shipped to other
+nodes (`replicate_ddl=no`), and its tables can never be added to a
+replication set, so `CREATE SCHEMA pgedge_ace` and DDL/tables underneath it
+stay local to the node where they were issued.
 
 To reserve an additional schema or extension of your own, use
 `spock.reserved_object_add`:
@@ -119,6 +136,9 @@ SELECT spock.reserved_object_add('ace', 'schema');
 
 -- exclude an extension from the dump but still allow its tables in repsets
 SELECT spock.reserved_object_add('myext', 'extension', p_block_in_repset := false);
+
+-- keep a custom schema node-local: AutoDDL will not replicate its DDL
+SELECT spock.reserved_object_add('myschema', 'schema', p_replicate_ddl := false);
 ```
 
 Use `spock.reserved_object_remove('ace', 'schema')` to drop your own entry.
@@ -343,7 +363,8 @@ object is already reserved, its flags are updated. Built-in objects cannot be
 changed.
 
 `spock.reserved_object_add(p_name name, p_kind text, p_exclude_from_dump bool
-DEFAULT true, p_block_in_repset bool DEFAULT true)`
+DEFAULT true, p_block_in_repset bool DEFAULT true, p_replicate_ddl bool
+DEFAULT NULL)`
 
 Parameters:
 
@@ -353,6 +374,11 @@ Parameters:
   default is `true`.
 - `p_block_in_repset` blocks the object from replication sets; the default is
   `true`.
+- `p_replicate_ddl` applies to schemas only. For a schema, leaving it unset
+  (`NULL`) defaults to `true`; pass `false` to keep the schema node-local so
+  AutoDDL does not ship its DDL to other nodes (as `pgedge_ace` is). For
+  `p_kind = 'extension'` the argument is ignored and the value is stored as
+  `NULL`.
 
 ### spock.reserved_object_remove
 

--- a/docs/spock_functions/repset_mgmt.md
+++ b/docs/spock_functions/repset_mgmt.md
@@ -89,18 +89,27 @@ columns are specified, all columns will be replicated.
 
 Some schemas and extensions are reserved and are treated specially by Spock.
 They are listed in the `spock.reserved_object` catalog, which is the single
-source of truth for two behaviours:
+source of truth for three behaviours:
 
 - `exclude_from_dump`: the object is left out of the structure-sync dump used
   when a subscription synchronizes structure. Restoring these on a subscriber
   that already has them would fail.
 - `block_in_repset`: a table in this schema, or belonging to this extension,
   may not be added to a replication set.
-- `replicate_ddl`: applies to schemas only. When `false`, AutoDDL does not
-  ship DDL that targets only this schema to other nodes -- the schema is
-  node-local. It is not meaningful for extensions, so it is required for
+- `replicate_ddl`: applies to schemas only. When `false`, AutoDDL keeps DDL
+  targeting this schema node-local -- it runs where issued but is not shipped
+  to other nodes. It is not meaningful for extensions, so it is required for
   `schema` rows and is `NULL` for `extension` rows (a `CHECK` enforces this,
   and `reserved_object_add` sets it to `NULL` automatically for an extension).
+
+  Only DDL whose target schema Spock can identify is kept local: `CREATE`
+  `SCHEMA`/`TABLE`/`TABLE AS`/`SEQUENCE`/`VIEW`/`INDEX`, `ALTER TABLE`, and
+  `DROP` of those object kinds. Other DDL against the schema (for example
+  `GRANT`, `COMMENT`, `TRUNCATE`, or `ALTER ... SET SCHEMA`) is not classified
+  and replicates as usual. A single `DROP` is kept local only when *every*
+  object it names is node-local; do not mix a node-local object and a
+  replicated one in one `DROP`, as the shipped command cannot be rewritten to
+  drop only the replicated object.
 
 Spock seeds the following built-in rows, and they cannot be removed or
 modified:
@@ -122,10 +131,11 @@ sets: its tables must replicate so that large objects survive a
 `DROP EXTENSION` on every node, not only where the drop was issued.
 
 `pgedge_ace` is the schema used by the pgEdge ACE utility. It is node-local
-configuration/state, not application data: its DDL is never shipped to other
-nodes (`replicate_ddl=no`), and its tables can never be added to a
-replication set, so `CREATE SCHEMA pgedge_ace` and DDL/tables underneath it
-stay local to the node where they were issued.
+configuration/state, not application data: its DDL is kept local for the
+classified statement kinds above (`replicate_ddl=no`), and its tables can
+never be added to a replication set (`block_in_repset=yes`), so
+`CREATE SCHEMA pgedge_ace` and the tables underneath it stay local to the
+node where they were issued.
 
 To reserve an additional schema or extension of your own, use
 `spock.reserved_object_add`:

--- a/docs/spock_functions/repset_mgmt.md
+++ b/docs/spock_functions/repset_mgmt.md
@@ -114,12 +114,12 @@ source of truth for three behaviours:
 Spock seeds the following built-in rows, and they cannot be removed or
 modified:
 
-| Object            | exclude_from_dump | block_in_repset | replicate_ddl |
-|-------------------|-------------------|-----------------|---------------|
-| `spock`           | yes               | yes             | yes           |
-| `snowflake`       | yes               | yes             | yes           |
-| `lolor`           | yes               | no              | yes           |
-| `pgedge_ace` (schema only) | yes      | yes             | no            |
+| Object            | exclude_from_dump | block_in_repset | replicate_ddl
+|-------------------|-------------------|-----------------|---------------
+| `spock`           | yes               | yes             | yes
+| `snowflake`       | yes               | yes             | yes
+| `lolor`           | yes               | no              | yes
+| `pgedge_ace` (schema only) | yes      | yes             | no
 
 `spock`, `snowflake`, and `lolor` each have both a `schema` and an
 `extension` row. The `replicate_ddl` column above is the value on the

--- a/docs/spock_functions/repset_mgmt.md
+++ b/docs/spock_functions/repset_mgmt.md
@@ -85,6 +85,47 @@ SELECT spock.repset_add_table('accts', 'payables');
 Adds a table named `payables` to a replication set named `accts`. Since no
 columns are specified, all columns will be replicated.
 
+## Reserved Schemas and Extensions
+
+Some schemas and extensions are reserved and are treated specially by Spock.
+They are listed in the `spock.reserved_object` catalog, which is the single
+source of truth for two behaviours:
+
+- `exclude_from_dump`: the object is left out of the structure-sync dump used
+  when a subscription synchronizes structure. Restoring these on a subscriber
+  that already has them would fail.
+- `block_in_repset`: a table in this schema, or belonging to this extension,
+  may not be added to a replication set.
+
+Spock seeds the following built-in rows, and they cannot be removed or
+modified:
+
+| Object            | exclude_from_dump | block_in_repset |
+|-------------------|-------------------|-----------------|
+| `spock`           | yes               | yes             |
+| `snowflake`       | yes               | yes             |
+| `lolor`           | yes               | no              |
+
+`lolor` is excluded from the dump but is intentionally allowed in replication
+sets: its tables must replicate so that large objects survive a
+`DROP EXTENSION` on every node, not only where the drop was issued.
+
+To reserve an additional schema or extension of your own, use
+`spock.reserved_object_add`:
+
+```sql
+-- keep a custom schema out of structure sync and out of replication sets
+SELECT spock.reserved_object_add('ace', 'schema');
+
+-- exclude an extension from the dump but still allow its tables in repsets
+SELECT spock.reserved_object_add('myext', 'extension', p_block_in_repset := false);
+```
+
+Use `spock.reserved_object_remove('ace', 'schema')` to drop your own entry.
+Reserved objects are node-local configuration: apply the same additions on
+each node of the cluster. Operator-added rows are preserved across
+`pg_dump`/`pg_restore`; the built-in rows are always re-seeded.
+
 ## Removing a Table from a Replication Set
 
 To remove a table from a replication set with Spock, connect to the server
@@ -293,3 +334,34 @@ Parameters:
 
 - `subscription_name` is the name of an existing subscription.
 - `replication_set` is the name of replication set to remove.
+
+### spock.reserved_object_add
+
+Use `spock.reserved_object_add` to reserve a schema or extension (see
+[Reserved Schemas and Extensions](#reserved-schemas-and-extensions)). If the
+object is already reserved, its flags are updated. Built-in objects cannot be
+changed.
+
+`spock.reserved_object_add(p_name name, p_kind text, p_exclude_from_dump bool
+DEFAULT true, p_block_in_repset bool DEFAULT true)`
+
+Parameters:
+
+- `p_name` is the schema or extension name.
+- `p_kind` is `'schema'` or `'extension'`.
+- `p_exclude_from_dump` keeps the object out of the structure-sync dump; the
+  default is `true`.
+- `p_block_in_repset` blocks the object from replication sets; the default is
+  `true`.
+
+### spock.reserved_object_remove
+
+Use `spock.reserved_object_remove` to remove one of your own reserved objects.
+Built-in objects are protected and cannot be removed.
+
+`spock.reserved_object_remove(p_name name, p_kind text)`
+
+Parameters:
+
+- `p_name` is the schema or extension name.
+- `p_kind` is `'schema'` or `'extension'`.

--- a/include/spock.h
+++ b/include/spock.h
@@ -155,6 +155,7 @@ extern bool in_spock_queue_ddl_command;
 extern bool spock_auto_replicate_ddl(const char *query, List *replication_sets,
 									 Oid roleoid, Node *stmt);
 extern bool spock_schema_is_ddl_local(const char *nspname);
+extern bool name_in_list(List *names, const char *name);
 
 /* spock_readonly.c */
 void		spock_roExecutorStart(QueryDesc *queryDesc, int eflags);

--- a/include/spock.h
+++ b/include/spock.h
@@ -154,6 +154,7 @@ extern bool in_spock_replicate_ddl_command;
 extern bool in_spock_queue_ddl_command;
 extern bool spock_auto_replicate_ddl(const char *query, List *replication_sets,
 									 Oid roleoid, Node *stmt);
+extern bool spock_schema_is_ddl_local(const char *nspname);
 
 /* spock_readonly.c */
 void		spock_roExecutorStart(QueryDesc *queryDesc, int eflags);

--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -75,7 +75,8 @@ typedef enum ReservedObjectKind
 typedef enum ReservedObjectPurpose
 {
 	RESERVED_PURPOSE_DUMP,		/* exclude_from_dump: kept out of structure sync */
-	RESERVED_PURPOSE_REPSET		/* block_in_repset: cannot join a replication set */
+	RESERVED_PURPOSE_REPSET,	/* block_in_repset: cannot join a replication set */
+	RESERVED_PURPOSE_DDL		/* replicate_ddl = false (node-local) */
 } ReservedObjectPurpose;
 
 extern List *spock_reserved_object_names(ReservedObjectKind kind,

--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -81,6 +81,9 @@ typedef enum ReservedObjectPurpose
 
 extern List *spock_reserved_object_names(ReservedObjectKind kind,
 										 ReservedObjectPurpose purpose);
+extern bool spock_name_is_reserved(ReservedObjectKind kind,
+								   ReservedObjectPurpose purpose,
+								   const char *name);
 
 extern void create_node(SpockNode *node);
 extern void drop_node(Oid nodeid);

--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -60,9 +60,26 @@ typedef struct SpockSubscription
 	TimestampTz	created_at;	/* When this subscription was created */
 } SpockSubscription;
 
-/* NULL-terminated arrays */
-extern const char *const skip_schema[];
-extern const char *const skip_extension[];
+/*
+ * Reserved schemas/extensions are stored in the spock.reserved_object catalog
+ * (the single source of truth, replacing the old hard-coded C arrays).
+ * spock_reserved_object_names() returns the names of one kind of object
+ * reserved for one purpose.
+ */
+typedef enum ReservedObjectKind
+{
+	RESERVED_KIND_SCHEMA,
+	RESERVED_KIND_EXTENSION
+} ReservedObjectKind;
+
+typedef enum ReservedObjectPurpose
+{
+	RESERVED_PURPOSE_DUMP,		/* exclude_from_dump: kept out of structure sync */
+	RESERVED_PURPOSE_REPSET		/* block_in_repset: cannot join a replication set */
+} ReservedObjectPurpose;
+
+extern List *spock_reserved_object_names(ReservedObjectKind kind,
+										 ReservedObjectPurpose purpose);
 
 extern void create_node(SpockNode *node);
 extern void drop_node(Oid nodeid);

--- a/sql/spock--5.0.10--6.0.0.sql
+++ b/sql/spock--5.0.10--6.0.0.sql
@@ -348,17 +348,31 @@ SELECT spock.slot_enable_failover();
 
 -- ----------------------------------------------------------------------------
 -- Reserved objects: schemas and extensions Spock treats specially.
--- Single source of truth (replacing hard-coded lists in the C code) for
--- exclude_from_dump (structure-sync dump exclusion) and block_in_repset
--- (may not be added to a replication set).  Built-in rows are protected.
+--
+-- Single source of truth (replacing hard-coded lists in the C code) for:
+--   * exclude_from_dump - kept out of the structure-sync dump (pg_dump
+--     --exclude-schema / --exclude-extension); restoring these on a subscriber
+--     that already has them would fail.
+--   * block_in_repset   - may not be added to a replication set.
+--   * replicate_ddl     - when false, AutoDDL does not ship DDL for this
+--                         object (node-local; e.g. pgedge_ace).
+--
+-- Built-in rows (builtin = true) are seeded by the extension and are protected
+-- from removal/modification.  Add your own with spock.reserved_object_add().
 -- ----------------------------------------------------------------------------
 CREATE TABLE spock.reserved_object (
     name              name    NOT NULL,
     kind              text    NOT NULL CHECK (kind IN ('schema', 'extension')),
     exclude_from_dump boolean NOT NULL DEFAULT true,
     block_in_repset   boolean NOT NULL DEFAULT true,
+    -- replicate_ddl applies to schemas only (when false, AutoDDL keeps DDL
+    -- targeting the schema node-local).  It is not meaningful for extensions,
+    -- so it is required for schemas and must be NULL for extensions.
+    replicate_ddl     boolean,
     builtin           boolean NOT NULL DEFAULT false,
-    PRIMARY KEY (name, kind)
+    PRIMARY KEY (name, kind),
+    CONSTRAINT reserved_object_replicate_ddl_kind
+        CHECK ((kind = 'schema') = (replicate_ddl IS NOT NULL))
 ) WITH (user_catalog_table=true);
 
 -- Preserve operator-added rows across pg_dump/restore; built-ins are re-seeded
@@ -367,13 +381,15 @@ SELECT pg_catalog.pg_extension_config_dump('spock.reserved_object', 'WHERE NOT b
 
 -- lolor is excluded from the dump but NOT blocked from replication sets: its
 -- tables must replicate so large objects survive a DROP EXTENSION on all nodes.
-INSERT INTO spock.reserved_object (name, kind, exclude_from_dump, block_in_repset, builtin) VALUES
-    ('spock',     'schema',    true, true,  true),
-    ('spock',     'extension', true, true,  true),
-    ('snowflake', 'schema',    true, true,  true),
-    ('snowflake', 'extension', true, true,  true),
-    ('lolor',     'schema',    true, false, true),
-    ('lolor',     'extension', true, false, true);
+INSERT INTO spock.reserved_object
+    (name, kind, exclude_from_dump, block_in_repset, replicate_ddl, builtin) VALUES
+    ('spock',      'schema',    true, true,  true,  true),
+    ('spock',      'extension', true, true,  NULL,  true),
+    ('snowflake',  'schema',    true, true,  true,  true),
+    ('snowflake',  'extension', true, true,  NULL,  true),
+    ('lolor',      'schema',    true, false, true,  true),
+    ('lolor',      'extension', true, false, NULL,  true),
+    ('pgedge_ace', 'schema',    true, true,  false, true);
 
 CREATE FUNCTION spock.reserved_object_guard()
 RETURNS trigger AS $$
@@ -397,24 +413,33 @@ CREATE FUNCTION spock.reserved_object_add(
     p_name              name,
     p_kind              text,
     p_exclude_from_dump boolean DEFAULT true,
-    p_block_in_repset   boolean DEFAULT true)
+    p_block_in_repset   boolean DEFAULT true,
+    p_replicate_ddl     boolean DEFAULT NULL)
 RETURNS void
 LANGUAGE plpgsql AS $$
+DECLARE
+    -- replicate_ddl is schema-only.  For a schema, an unset (NULL) argument
+    -- defaults to true; for an extension it is always NULL, so the
+    -- reserved_object_replicate_ddl_kind CHECK holds without the caller
+    -- having to pass NULL explicitly.
+    v_replicate_ddl boolean := CASE WHEN p_kind = 'schema'
+                                    THEN COALESCE(p_replicate_ddl, true) END;
 BEGIN
     UPDATE spock.reserved_object
        SET exclude_from_dump = p_exclude_from_dump,
-           block_in_repset   = p_block_in_repset
+           block_in_repset   = p_block_in_repset,
+           replicate_ddl     = v_replicate_ddl
      WHERE name = p_name AND kind = p_kind;
     IF NOT FOUND THEN
         BEGIN
             INSERT INTO spock.reserved_object
-                (name, kind, exclude_from_dump, block_in_repset, builtin)
-            VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+                (name, kind, exclude_from_dump, block_in_repset, replicate_ddl, builtin)
+            VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, v_replicate_ddl, false);
         EXCEPTION WHEN unique_violation THEN
-            -- A concurrent call inserted the same object; apply as an update.
             UPDATE spock.reserved_object
                SET exclude_from_dump = p_exclude_from_dump,
-                   block_in_repset   = p_block_in_repset
+                   block_in_repset   = p_block_in_repset,
+                   replicate_ddl     = v_replicate_ddl
              WHERE name = p_name AND kind = p_kind;
         END;
     END IF;

--- a/sql/spock--5.0.10--6.0.0.sql
+++ b/sql/spock--5.0.10--6.0.0.sql
@@ -346,3 +346,76 @@ REVOKE ALL ON FUNCTION spock.slot_enable_failover() FROM PUBLIC;
 
 SELECT spock.slot_enable_failover();
 
+-- ----------------------------------------------------------------------------
+-- Reserved objects: schemas and extensions Spock treats specially.
+-- Single source of truth (replacing hard-coded lists in the C code) for
+-- exclude_from_dump (structure-sync dump exclusion) and block_in_repset
+-- (may not be added to a replication set).  Built-in rows are protected.
+-- ----------------------------------------------------------------------------
+CREATE TABLE spock.reserved_object (
+    name              name    NOT NULL,
+    kind              text    NOT NULL CHECK (kind IN ('schema', 'extension')),
+    exclude_from_dump boolean NOT NULL DEFAULT true,
+    block_in_repset   boolean NOT NULL DEFAULT true,
+    builtin           boolean NOT NULL DEFAULT false,
+    PRIMARY KEY (name, kind)
+) WITH (user_catalog_table=true);
+
+-- Preserve operator-added rows across pg_dump/restore; built-ins are re-seeded
+-- by this script, so only non-built-in rows are dumped.
+SELECT pg_catalog.pg_extension_config_dump('spock.reserved_object', 'WHERE NOT builtin');
+
+-- lolor is excluded from the dump but NOT blocked from replication sets: its
+-- tables must replicate so large objects survive a DROP EXTENSION on all nodes.
+INSERT INTO spock.reserved_object (name, kind, exclude_from_dump, block_in_repset, builtin) VALUES
+    ('spock',     'schema',    true, true,  true),
+    ('spock',     'extension', true, true,  true),
+    ('snowflake', 'schema',    true, true,  true),
+    ('snowflake', 'extension', true, true,  true),
+    ('lolor',     'schema',    true, false, true),
+    ('lolor',     'extension', true, false, true);
+
+CREATE FUNCTION spock.reserved_object_guard()
+RETURNS trigger AS $$
+BEGIN
+    IF OLD.builtin THEN
+        RAISE EXCEPTION 'cannot % built-in reserved object "%" (%)',
+            lower(TG_OP), OLD.name, OLD.kind;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER reserved_object_guard
+    BEFORE UPDATE OR DELETE ON spock.reserved_object
+    FOR EACH ROW EXECUTE FUNCTION spock.reserved_object_guard();
+
+CREATE FUNCTION spock.reserved_object_add(
+    p_name              name,
+    p_kind              text,
+    p_exclude_from_dump boolean DEFAULT true,
+    p_block_in_repset   boolean DEFAULT true)
+RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE spock.reserved_object
+       SET exclude_from_dump = p_exclude_from_dump,
+           block_in_repset   = p_block_in_repset
+     WHERE name = p_name AND kind = p_kind;
+    IF NOT FOUND THEN
+        INSERT INTO spock.reserved_object
+            (name, kind, exclude_from_dump, block_in_repset, builtin)
+        VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+    END IF;
+END;
+$$;
+
+CREATE FUNCTION spock.reserved_object_remove(object_name name, object_kind text)
+RETURNS void
+LANGUAGE sql AS $$
+    DELETE FROM spock.reserved_object WHERE name = object_name AND kind = object_kind;
+$$;
+

--- a/sql/spock--5.0.10--6.0.0.sql
+++ b/sql/spock--5.0.10--6.0.0.sql
@@ -406,16 +406,24 @@ BEGIN
            block_in_repset   = p_block_in_repset
      WHERE name = p_name AND kind = p_kind;
     IF NOT FOUND THEN
-        INSERT INTO spock.reserved_object
-            (name, kind, exclude_from_dump, block_in_repset, builtin)
-        VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+        BEGIN
+            INSERT INTO spock.reserved_object
+                (name, kind, exclude_from_dump, block_in_repset, builtin)
+            VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+        EXCEPTION WHEN unique_violation THEN
+            -- A concurrent call inserted the same object; apply as an update.
+            UPDATE spock.reserved_object
+               SET exclude_from_dump = p_exclude_from_dump,
+                   block_in_repset   = p_block_in_repset
+             WHERE name = p_name AND kind = p_kind;
+        END;
     END IF;
 END;
 $$;
 
-CREATE FUNCTION spock.reserved_object_remove(object_name name, object_kind text)
+CREATE FUNCTION spock.reserved_object_remove(p_name name, p_kind text)
 RETURNS void
 LANGUAGE sql AS $$
-    DELETE FROM spock.reserved_object WHERE name = object_name AND kind = object_kind;
+    DELETE FROM spock.reserved_object WHERE name = p_name AND kind = p_kind;
 $$;
 

--- a/sql/spock--5.0.10--6.0.0.sql
+++ b/sql/spock--5.0.10--6.0.0.sql
@@ -421,7 +421,8 @@ DECLARE
     -- replicate_ddl is schema-only.  For a schema, an unset (NULL) argument
     -- defaults to true; for an extension it is always NULL, so the
     -- reserved_object_replicate_ddl_kind CHECK holds without the caller
-    -- having to pass NULL explicitly.
+    -- having to pass NULL explicitly.  (The table is a user_catalog_table,
+    -- which forbids INSERT ... ON CONFLICT, so this hand-rolled upsert stands.)
     v_replicate_ddl boolean := CASE WHEN p_kind = 'schema'
                                     THEN COALESCE(p_replicate_ddl, true) END;
 BEGIN

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -394,7 +394,8 @@ DECLARE
     -- replicate_ddl is schema-only.  For a schema, an unset (NULL) argument
     -- defaults to true; for an extension it is always NULL, so the
     -- reserved_object_replicate_ddl_kind CHECK holds without the caller
-    -- having to pass NULL explicitly.
+    -- having to pass NULL explicitly.  (The table is a user_catalog_table,
+    -- which forbids INSERT ... ON CONFLICT, so this hand-rolled upsert stands.)
     v_replicate_ddl boolean := CASE WHEN p_kind = 'schema'
                                     THEN COALESCE(p_replicate_ddl, true) END;
 BEGIN

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -327,6 +327,8 @@ CREATE TABLE spock.replication_set_seq (
 --     --exclude-schema / --exclude-extension); restoring these on a subscriber
 --     that already has them would fail.
 --   * block_in_repset   - may not be added to a replication set.
+--   * replicate_ddl     - when false, AutoDDL does not ship DDL for this
+--                         object (node-local; e.g. pgedge_ace).
 --
 -- Built-in rows (builtin = true) are seeded by the extension and are protected
 -- from removal/modification.  Add your own with spock.reserved_object_add().
@@ -336,8 +338,14 @@ CREATE TABLE spock.reserved_object (
     kind              text    NOT NULL CHECK (kind IN ('schema', 'extension')),
     exclude_from_dump boolean NOT NULL DEFAULT true,
     block_in_repset   boolean NOT NULL DEFAULT true,
+    -- replicate_ddl applies to schemas only (when false, AutoDDL keeps DDL
+    -- targeting the schema node-local).  It is not meaningful for extensions,
+    -- so it is required for schemas and must be NULL for extensions.
+    replicate_ddl     boolean,
     builtin           boolean NOT NULL DEFAULT false,
-    PRIMARY KEY (name, kind)
+    PRIMARY KEY (name, kind),
+    CONSTRAINT reserved_object_replicate_ddl_kind
+        CHECK ((kind = 'schema') = (replicate_ddl IS NOT NULL))
 ) WITH (user_catalog_table=true);
 
 -- Preserve operator-added rows across pg_dump/restore; built-ins are re-seeded
@@ -346,16 +354,16 @@ SELECT pg_catalog.pg_extension_config_dump('spock.reserved_object', 'WHERE NOT b
 
 -- lolor is excluded from the dump but NOT blocked from replication sets: its
 -- tables must replicate so large objects survive a DROP EXTENSION on all nodes.
-INSERT INTO spock.reserved_object (name, kind, exclude_from_dump, block_in_repset, builtin) VALUES
-    ('spock',     'schema',    true, true,  true),
-    ('spock',     'extension', true, true,  true),
-    ('snowflake', 'schema',    true, true,  true),
-    ('snowflake', 'extension', true, true,  true),
-    ('lolor',     'schema',    true, false, true),
-    ('lolor',     'extension', true, false, true);
+INSERT INTO spock.reserved_object
+    (name, kind, exclude_from_dump, block_in_repset, replicate_ddl, builtin) VALUES
+    ('spock',      'schema',    true, true,  true,  true),
+    ('spock',      'extension', true, true,  NULL,  true),
+    ('snowflake',  'schema',    true, true,  true,  true),
+    ('snowflake',  'extension', true, true,  NULL,  true),
+    ('lolor',      'schema',    true, false, true,  true),
+    ('lolor',      'extension', true, false, NULL,  true),
+    ('pgedge_ace', 'schema',    true, true,  false, true);
 
--- Protect built-in rows so replication can't be broken by dropping
--- spock/snowflake/lolor from the reserved set.
 CREATE FUNCTION spock.reserved_object_guard()
 RETURNS trigger AS $$
 BEGIN
@@ -374,38 +382,43 @@ CREATE TRIGGER reserved_object_guard
     BEFORE UPDATE OR DELETE ON spock.reserved_object
     FOR EACH ROW EXECUTE FUNCTION spock.reserved_object_guard();
 
--- Add (or update) a user-defined reserved object.  (ON CONFLICT is not
--- allowed on a user_catalog_table, so upsert by hand; updating a built-in row
--- is rejected by the guard trigger.)
 CREATE FUNCTION spock.reserved_object_add(
     p_name              name,
     p_kind              text,
     p_exclude_from_dump boolean DEFAULT true,
-    p_block_in_repset   boolean DEFAULT true)
+    p_block_in_repset   boolean DEFAULT true,
+    p_replicate_ddl     boolean DEFAULT NULL)
 RETURNS void
 LANGUAGE plpgsql AS $$
+DECLARE
+    -- replicate_ddl is schema-only.  For a schema, an unset (NULL) argument
+    -- defaults to true; for an extension it is always NULL, so the
+    -- reserved_object_replicate_ddl_kind CHECK holds without the caller
+    -- having to pass NULL explicitly.
+    v_replicate_ddl boolean := CASE WHEN p_kind = 'schema'
+                                    THEN COALESCE(p_replicate_ddl, true) END;
 BEGIN
     UPDATE spock.reserved_object
        SET exclude_from_dump = p_exclude_from_dump,
-           block_in_repset   = p_block_in_repset
+           block_in_repset   = p_block_in_repset,
+           replicate_ddl     = v_replicate_ddl
      WHERE name = p_name AND kind = p_kind;
     IF NOT FOUND THEN
         BEGIN
             INSERT INTO spock.reserved_object
-                (name, kind, exclude_from_dump, block_in_repset, builtin)
-            VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+                (name, kind, exclude_from_dump, block_in_repset, replicate_ddl, builtin)
+            VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, v_replicate_ddl, false);
         EXCEPTION WHEN unique_violation THEN
-            -- A concurrent call inserted the same object; apply as an update.
             UPDATE spock.reserved_object
                SET exclude_from_dump = p_exclude_from_dump,
-                   block_in_repset   = p_block_in_repset
+                   block_in_repset   = p_block_in_repset,
+                   replicate_ddl     = v_replicate_ddl
              WHERE name = p_name AND kind = p_kind;
         END;
     END IF;
 END;
 $$;
 
--- Remove a user-defined reserved object (built-ins are protected by the guard).
 CREATE FUNCTION spock.reserved_object_remove(p_name name, p_kind text)
 RETURNS void
 LANGUAGE sql AS $$

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -390,18 +390,26 @@ BEGIN
            block_in_repset   = p_block_in_repset
      WHERE name = p_name AND kind = p_kind;
     IF NOT FOUND THEN
-        INSERT INTO spock.reserved_object
-            (name, kind, exclude_from_dump, block_in_repset, builtin)
-        VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+        BEGIN
+            INSERT INTO spock.reserved_object
+                (name, kind, exclude_from_dump, block_in_repset, builtin)
+            VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+        EXCEPTION WHEN unique_violation THEN
+            -- A concurrent call inserted the same object; apply as an update.
+            UPDATE spock.reserved_object
+               SET exclude_from_dump = p_exclude_from_dump,
+                   block_in_repset   = p_block_in_repset
+             WHERE name = p_name AND kind = p_kind;
+        END;
     END IF;
 END;
 $$;
 
 -- Remove a user-defined reserved object (built-ins are protected by the guard).
-CREATE FUNCTION spock.reserved_object_remove(object_name name, object_kind text)
+CREATE FUNCTION spock.reserved_object_remove(p_name name, p_kind text)
 RETURNS void
 LANGUAGE sql AS $$
-    DELETE FROM spock.reserved_object WHERE name = object_name AND kind = object_kind;
+    DELETE FROM spock.reserved_object WHERE name = p_name AND kind = p_kind;
 $$;
 
 CREATE TABLE spock.sequence_state (

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -319,6 +319,91 @@ CREATE TABLE spock.replication_set_seq (
     PRIMARY KEY(set_id, set_seqoid)
 ) WITH (user_catalog_table=true);
 
+-- ----------------------------------------------------------------------------
+-- Reserved objects: schemas and extensions Spock treats specially.
+--
+-- Single source of truth (replacing hard-coded lists in the C code) for:
+--   * exclude_from_dump - kept out of the structure-sync dump (pg_dump
+--     --exclude-schema / --exclude-extension); restoring these on a subscriber
+--     that already has them would fail.
+--   * block_in_repset   - may not be added to a replication set.
+--
+-- Built-in rows (builtin = true) are seeded by the extension and are protected
+-- from removal/modification.  Add your own with spock.reserved_object_add().
+-- ----------------------------------------------------------------------------
+CREATE TABLE spock.reserved_object (
+    name              name    NOT NULL,
+    kind              text    NOT NULL CHECK (kind IN ('schema', 'extension')),
+    exclude_from_dump boolean NOT NULL DEFAULT true,
+    block_in_repset   boolean NOT NULL DEFAULT true,
+    builtin           boolean NOT NULL DEFAULT false,
+    PRIMARY KEY (name, kind)
+) WITH (user_catalog_table=true);
+
+-- Preserve operator-added rows across pg_dump/restore; built-ins are re-seeded
+-- by this script, so only non-built-in rows are dumped.
+SELECT pg_catalog.pg_extension_config_dump('spock.reserved_object', 'WHERE NOT builtin');
+
+-- lolor is excluded from the dump but NOT blocked from replication sets: its
+-- tables must replicate so large objects survive a DROP EXTENSION on all nodes.
+INSERT INTO spock.reserved_object (name, kind, exclude_from_dump, block_in_repset, builtin) VALUES
+    ('spock',     'schema',    true, true,  true),
+    ('spock',     'extension', true, true,  true),
+    ('snowflake', 'schema',    true, true,  true),
+    ('snowflake', 'extension', true, true,  true),
+    ('lolor',     'schema',    true, false, true),
+    ('lolor',     'extension', true, false, true);
+
+-- Protect built-in rows so replication can't be broken by dropping
+-- spock/snowflake/lolor from the reserved set.
+CREATE FUNCTION spock.reserved_object_guard()
+RETURNS trigger AS $$
+BEGIN
+    IF OLD.builtin THEN
+        RAISE EXCEPTION 'cannot % built-in reserved object "%" (%)',
+            lower(TG_OP), OLD.name, OLD.kind;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER reserved_object_guard
+    BEFORE UPDATE OR DELETE ON spock.reserved_object
+    FOR EACH ROW EXECUTE FUNCTION spock.reserved_object_guard();
+
+-- Add (or update) a user-defined reserved object.  (ON CONFLICT is not
+-- allowed on a user_catalog_table, so upsert by hand; updating a built-in row
+-- is rejected by the guard trigger.)
+CREATE FUNCTION spock.reserved_object_add(
+    p_name              name,
+    p_kind              text,
+    p_exclude_from_dump boolean DEFAULT true,
+    p_block_in_repset   boolean DEFAULT true)
+RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE spock.reserved_object
+       SET exclude_from_dump = p_exclude_from_dump,
+           block_in_repset   = p_block_in_repset
+     WHERE name = p_name AND kind = p_kind;
+    IF NOT FOUND THEN
+        INSERT INTO spock.reserved_object
+            (name, kind, exclude_from_dump, block_in_repset, builtin)
+        VALUES (p_name, p_kind, p_exclude_from_dump, p_block_in_repset, false);
+    END IF;
+END;
+$$;
+
+-- Remove a user-defined reserved object (built-ins are protected by the guard).
+CREATE FUNCTION spock.reserved_object_remove(object_name name, object_kind text)
+RETURNS void
+LANGUAGE sql AS $$
+    DELETE FROM spock.reserved_object WHERE name = object_name AND kind = object_kind;
+$$;
+
 CREATE TABLE spock.sequence_state (
 	seqoid oid NOT NULL PRIMARY KEY,
 	cache_size integer NOT NULL,

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -355,6 +355,36 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
 
 	targetrel = RelationIdGetRelation(reloid);
 
+	{
+		char	   *nsp = get_namespace_name(RelationGetNamespace(targetrel));
+		List	   *blocked = spock_reserved_object_names(RESERVED_KIND_SCHEMA,
+														 RESERVED_PURPOSE_REPSET);
+		ListCell   *lc;
+		bool		skip = false;
+
+		foreach(lc, blocked)
+		{
+			if (strcmp((char *) lfirst(lc), nsp) == 0)
+			{
+				skip = true;
+				break;
+			}
+		}
+		list_free_deep(blocked);
+		if (skip)
+		{
+			/*
+			 * A block_in_repset schema's tables must not replicate.  Like the
+			 * UNLOGGED/TEMP case below, evict any existing membership (covers a
+			 * table that joined a repset before its schema was reserved) rather
+			 * than only skipping routing.
+			 */
+			remove_table_from_repsets(node->node->id, reloid, false);
+			table_close(targetrel, NoLock);
+			return;
+		}
+	}
+
 	/* UNLOGGED and TEMP relations cannot be part of replication set. */
 	if (!RelationNeedsWAL(targetrel))
 	{

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -355,34 +355,18 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
 
 	targetrel = RelationIdGetRelation(reloid);
 
+	if (spock_name_is_reserved(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_REPSET,
+							   get_namespace_name(RelationGetNamespace(targetrel))))
 	{
-		char	   *nsp = get_namespace_name(RelationGetNamespace(targetrel));
-		List	   *blocked = spock_reserved_object_names(RESERVED_KIND_SCHEMA,
-														 RESERVED_PURPOSE_REPSET);
-		ListCell   *lc;
-		bool		skip = false;
-
-		foreach(lc, blocked)
-		{
-			if (strcmp((char *) lfirst(lc), nsp) == 0)
-			{
-				skip = true;
-				break;
-			}
-		}
-		list_free_deep(blocked);
-		if (skip)
-		{
-			/*
-			 * A block_in_repset schema's tables must not replicate.  Like the
-			 * UNLOGGED/TEMP case below, evict any existing membership (covers a
-			 * table that joined a repset before its schema was reserved) rather
-			 * than only skipping routing.
-			 */
-			remove_table_from_repsets(node->node->id, reloid, false);
-			table_close(targetrel, NoLock);
-			return;
-		}
+		/*
+		 * A block_in_repset schema's tables must not replicate.  Like the
+		 * UNLOGGED/TEMP case below, evict any existing membership (covers a
+		 * table that joined a repset before its schema was reserved) rather
+		 * than only skipping routing.
+		 */
+		remove_table_from_repsets(node->node->id, reloid, false);
+		table_close(targetrel, NoLock);
+		return;
 	}
 
 	/* UNLOGGED and TEMP relations cannot be part of replication set. */

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2420,24 +2420,8 @@ query_temp_like_source(const char *query)
 bool
 spock_schema_is_ddl_local(const char *nspname)
 {
-	List	   *ddl_local;
-	ListCell   *lc;
-	bool		result = false;
-
-	if (nspname == NULL)
-		return false;
-
-	ddl_local = spock_reserved_object_names(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_DDL);
-	foreach(lc, ddl_local)
-	{
-		if (strcmp((char *) lfirst(lc), nspname) == 0)
-		{
-			result = true;
-			break;
-		}
-	}
-	list_free_deep(ddl_local);
-	return result;
+	return spock_name_is_reserved(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_DDL,
+								  nspname);
 }
 
 /*
@@ -2465,11 +2449,32 @@ rangevar_is_ddl_local(RangeVar *rv)
 	return local;
 }
 
+/* Membership test used to classify a DROP against one catalog read. */
+static bool
+name_in_list(List *names, const char *name)
+{
+	ListCell   *lc;
+
+	if (name == NULL)
+		return false;
+	foreach(lc, names)
+		if (strcmp((char *) lfirst(lc), name) == 0)
+			return true;
+	return false;
+}
+
 /*
  * Does this DDL target ONLY node-local (replicate_ddl=false) schemas?  Only
  * statement types whose target schema is identifiable are classified; all
  * others replicate as before.  Known gap: dropping a node-local relation by an
  * unqualified name cannot be classified (the relation is already gone).
+ *
+ * A DROP is skipped only when EVERY object is node-local.  A statement mixing a
+ * node-local object with a replicated one is shipped as-is: the raw command
+ * text cannot be rewritten to strip the node-local object, so the subscriber --
+ * where that object never existed -- would fail to drop it unless the drop
+ * carries IF EXISTS.  Mixing node-local and replicated objects in one DROP is
+ * therefore unsupported.
  */
 static bool
 stmt_targets_only_ddl_local(Node *stmt)
@@ -2494,27 +2499,34 @@ stmt_targets_only_ddl_local(Node *stmt)
 			{
 				DropStmt   *drop = (DropStmt *) stmt;
 				ListCell   *cell;
+				List	   *local;
+				bool		all_local = true;
 
 				if (drop->objects == NIL)
 					return false;
-				if (drop->removeType == OBJECT_SCHEMA)
-				{
-					foreach(cell, drop->objects)
-						if (!spock_schema_is_ddl_local(strVal(lfirst(cell))))
-							return false;
-					return true;
-				}
-				if (drop->removeType != OBJECT_TABLE && drop->removeType != OBJECT_INDEX &&
+				if (drop->removeType != OBJECT_SCHEMA &&
+					drop->removeType != OBJECT_TABLE && drop->removeType != OBJECT_INDEX &&
 					drop->removeType != OBJECT_SEQUENCE && drop->removeType != OBJECT_VIEW &&
 					drop->removeType != OBJECT_MATVIEW && drop->removeType != OBJECT_FOREIGN_TABLE)
 					return false;
+
+				/* One catalog read for the whole (possibly multi-object) DROP. */
+				local = spock_reserved_object_names(RESERVED_KIND_SCHEMA,
+													RESERVED_PURPOSE_DDL);
 				foreach(cell, drop->objects)
 				{
-					RangeVar *rv = makeRangeVarFromNameList((List *) lfirst(cell));
-					if (rv->schemaname == NULL || !spock_schema_is_ddl_local(rv->schemaname))
-						return false;
+					const char *schema = (drop->removeType == OBJECT_SCHEMA)
+						? strVal(lfirst(cell))
+						: makeRangeVarFromNameList((List *) lfirst(cell))->schemaname;
+
+					if (!name_in_list(local, schema))
+					{
+						all_local = false;
+						break;
+					}
 				}
-				return true;
+				list_free_deep(local);
+				return all_local;
 			}
 		default:
 			return false;

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2449,8 +2449,8 @@ rangevar_is_ddl_local(RangeVar *rv)
 	return local;
 }
 
-/* Membership test used to classify a DROP against one catalog read. */
-static bool
+/* True if `name` (case-sensitive) appears in a List of C strings. */
+bool
 name_in_list(List *names, const char *name)
 {
 	ListCell   *lc;

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -16,6 +16,7 @@
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
+#include "access/relation.h"
 #include "access/sysattr.h"
 #include "access/xact.h"
 #include "access/xlog.h"
@@ -2415,6 +2416,111 @@ query_temp_like_source(const char *query)
 	return NULL;
 }
 
+/* True when nspname is a reserved schema with replicate_ddl = false. */
+bool
+spock_schema_is_ddl_local(const char *nspname)
+{
+	List	   *ddl_local;
+	ListCell   *lc;
+	bool		result = false;
+
+	if (nspname == NULL)
+		return false;
+
+	ddl_local = spock_reserved_object_names(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_DDL);
+	foreach(lc, ddl_local)
+	{
+		if (strcmp((char *) lfirst(lc), nspname) == 0)
+		{
+			result = true;
+			break;
+		}
+	}
+	list_free_deep(ddl_local);
+	return result;
+}
+
+/*
+ * Resolve rv to its schema and test replicate_ddl=false.  Runs post-execution,
+ * so CREATE/ALTER targets exist and an unqualified name resolves by opening the
+ * relation (relation_openrv, not table_openrv: rv may name an index/view).  A
+ * dropped relation is classifiable only when schema-qualified.
+ */
+static bool
+rangevar_is_ddl_local(RangeVar *rv)
+{
+	Relation	rel;
+	bool		local;
+
+	if (rv == NULL)
+		return false;
+	if (rv->schemaname != NULL)
+		return spock_schema_is_ddl_local(rv->schemaname);
+
+	rel = relation_openrv_extended(rv, AccessShareLock, true);
+	if (rel == NULL)
+		return false;
+	local = spock_schema_is_ddl_local(get_namespace_name(RelationGetNamespace(rel)));
+	relation_close(rel, AccessShareLock);
+	return local;
+}
+
+/*
+ * Does this DDL target ONLY node-local (replicate_ddl=false) schemas?  Only
+ * statement types whose target schema is identifiable are classified; all
+ * others replicate as before.  Known gap: dropping a node-local relation by an
+ * unqualified name cannot be classified (the relation is already gone).
+ */
+static bool
+stmt_targets_only_ddl_local(Node *stmt)
+{
+	switch (nodeTag(stmt))
+	{
+		case T_CreateSchemaStmt:
+			return spock_schema_is_ddl_local(((CreateSchemaStmt *) stmt)->schemaname);
+		case T_CreateStmt:
+			return rangevar_is_ddl_local(((CreateStmt *) stmt)->relation);
+		case T_CreateTableAsStmt:
+			return rangevar_is_ddl_local(((CreateTableAsStmt *) stmt)->into->rel);
+		case T_AlterTableStmt:
+			return rangevar_is_ddl_local(((AlterTableStmt *) stmt)->relation);
+		case T_ViewStmt:
+			return rangevar_is_ddl_local(((ViewStmt *) stmt)->view);
+		case T_CreateSeqStmt:
+			return rangevar_is_ddl_local(((CreateSeqStmt *) stmt)->sequence);
+		case T_IndexStmt:
+			return rangevar_is_ddl_local(((IndexStmt *) stmt)->relation);
+		case T_DropStmt:
+			{
+				DropStmt   *drop = (DropStmt *) stmt;
+				ListCell   *cell;
+
+				if (drop->objects == NIL)
+					return false;
+				if (drop->removeType == OBJECT_SCHEMA)
+				{
+					foreach(cell, drop->objects)
+						if (!spock_schema_is_ddl_local(strVal(lfirst(cell))))
+							return false;
+					return true;
+				}
+				if (drop->removeType != OBJECT_TABLE && drop->removeType != OBJECT_INDEX &&
+					drop->removeType != OBJECT_SEQUENCE && drop->removeType != OBJECT_VIEW &&
+					drop->removeType != OBJECT_MATVIEW && drop->removeType != OBJECT_FOREIGN_TABLE)
+					return false;
+				foreach(cell, drop->objects)
+				{
+					RangeVar *rv = makeRangeVarFromNameList((List *) lfirst(cell));
+					if (rv->schemaname == NULL || !spock_schema_is_ddl_local(rv->schemaname))
+						return false;
+				}
+				return true;
+			}
+		default:
+			return false;
+	}
+}
+
 /*
  * spock_auto_replicate_ddl
  *
@@ -2450,6 +2556,14 @@ spock_auto_replicate_ddl(const char *query, List *replication_sets,
 
 		(void) get_replication_set_by_name(node->node->id, setname, false);
 	}
+
+	/*
+	 * DDL targeting only node-local schemas (replicate_ddl=false) is not
+	 * shipped: skipping here also keeps the affected tables out of repsets
+	 * (the caller adds them only when we return true).
+	 */
+	if (stmt_targets_only_ddl_local(stmt))
+		goto skip_ddl;
 
 	/*
 	 * Filter local commands and decide on search path setting.

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -122,43 +122,30 @@ typedef struct SubscriptionTuple
 #define Anum_sub_skip_schema		14
 #define Anum_sub_created_at			15
 
-/*
- * Names of the reserved objects of the given kind (schema or extension) that
- * are reserved for the given purpose, read from the spock.reserved_object
- * catalog.  Names are palloc'd in the caller's context.
- */
-List *
-spock_reserved_object_names(ReservedObjectKind kind,
-							ReservedObjectPurpose purpose)
+/* Column holding the flag for a purpose; *invert set when true means "not". */
+static AttrNumber
+reserved_purpose_attnum(ReservedObjectPurpose purpose, bool *invert)
 {
-	RangeVar	   *catalog_rv;
-	Relation		catalog_rel;
-	TupleDesc		tuple_desc;
-	SysScanDesc		scan;
-	HeapTuple		tuple;
-	List		   *names = NIL;
-	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
-									? "extension" : "schema";
-	AttrNumber		flag_attnum;
-	bool			invert = false;
-
+	*invert = false;
 	switch (purpose)
 	{
 		case RESERVED_PURPOSE_DUMP:
-			flag_attnum = Anum_reserved_exclude_from_dump;
-			break;
+			return Anum_reserved_exclude_from_dump;
 		case RESERVED_PURPOSE_REPSET:
-			flag_attnum = Anum_reserved_block_in_repset;
-			break;
+			return Anum_reserved_block_in_repset;
 		case RESERVED_PURPOSE_DDL:
-			flag_attnum = Anum_reserved_replicate_ddl;
-			invert = true;		/* select rows that do NOT replicate DDL */
-			break;
-		default:
-			elog(ERROR, "unknown reserved object purpose %d", (int) purpose);
+			*invert = true;		/* select rows that do NOT replicate DDL */
+			return Anum_reserved_replicate_ddl;
 	}
+	elog(ERROR, "unknown reserved object purpose %d", (int) purpose);
+	return InvalidAttrNumber;	/* unreachable; keeps the compiler quiet */
+}
 
-	catalog_rv = makeRangeVar(EXTENSION_NAME, CATALOG_RESERVED_OBJECT, -1);
+/* Open spock.reserved_object, failing closed with a hint if it is missing. */
+static Relation
+open_reserved_object(LOCKMODE lockmode)
+{
+	RangeVar   *catalog_rv = makeRangeVar(EXTENSION_NAME, CATALOG_RESERVED_OBJECT, -1);
 
 	/*
 	 * Fail closed with a clear message if the catalog is missing (e.g. a new
@@ -172,7 +159,87 @@ spock_reserved_object_names(ReservedObjectKind kind,
 						EXTENSION_NAME, CATALOG_RESERVED_OBJECT),
 				 errhint("Run \"ALTER EXTENSION spock UPDATE\".")));
 
-	catalog_rel = table_openrv(catalog_rv, AccessShareLock);
+	return table_openrv(catalog_rv, lockmode);
+}
+
+/*
+ * True if `name` is a reserved object of the given kind reserved for the given
+ * purpose.  Unlike spock_reserved_object_names() this stops at the first match
+ * and allocates nothing -- for the common "is this one name reserved?" checks
+ * on the DDL and replication-set paths.
+ */
+bool
+spock_name_is_reserved(ReservedObjectKind kind, ReservedObjectPurpose purpose,
+					   const char *name)
+{
+	Relation		catalog_rel;
+	TupleDesc		tuple_desc;
+	SysScanDesc		scan;
+	HeapTuple		tuple;
+	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
+									? "extension" : "schema";
+	bool			invert;
+	AttrNumber		flag_attnum = reserved_purpose_attnum(purpose, &invert);
+	bool			found = false;
+
+	if (name == NULL)
+		return false;
+
+	catalog_rel = open_reserved_object(AccessShareLock);
+	tuple_desc = RelationGetDescr(catalog_rel);
+
+	scan = systable_beginscan(catalog_rel, InvalidOid, false, NULL, 0, NULL);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool	isnull;
+		char   *row_kind;
+		bool	flag;
+
+		if (strcmp(NameStr(*DatumGetName(heap_getattr(tuple, Anum_reserved_name,
+													  tuple_desc, &isnull))),
+				   name) != 0)
+			continue;
+
+		row_kind = TextDatumGetCString(heap_getattr(tuple, Anum_reserved_kind,
+													tuple_desc, &isnull));
+		if (strcmp(row_kind, wanted_kind) != 0)
+		{
+			pfree(row_kind);
+			continue;
+		}
+		pfree(row_kind);
+
+		flag = DatumGetBool(heap_getattr(tuple, flag_attnum, tuple_desc, &isnull));
+		/* replicate_ddl is NULL for extensions; NULL is not "node-local". */
+		found = invert ? (!isnull && !flag) : flag;
+		break;
+	}
+
+	systable_endscan(scan);
+	table_close(catalog_rel, AccessShareLock);
+	return found;
+}
+
+/*
+ * Names of the reserved objects of the given kind (schema or extension) that
+ * are reserved for the given purpose, read from the spock.reserved_object
+ * catalog.  Names are palloc'd in the caller's context.
+ */
+List *
+spock_reserved_object_names(ReservedObjectKind kind,
+							ReservedObjectPurpose purpose)
+{
+	Relation		catalog_rel;
+	TupleDesc		tuple_desc;
+	SysScanDesc		scan;
+	HeapTuple		tuple;
+	List		   *names = NIL;
+	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
+									? "extension" : "schema";
+	bool			invert;
+	AttrNumber		flag_attnum = reserved_purpose_attnum(purpose, &invert);
+
+	catalog_rel = open_reserved_object(AccessShareLock);
 	tuple_desc = RelationGetDescr(catalog_rel);
 
 	scan = systable_beginscan(catalog_rel, InvalidOid, false, NULL, 0, NULL);
@@ -1385,53 +1452,29 @@ EnsureRelationNotIgnored(Relation rel)
 {
 	char	   *nspname;
 	Oid			extoid;
-	List	   *reserved;
-	ListCell   *lc;
+	char	   *extname;
 
 	nspname = get_namespace_name(RelationGetNamespace(rel));
 
-	reserved = spock_reserved_object_names(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_REPSET);
-	foreach(lc, reserved)
-	{
-		const char *schema_name = (const char *) lfirst(lc);
-
-		if (strcmp(schema_name, nspname) != 0)
-			continue;
-
+	if (spock_name_is_reserved(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_REPSET, nspname))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("relation %s cannot be added to any replication set",
 						RelationGetRelationName(rel)),
-				 errdetail("table is in the ignored schema %s",
-						   schema_name),
+				 errdetail("table is in the ignored schema %s", nspname),
 				 errhint("Move this relation to a schema allowed for replication")));
-	}
-	list_free_deep(reserved);
 
 	extoid = getExtensionOfObject(RelationRelationId, RelationGetRelid(rel));
 	if (!OidIsValid(extoid))
 		return;
 
-	reserved = spock_reserved_object_names(RESERVED_KIND_EXTENSION, RESERVED_PURPOSE_REPSET);
-	foreach(lc, reserved)
-	{
-		const char *ext_name = (const char *) lfirst(lc);
-
-		/*
-		 * Detect if extension includes this relation.
-		 * XXX: Should we check if the relation doesn't belong to the extension
-		 * but depends on it?
-		 */
-		if (extoid != get_extension_oid(ext_name, true))
-			continue;
-
+	extname = get_extension_name(extoid);
+	if (extname != NULL &&
+		spock_name_is_reserved(RESERVED_KIND_EXTENSION, RESERVED_PURPOSE_REPSET, extname))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("relation %s cannot be added to any replication set",
 						RelationGetRelationName(rel)),
-				 errdetail("relation belongs to the ignored extension %s",
-						   ext_name),
+				 errdetail("relation belongs to the ignored extension %s", extname),
 				 errhint("Move this relation to an extension allowed for replication")));
-	}
-	list_free_deep(reserved);
 }

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -122,23 +122,44 @@ typedef struct SubscriptionTuple
 #define Anum_sub_skip_schema		14
 #define Anum_sub_created_at			15
 
-/* Column holding the flag for a purpose; *invert set when true means "not". */
-static AttrNumber
-reserved_purpose_attnum(ReservedObjectPurpose purpose, bool *invert)
+/*
+ * Is this spock.reserved_object row reserved for the given purpose?
+ *
+ * Each purpose is decided by one boolean column, but the column and the sense
+ * of "reserved" differ, so keep that knowledge in one place:
+ *
+ *   RESERVED_PURPOSE_DUMP    exclude_from_dump  reserved when true
+ *   RESERVED_PURPOSE_REPSET  block_in_repset    reserved when true
+ *   RESERVED_PURPOSE_DDL     replicate_ddl      reserved when *false*
+ *
+ * DDL is reserved when the object is node-local, i.e. its DDL is not
+ * replicated, so replicate_ddl == false means reserved.  A NULL flag (e.g.
+ * replicate_ddl is NULL for extensions) is never treated as reserved.
+ */
+static bool
+row_reserved_for_purpose(HeapTuple tuple, TupleDesc tuple_desc,
+						 ReservedObjectPurpose purpose)
 {
-	*invert = false;
+	bool	isnull;
+	bool	flag;
+
 	switch (purpose)
 	{
 		case RESERVED_PURPOSE_DUMP:
-			return Anum_reserved_exclude_from_dump;
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_exclude_from_dump,
+											 tuple_desc, &isnull));
+			return !isnull && flag;
 		case RESERVED_PURPOSE_REPSET:
-			return Anum_reserved_block_in_repset;
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_block_in_repset,
+											 tuple_desc, &isnull));
+			return !isnull && flag;
 		case RESERVED_PURPOSE_DDL:
-			*invert = true;		/* select rows that do NOT replicate DDL */
-			return Anum_reserved_replicate_ddl;
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_replicate_ddl,
+											 tuple_desc, &isnull));
+			return !isnull && !flag;
 	}
 	elog(ERROR, "unknown reserved object purpose %d", (int) purpose);
-	return InvalidAttrNumber;	/* unreachable; keeps the compiler quiet */
+	return false;	/* unreachable; keeps the compiler quiet */
 }
 
 /* Open spock.reserved_object, failing closed with a hint if it is missing. */
@@ -178,8 +199,6 @@ spock_name_is_reserved(ReservedObjectKind kind, ReservedObjectPurpose purpose,
 	HeapTuple		tuple;
 	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
 									? "extension" : "schema";
-	bool			invert;
-	AttrNumber		flag_attnum = reserved_purpose_attnum(purpose, &invert);
 	bool			found = false;
 
 	if (name == NULL)
@@ -193,7 +212,6 @@ spock_name_is_reserved(ReservedObjectKind kind, ReservedObjectPurpose purpose,
 	{
 		bool	isnull;
 		char   *row_kind;
-		bool	flag;
 
 		if (strcmp(NameStr(*DatumGetName(heap_getattr(tuple, Anum_reserved_name,
 													  tuple_desc, &isnull))),
@@ -209,9 +227,7 @@ spock_name_is_reserved(ReservedObjectKind kind, ReservedObjectPurpose purpose,
 		}
 		pfree(row_kind);
 
-		flag = DatumGetBool(heap_getattr(tuple, flag_attnum, tuple_desc, &isnull));
-		/* replicate_ddl is NULL for extensions; NULL is not "node-local". */
-		found = invert ? (!isnull && !flag) : flag;
+		found = row_reserved_for_purpose(tuple, tuple_desc, purpose);
 		break;
 	}
 
@@ -236,8 +252,6 @@ spock_reserved_object_names(ReservedObjectKind kind,
 	List		   *names = NIL;
 	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
 									? "extension" : "schema";
-	bool			invert;
-	AttrNumber		flag_attnum = reserved_purpose_attnum(purpose, &invert);
 
 	catalog_rel = open_reserved_object(AccessShareLock);
 	tuple_desc = RelationGetDescr(catalog_rel);
@@ -247,7 +261,6 @@ spock_reserved_object_names(ReservedObjectKind kind,
 	{
 		bool	isnull;
 		char   *row_kind;
-		bool	reserved_for_purpose;
 
 		row_kind = TextDatumGetCString(heap_getattr(tuple, Anum_reserved_kind,
 													tuple_desc, &isnull));
@@ -258,11 +271,7 @@ spock_reserved_object_names(ReservedObjectKind kind,
 		}
 		pfree(row_kind);
 
-		reserved_for_purpose = DatumGetBool(heap_getattr(tuple, flag_attnum,
-														 tuple_desc, &isnull));
-		if (invert)
-			reserved_for_purpose = !reserved_for_purpose;
-		if (!reserved_for_purpose)
+		if (!row_reserved_for_purpose(tuple, tuple_desc, purpose))
 			continue;
 
 		names = lappend(names,

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -59,7 +59,8 @@
 #define Anum_reserved_kind				2
 #define Anum_reserved_exclude_from_dump	3
 #define Anum_reserved_block_in_repset	4
-#define Anum_reserved_builtin			5
+#define Anum_reserved_replicate_ddl		5
+#define Anum_reserved_builtin			6
 
 typedef struct NodeTuple
 {
@@ -138,9 +139,24 @@ spock_reserved_object_names(ReservedObjectKind kind,
 	List		   *names = NIL;
 	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
 									? "extension" : "schema";
-	AttrNumber		flag_attnum = (purpose == RESERVED_PURPOSE_DUMP)
-									? Anum_reserved_exclude_from_dump
-									: Anum_reserved_block_in_repset;
+	AttrNumber		flag_attnum;
+	bool			invert = false;
+
+	switch (purpose)
+	{
+		case RESERVED_PURPOSE_DUMP:
+			flag_attnum = Anum_reserved_exclude_from_dump;
+			break;
+		case RESERVED_PURPOSE_REPSET:
+			flag_attnum = Anum_reserved_block_in_repset;
+			break;
+		case RESERVED_PURPOSE_DDL:
+			flag_attnum = Anum_reserved_replicate_ddl;
+			invert = true;		/* select rows that do NOT replicate DDL */
+			break;
+		default:
+			elog(ERROR, "unknown reserved object purpose %d", (int) purpose);
+	}
 
 	catalog_rv = makeRangeVar(EXTENSION_NAME, CATALOG_RESERVED_OBJECT, -1);
 
@@ -177,6 +193,8 @@ spock_reserved_object_names(ReservedObjectKind kind,
 
 		reserved_for_purpose = DatumGetBool(heap_getattr(tuple, flag_attnum,
 														 tuple_desc, &isnull));
+		if (invert)
+			reserved_for_purpose = !reserved_for_purpose;
 		if (!reserved_for_purpose)
 			continue;
 

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -21,6 +21,7 @@
 #include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/namespace.h"
 #include "catalog/objectaddress.h"
 #include "catalog/pg_type.h"
 
@@ -51,6 +52,14 @@
 #define CATALOG_NODE_INTERFACE	"node_interface"
 #define CATALOG_SUBSCRIPTION_ID	"sub_id_generator"
 #define CATALOG_SUBSCRIPTION	"subscription"
+#define CATALOG_RESERVED_OBJECT	"reserved_object"
+
+/* spock.reserved_object column numbers */
+#define Anum_reserved_name				1
+#define Anum_reserved_kind				2
+#define Anum_reserved_exclude_from_dump	3
+#define Anum_reserved_block_in_repset	4
+#define Anum_reserved_builtin			5
 
 typedef struct NodeTuple
 {
@@ -113,39 +122,75 @@ typedef struct SubscriptionTuple
 #define Anum_sub_created_at			15
 
 /*
- * Schemas and extensions excluded from the structure-sync dump. Restoring
- * these on a subscriber that already has them fails, so keep them out of the
- * dump. Kept separate from the subscription-specific skip list to avoid cases
- * when user drops 'sub->skip_schema' and violates these restrictions.
+ * Names of the reserved objects of the given kind (schema or extension) that
+ * are reserved for the given purpose, read from the spock.reserved_object
+ * catalog.  Names are palloc'd in the caller's context.
  */
-const char *const skip_schema[] = {
-	"lolor",
-	"snowflake",
-	"spock",
-	NULL  /* sentinel */
-};
-const char *const skip_extension[] = {
-	"lolor",
-	"snowflake",
-	"spock",
-	NULL  /* sentinel */
-};
+List *
+spock_reserved_object_names(ReservedObjectKind kind,
+							ReservedObjectPurpose purpose)
+{
+	RangeVar	   *catalog_rv;
+	Relation		catalog_rel;
+	TupleDesc		tuple_desc;
+	SysScanDesc		scan;
+	HeapTuple		tuple;
+	List		   *names = NIL;
+	const char	   *wanted_kind = (kind == RESERVED_KIND_EXTENSION)
+									? "extension" : "schema";
+	AttrNumber		flag_attnum = (purpose == RESERVED_PURPOSE_DUMP)
+									? Anum_reserved_exclude_from_dump
+									: Anum_reserved_block_in_repset;
 
-/*
- * Schemas and extensions that may not be added to a replication set. lolor is
- * absent here on purpose: its tables must replicate so large objects survive a
- * DROP EXTENSION on every node, not only where the drop was issued.
- */
-static const char *const norepset_schema[] = {
-	"snowflake",
-	"spock",
-	NULL  /* sentinel */
-};
-static const char *const norepset_extension[] = {
-	"snowflake",
-	"spock",
-	NULL  /* sentinel */
-};
+	catalog_rv = makeRangeVar(EXTENSION_NAME, CATALOG_RESERVED_OBJECT, -1);
+
+	/*
+	 * Fail closed with a clear message if the catalog is missing (e.g. a new
+	 * binary is running against a not-yet-updated extension) rather than
+	 * letting a bare "relation does not exist" leak out.
+	 */
+	if (!OidIsValid(RangeVarGetRelid(catalog_rv, NoLock, true)))
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_TABLE),
+				 errmsg("catalog \"%s.%s\" does not exist",
+						EXTENSION_NAME, CATALOG_RESERVED_OBJECT),
+				 errhint("Run \"ALTER EXTENSION spock UPDATE\".")));
+
+	catalog_rel = table_openrv(catalog_rv, AccessShareLock);
+	tuple_desc = RelationGetDescr(catalog_rel);
+
+	scan = systable_beginscan(catalog_rel, InvalidOid, false, NULL, 0, NULL);
+	while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+	{
+		bool	isnull;
+		char   *row_kind;
+		bool	reserved_for_purpose;
+
+		row_kind = TextDatumGetCString(heap_getattr(tuple, Anum_reserved_kind,
+													tuple_desc, &isnull));
+		if (strcmp(row_kind, wanted_kind) != 0)
+		{
+			pfree(row_kind);
+			continue;
+		}
+		pfree(row_kind);
+
+		reserved_for_purpose = DatumGetBool(heap_getattr(tuple, flag_attnum,
+														 tuple_desc, &isnull));
+		if (!reserved_for_purpose)
+			continue;
+
+		names = lappend(names,
+						pstrdup(NameStr(*DatumGetName(
+							heap_getattr(tuple, Anum_reserved_name,
+										 tuple_desc, &isnull)))));
+	}
+
+	systable_endscan(scan);
+	table_close(catalog_rel, AccessShareLock);
+
+	return names;
+}
 
 /*
  * We impose same validation rules as replication slot name validation does.
@@ -1320,15 +1365,19 @@ get_node_subscriptions(Oid nodeid, bool origin)
 void
 EnsureRelationNotIgnored(Relation rel)
 {
-	int		i;
-	char   *nspname;
-	Oid		extoid;
+	char	   *nspname;
+	Oid			extoid;
+	List	   *reserved;
+	ListCell   *lc;
 
 	nspname = get_namespace_name(RelationGetNamespace(rel));
 
-	for (i = 0; norepset_schema[i] != NULL; i++)
+	reserved = spock_reserved_object_names(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_REPSET);
+	foreach(lc, reserved)
 	{
-		if (strcmp(norepset_schema[i], nspname) != 0)
+		const char *schema_name = (const char *) lfirst(lc);
+
+		if (strcmp(schema_name, nspname) != 0)
 			continue;
 
 		ereport(ERROR,
@@ -1336,22 +1385,26 @@ EnsureRelationNotIgnored(Relation rel)
 				 errmsg("relation %s cannot be added to any replication set",
 						RelationGetRelationName(rel)),
 				 errdetail("table is in the ignored schema %s",
-						   norepset_schema[i]),
+						   schema_name),
 				 errhint("Move this relation to a schema allowed for replication")));
 	}
+	list_free_deep(reserved);
 
 	extoid = getExtensionOfObject(RelationRelationId, RelationGetRelid(rel));
 	if (!OidIsValid(extoid))
 		return;
 
-	for (i = 0; norepset_extension[i] != NULL; i++)
+	reserved = spock_reserved_object_names(RESERVED_KIND_EXTENSION, RESERVED_PURPOSE_REPSET);
+	foreach(lc, reserved)
 	{
+		const char *ext_name = (const char *) lfirst(lc);
+
 		/*
 		 * Detect if extension includes this relation.
 		 * XXX: Should we check if the relation doesn't belong to the extension
 		 * but depends on it?
 		 */
-		if (extoid != get_extension_oid(norepset_extension[i], true))
+		if (extoid != get_extension_oid(ext_name, true))
 			continue;
 
 		ereport(ERROR,
@@ -1359,7 +1412,8 @@ EnsureRelationNotIgnored(Relation rel)
 				 errmsg("relation %s cannot be added to any replication set",
 						RelationGetRelationName(rel)),
 				 errdetail("relation belongs to the ignored extension %s",
-						   norepset_extension[i]),
+						   ext_name),
 				 errhint("Move this relation to an extension allowed for replication")));
 	}
+	list_free_deep(reserved);
 }

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -1332,32 +1332,13 @@ copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 		foreach(lc_filter, tables)
 		{
 			SpockRemoteRel *remoterel = lfirst(lc_filter);
-			bool		skip_table = false;
-			ListCell   *lc_skip;
 
-			foreach(lc_skip, blocked)
-			{
-				if (strcmp(remoterel->nspname, (char *) lfirst(lc_skip)) == 0)
-				{
-					skip_table = true;
-					break;
-				}
-			}
+			/* Skip if the schema is blocked or on the sub's own skip list. */
+			if (name_in_list(blocked, remoterel->nspname) ||
+				name_in_list(sub->skip_schema, remoterel->nspname))
+				continue;
 
-			if (!skip_table && sub->skip_schema)
-			{
-				foreach(lc_skip, sub->skip_schema)
-				{
-					if (strcmp(remoterel->nspname, (char *) lfirst(lc_skip)) == 0)
-					{
-						skip_table = true;
-						break;
-					}
-				}
-			}
-
-			if (!skip_table)
-				filtered_tables = lappend(filtered_tables, remoterel);
+			filtered_tables = lappend(filtered_tables, remoterel);
 		}
 		list_free_deep(blocked);
 		tables = filtered_tables;

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -157,18 +157,23 @@ get_pg_executable(char *cmdname, char *cmdbuf)
 static List *
 build_exclude_extension_string(void)
 {
-	List   *lst = NIL;
-	char   *arg;
-	int		i;
+	List	   *lst = NIL;
+	char	   *arg;
+	List	   *reserved;
+	ListCell   *lc;
 
-	for (i = 0; skip_extension[i] != NULL; i++)
+	reserved = spock_reserved_object_names(RESERVED_KIND_EXTENSION, RESERVED_PURPOSE_DUMP);
+	foreach(lc, reserved)
 	{
-		if (!OidIsValid(get_extension_oid(skip_extension[i], true)))
+		const char *ext_name = (const char *) lfirst(lc);
+
+		if (!OidIsValid(get_extension_oid(ext_name, true)))
 			continue;
 
-		arg = psprintf("--exclude-extension=%s", skip_extension[i]);
+		arg = psprintf("--exclude-extension=%s", ext_name);
 		lst = lappend(lst, arg);
 	}
+	list_free_deep(reserved);
 	return lst;
 }
 #endif
@@ -178,17 +183,21 @@ build_exclude_schema_string(SpockSubscription *sub)
 {
 	List	   *lst = NIL;
 	char	   *arg;
-	int			i;
+	List	   *reserved;
 	ListCell   *lc;
 
-	for (i = 0; skip_schema[i] != NULL; i++)
+	reserved = spock_reserved_object_names(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_DUMP);
+	foreach(lc, reserved)
 	{
-		if (!OidIsValid(LookupExplicitNamespace(skip_schema[i], true)))
+		const char *schema_name = (const char *) lfirst(lc);
+
+		if (!OidIsValid(LookupExplicitNamespace(schema_name, true)))
 			continue;
 
-		arg = psprintf("--exclude-schema=%s", skip_schema[i]);
+		arg = psprintf("--exclude-schema=%s", schema_name);
 		lst = lappend(lst, arg);
 	}
+	list_free_deep(reserved);
 
 	if (sub)
 	{

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -167,9 +167,7 @@ build_exclude_extension_string(void)
 	{
 		const char *ext_name = (const char *) lfirst(lc);
 
-		if (!OidIsValid(get_extension_oid(ext_name, true)))
-			continue;
-
+		/* Unconditional: see build_exclude_schema_string(). */
 		arg = psprintf("--exclude-extension=%s", ext_name);
 		lst = lappend(lst, arg);
 	}
@@ -191,9 +189,11 @@ build_exclude_schema_string(SpockSubscription *sub)
 	{
 		const char *schema_name = (const char *) lfirst(lc);
 
-		if (!OidIsValid(LookupExplicitNamespace(schema_name, true)))
-			continue;
-
+		/*
+		 * Exclude unconditionally: we run on the subscriber but pg_dump reads
+		 * the provider (e.g. pgedge_ace exists only there on a fresh join), and
+		 * pg_dump ignores an exclude pattern that matches nothing.
+		 */
 		arg = psprintf("--exclude-schema=%s", schema_name);
 		lst = lappend(lst, arg);
 	}
@@ -1291,36 +1291,75 @@ copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 	tables = spock_get_remote_repset_tables(origin_conn,
 											replication_sets);
 
-	/* Filter out tables from schemas that should be skipped */
-	if (sub->skip_schema && list_length(sub->skip_schema) > 0)
+	/*
+	 * Drop tables we must not data-sync: any block_in_repset schema (a table
+	 * may have joined a repset before its schema was reserved), plus the
+	 * subscription's own skip_schema.  Matched by the table's own namespace;
+	 * this does not descend partition hierarchies, so a partition physically
+	 * in a reserved schema under a non-reserved parent is not caught here
+	 * (rare: the parent copy would target a partition the reserved schema's
+	 * dump-exclusion left off the subscriber, so it errors rather than
+	 * silently importing the data).
+	 */
 	{
+		MemoryContext synccxt = CurrentMemoryContext;
+		List	   *blocked = NIL;
 		List	   *filtered_tables = NIL;
 		ListCell   *lc_filter;
+
+		/*
+		 * Reading the catalog needs a transaction and this function runs with
+		 * none open; copy the names into the persistent context so they
+		 * survive the commit.
+		 */
+		StartTransactionCommand();
+		{
+			List	   *reserved = spock_reserved_object_names(RESERVED_KIND_SCHEMA,
+														   RESERVED_PURPOSE_REPSET);
+			ListCell   *lc_res;
+			MemoryContext txcxt = MemoryContextSwitchTo(synccxt);
+
+			foreach(lc_res, reserved)
+				blocked = lappend(blocked, pstrdup((char *) lfirst(lc_res)));
+
+			MemoryContextSwitchTo(txcxt);
+		}
+		CommitTransactionCommand();
+
+		/* Commit reset the current context; restore the sync context. */
+		MemoryContextSwitchTo(synccxt);
 
 		foreach(lc_filter, tables)
 		{
 			SpockRemoteRel *remoterel = lfirst(lc_filter);
-			ListCell   *lc_skip;
 			bool		skip_table = false;
+			ListCell   *lc_skip;
 
-			/* Check if this table's schema should be skipped */
-			foreach(lc_skip, sub->skip_schema)
+			foreach(lc_skip, blocked)
 			{
-				char	   *skip_schema_name = (char *) lfirst(lc_skip);
-
-				if (strcmp(remoterel->nspname, skip_schema_name) == 0)
+				if (strcmp(remoterel->nspname, (char *) lfirst(lc_skip)) == 0)
 				{
 					skip_table = true;
 					break;
 				}
 			}
 
-			/* Add table to filtered list if it shouldn't be skipped */
+			if (!skip_table && sub->skip_schema)
+			{
+				foreach(lc_skip, sub->skip_schema)
+				{
+					if (strcmp(remoterel->nspname, (char *) lfirst(lc_skip)) == 0)
+					{
+						skip_table = true;
+						break;
+					}
+				}
+			}
+
 			if (!skip_table)
 				filtered_tables = lappend(filtered_tables, remoterel);
 		}
-
-		/* Replace the original tables list with the filtered one */
+		list_free_deep(blocked);
 		tables = filtered_tables;
 	}
 

--- a/tests/regress/expected/init.out
+++ b/tests/regress/expected/init.out
@@ -43,13 +43,13 @@ CREATE EXTENSION IF NOT EXISTS spock;
 SELECT
   extnamespace::regnamespace,
   extrelocatable,
-  extconfig,
+  extconfig::regclass[] AS extconfig,
   extcondition,
   obj_description(oid) AS comment
 FROM pg_extension WHERE extname = 'spock';
- extnamespace | extrelocatable | extconfig | extcondition |            comment             
---------------+----------------+-----------+--------------+--------------------------------
- spock        | f              |           |              | PostgreSQL Logical Replication
+ extnamespace | extrelocatable |        extconfig        |     extcondition      |            comment             
+--------------+----------------+-------------------------+-----------------------+--------------------------------
+ spock        | f              | {spock.reserved_object} | {"WHERE NOT builtin"} | PostgreSQL Logical Replication
 (1 row)
 
 SELECT * FROM spock.node_create(node_name := 'test_provider', dsn := (SELECT provider_dsn FROM spock_regress_variables()) || ' user=super');

--- a/tests/regress/sql/init.sql
+++ b/tests/regress/sql/init.sql
@@ -49,7 +49,7 @@ CREATE EXTENSION IF NOT EXISTS spock;
 SELECT
   extnamespace::regnamespace,
   extrelocatable,
-  extconfig,
+  extconfig::regclass[] AS extconfig,
   extcondition,
   obj_description(oid) AS comment
 FROM pg_extension WHERE extname = 'spock';

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -48,9 +48,11 @@ test: 022_rmgr_progress_post_checkpoint_crash
 test: 022_apply_mem_context
 test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
+test: 027_reserved_object
 test: 030_autoddl_repset_stickiness
 test: 032_lolor_largeobject_repset
 test: 033_zodan_lolor_add_node
+test: 034_reserved_object_ddl
 test: 044_apply_change_logging
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match

--- a/tests/tap/t/027_reserved_object.pl
+++ b/tests/tap/t/027_reserved_object.pl
@@ -42,13 +42,23 @@ sub psql_try {
 # Seeded built-ins
 # --------------------------------------------------------------------------
 is(scalar_query(1, "SELECT count(*) FROM spock.reserved_object WHERE builtin"),
-   '6', 'six built-in reserved objects are seeded');
+   '7', 'seven built-in reserved objects are seeded');
 is(scalar_query(1, "SELECT block_in_repset FROM spock.reserved_object WHERE name='spock' AND kind='schema'"),
    't', 'spock schema is blocked from replication sets');
 is(scalar_query(1, "SELECT block_in_repset FROM spock.reserved_object WHERE name='lolor' AND kind='schema'"),
    'f', 'lolor schema is NOT blocked from replication sets (its tables must replicate)');
 is(scalar_query(1, "SELECT exclude_from_dump FROM spock.reserved_object WHERE name='lolor' AND kind='schema'"),
    't', 'lolor schema is excluded from the structure dump');
+
+# --------------------------------------------------------------------------
+# pgedge_ace: node-local schema (replicate_ddl=false), seeded as builtin
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT replicate_ddl FROM spock.reserved_object WHERE name='pgedge_ace' AND kind='schema'"),
+   'f', 'pgedge_ace schema has replicate_ddl=false (AutoDDL keeps it node-local)');
+is(scalar_query(1, "SELECT block_in_repset FROM spock.reserved_object WHERE name='pgedge_ace' AND kind='schema'"),
+   't', 'pgedge_ace schema is blocked from replication sets');
+is(scalar_query(1, "SELECT exclude_from_dump FROM spock.reserved_object WHERE name='pgedge_ace' AND kind='schema'"),
+   't', 'pgedge_ace schema is excluded from the structure dump');
 
 # --------------------------------------------------------------------------
 # Built-in rows are protected
@@ -60,6 +70,10 @@ like($out, qr/cannot delete built-in reserved object/, 'guard message shown on d
 ($rc, $out) = psql_try("UPDATE spock.reserved_object SET builtin=false WHERE name='spock' AND kind='schema'");
 isnt($rc, 0, 'modifying a built-in reserved object is rejected');
 
+($rc, $out) = psql_try("DELETE FROM spock.reserved_object WHERE name='pgedge_ace' AND kind='schema'");
+isnt($rc, 0, 'deleting the built-in pgedge_ace reserved object is rejected');
+like($out, qr/cannot delete built-in reserved object/, 'guard message shown on pgedge_ace delete');
+
 # --------------------------------------------------------------------------
 # Add helper + the C repset path reading the table live
 # --------------------------------------------------------------------------
@@ -67,6 +81,35 @@ isnt($rc, 0, 'modifying a built-in reserved object is rejected');
 is($rc, 0, "reserved_object_add('ace','schema') succeeds") or diag($out);
 is(scalar_query(1, "SELECT builtin FROM spock.reserved_object WHERE name='ace' AND kind='schema'"),
    'f', "user-added 'ace' is not a built-in");
+
+# p_replicate_ddl round-trips through reserved_object_add.
+($rc, $out) = psql_try("SELECT spock.reserved_object_add('foo','schema', p_replicate_ddl := false)");
+is($rc, 0, "reserved_object_add('foo','schema', p_replicate_ddl := false) succeeds") or diag($out);
+is(scalar_query(1, "SELECT replicate_ddl FROM spock.reserved_object WHERE name='foo' AND kind='schema'"),
+   'f', "'foo' round-trips replicate_ddl=false");
+is(scalar_query(1, "SELECT builtin FROM spock.reserved_object WHERE name='foo' AND kind='schema'"),
+   'f', "user-added 'foo' is not a built-in");
+
+# --------------------------------------------------------------------------
+# replicate_ddl is schema-only: NULL for extensions, enforced by a CHECK.
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT replicate_ddl IS NULL FROM spock.reserved_object WHERE name='spock' AND kind='extension'"),
+   't', 'built-in extension row has replicate_ddl NULL (not applicable)');
+
+# reserved_object_add coerces replicate_ddl to NULL for an extension, even
+# when a value is passed for it.
+($rc, $out) = psql_try("SELECT spock.reserved_object_add('myext','extension', p_replicate_ddl := false)");
+is($rc, 0, 'reserved_object_add for an extension succeeds') or diag($out);
+is(scalar_query(1, "SELECT replicate_ddl IS NULL FROM spock.reserved_object WHERE name='myext' AND kind='extension'"),
+   't', "extension row's replicate_ddl is coerced to NULL");
+
+# The CHECK rejects a non-NULL replicate_ddl on an extension row...
+($rc, $out) = psql_try("INSERT INTO spock.reserved_object (name, kind, replicate_ddl) VALUES ('badext', 'extension', true)");
+isnt($rc, 0, 'CHECK rejects a non-NULL replicate_ddl on an extension row');
+
+# ...and rejects a NULL replicate_ddl on a schema row.
+($rc, $out) = psql_try("INSERT INTO spock.reserved_object (name, kind, replicate_ddl) VALUES ('badschema', 'schema', NULL)");
+isnt($rc, 0, 'CHECK rejects a NULL replicate_ddl on a schema row');
 
 # Create the schemas/tables with DDL replication off, so nothing is
 # auto-added to a replication set (this cluster runs with include_ddl_repset
@@ -87,6 +130,22 @@ like($out, qr/ignored schema ace/, 'block message names the reserved schema');
 is($rc, 0, 'ace can be unblocked via the helper');
 ($rc, $out) = psql_try("SELECT spock.repset_add_table('default','ace.t')");
 is($rc, 0, 'after unblocking, the ace table can join the replication set') or diag($out);
+
+# --------------------------------------------------------------------------
+# Reserving a schema block_in_repset evicts an already-member table the next
+# time AutoDDL re-evaluates it (apply_repset_policy_for_reloid).
+# --------------------------------------------------------------------------
+psql_try("SET spock.enable_ddl_replication=off; CREATE SCHEMA evict_ns; CREATE TABLE evict_ns.t (id int primary key)");
+($rc, $out) = psql_try("SELECT spock.repset_add_table('default','evict_ns.t')");
+is($rc, 0, 'evict_ns.t joins a repset while its schema is unreserved') or diag($out);
+is(scalar_query(1, "SELECT count(*) FROM spock.tables WHERE nspname='evict_ns' AND set_name IS NOT NULL"),
+   '1', 'evict_ns.t is a repset member before its schema is reserved');
+
+psql_try("SELECT spock.reserved_object_add('evict_ns','schema')");
+($rc, $out) = psql_try("SET spock.enable_ddl_replication=on; ALTER TABLE evict_ns.t ADD COLUMN v text");
+is($rc, 0, 'ALTER on a table in a now-reserved schema succeeds locally') or diag($out);
+is(scalar_query(1, "SELECT count(*) FROM spock.tables WHERE nspname='evict_ns' AND set_name IS NOT NULL"),
+   '0', 'reserving block_in_repset then AutoDDL evicts the table from all repsets');
 
 destroy_cluster();
 done_testing();

--- a/tests/tap/t/027_reserved_object.pl
+++ b/tests/tap/t/027_reserved_object.pl
@@ -147,5 +147,40 @@ is($rc, 0, 'ALTER on a table in a now-reserved schema succeeds locally') or diag
 is(scalar_query(1, "SELECT count(*) FROM spock.tables WHERE nspname='evict_ns' AND set_name IS NOT NULL"),
    '0', 'reserving block_in_repset then AutoDDL evicts the table from all repsets');
 
+# --------------------------------------------------------------------------
+# pg_dump/pg_restore round-trip: pg_extension_config_dump(..., 'WHERE NOT
+# builtin') dumps only operator-added rows; CREATE EXTENSION re-seeds the
+# built-ins on restore, so they are preserved and never duplicated.
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT count(*) FROM spock.reserved_object WHERE NOT builtin"),
+   '4', 'four operator-added rows present before the dump (ace, foo, myext, evict_ns)');
+
+my $dumpfile = "/tmp/spock_reserved_$$.dump";
+my $rtdb     = "reserved_roundtrip";
+system("$bin/pg_dump -Fc -h $host -p $port -U $user -d $db -f $dumpfile") == 0
+    or diag("pg_dump failed");
+system("$bin/dropdb --if-exists -h $host -p $port -U $user $rtdb 2>/dev/null");
+system("$bin/createdb -h $host -p $port -U $user $rtdb") == 0
+    or diag("createdb failed");
+# Default (no --exit-on-error): unrelated restore noise never fails the run;
+# the reserved_object COPY still lands.
+system("$bin/pg_restore -h $host -p $port -U $user -d $rtdb $dumpfile 2>/dev/null");
+
+my $rt = sub {
+    my ($sql) = @_;
+    my $r = `$bin/psql -X -h $host -p $port -d $rtdb -U $user -tAc "$sql" 2>/dev/null`;
+    $r =~ s/\s+//g;
+    return $r;
+};
+is($rt->("SELECT count(*) FROM spock.reserved_object WHERE builtin"), '7',
+   'restore re-seeded exactly 7 built-in rows (no duplicates)');
+is($rt->("SELECT count(*) FROM spock.reserved_object WHERE NOT builtin"), '4',
+   'restore preserved all 4 operator-added rows');
+is($rt->("SELECT replicate_ddl FROM spock.reserved_object WHERE name='foo' AND kind='schema'"),
+   'f', "operator-added 'foo' kept replicate_ddl=false across the round-trip");
+
+system("$bin/dropdb --if-exists -h $host -p $port -U $user $rtdb 2>/dev/null");
+unlink $dumpfile;
+
 destroy_cluster();
 done_testing();

--- a/tests/tap/t/027_reserved_object.pl
+++ b/tests/tap/t/027_reserved_object.pl
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query
+);
+
+# =============================================================================
+# Test: 027_reserved_object.pl
+#
+# Verifies the spock.reserved_object catalog: the single source of truth for
+# schemas/extensions that are excluded from the structure-sync dump
+# (exclude_from_dump) and blocked from replication sets (block_in_repset),
+# replacing the old hard-coded C arrays.
+#
+# Checks the seeded built-ins, the built-in guard, the add helper, and that
+# the C repset-validation path reads the table live (adding/removing a
+# reserved schema changes whether its tables can join a replication set).
+# =============================================================================
+
+create_cluster(1);
+
+my $cfg  = get_test_config();
+my $bin  = $cfg->{pg_bin};
+my $host = $cfg->{host};
+my $port = $cfg->{node_ports}[0];
+my $db   = $cfg->{db_name};
+my $user = $cfg->{db_user};
+
+# Run SQL, return (exit_code, combined_output).  ON_ERROR_STOP => non-zero on
+# server error, so we can assert both success and failure.
+sub psql_try {
+    my ($sql) = @_;
+    my $out = `$bin/psql -X -h $host -p $port -d $db -U $user -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    return ($? >> 8, $out);
+}
+
+# --------------------------------------------------------------------------
+# Seeded built-ins
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT count(*) FROM spock.reserved_object WHERE builtin"),
+   '6', 'six built-in reserved objects are seeded');
+is(scalar_query(1, "SELECT block_in_repset FROM spock.reserved_object WHERE name='spock' AND kind='schema'"),
+   't', 'spock schema is blocked from replication sets');
+is(scalar_query(1, "SELECT block_in_repset FROM spock.reserved_object WHERE name='lolor' AND kind='schema'"),
+   'f', 'lolor schema is NOT blocked from replication sets (its tables must replicate)');
+is(scalar_query(1, "SELECT exclude_from_dump FROM spock.reserved_object WHERE name='lolor' AND kind='schema'"),
+   't', 'lolor schema is excluded from the structure dump');
+
+# --------------------------------------------------------------------------
+# Built-in rows are protected
+# --------------------------------------------------------------------------
+my ($rc, $out) = psql_try("DELETE FROM spock.reserved_object WHERE name='spock' AND kind='schema'");
+isnt($rc, 0, 'deleting a built-in reserved object is rejected');
+like($out, qr/cannot delete built-in reserved object/, 'guard message shown on delete');
+
+($rc, $out) = psql_try("UPDATE spock.reserved_object SET builtin=false WHERE name='spock' AND kind='schema'");
+isnt($rc, 0, 'modifying a built-in reserved object is rejected');
+
+# --------------------------------------------------------------------------
+# Add helper + the C repset path reading the table live
+# --------------------------------------------------------------------------
+($rc, $out) = psql_try("SELECT spock.reserved_object_add('ace','schema')");
+is($rc, 0, "reserved_object_add('ace','schema') succeeds") or diag($out);
+is(scalar_query(1, "SELECT builtin FROM spock.reserved_object WHERE name='ace' AND kind='schema'"),
+   'f', "user-added 'ace' is not a built-in");
+
+# Create the schemas/tables with DDL replication off, so nothing is
+# auto-added to a replication set (this cluster runs with include_ddl_repset
+# on).  That keeps the explicit repset_add_table calls below deterministic.
+psql_try("SET spock.enable_ddl_replication=off; CREATE SCHEMA ace; CREATE TABLE ace.t (id int primary key); CREATE TABLE public.ok (id int primary key)");
+
+# public table: allowed
+($rc, $out) = psql_try("SELECT spock.repset_add_table('default','public.ok')");
+is($rc, 0, 'a public table can be added to a replication set') or diag($out);
+
+# ace table: blocked, because ace is a reserved (block_in_repset) schema
+($rc, $out) = psql_try("SELECT spock.repset_add_table('default','ace.t')");
+isnt($rc, 0, 'a table in a reserved schema is blocked from the replication set');
+like($out, qr/ignored schema ace/, 'block message names the reserved schema');
+
+# unblock ace at runtime -> the C path picks it up immediately
+($rc, $out) = psql_try("SELECT spock.reserved_object_add('ace','schema', p_block_in_repset := false)");
+is($rc, 0, 'ace can be unblocked via the helper');
+($rc, $out) = psql_try("SELECT spock.repset_add_table('default','ace.t')");
+is($rc, 0, 'after unblocking, the ace table can join the replication set') or diag($out);
+
+destroy_cluster();
+done_testing();

--- a/tests/tap/t/027_reserved_object.pl
+++ b/tests/tap/t/027_reserved_object.pl
@@ -162,16 +162,26 @@ system("$bin/pg_dump -Fc -h $host -p $port -U $user -d $db -f $dumpfile") == 0
 system("$bin/dropdb --if-exists -h $host -p $port -U $user $rtdb 2>/dev/null");
 system("$bin/createdb -h $host -p $port -U $user $rtdb") == 0
     or diag("createdb failed");
-# Default (no --exit-on-error): unrelated restore noise never fails the run;
-# the reserved_object COPY still lands.
-system("$bin/pg_restore -h $host -p $port -U $user -d $rtdb $dumpfile 2>/dev/null");
-
 my $rt = sub {
     my ($sql) = @_;
     my $r = `$bin/psql -X -h $host -p $port -d $rtdb -U $user -tAc "$sql" 2>/dev/null`;
     $r =~ s/\s+//g;
     return $r;
 };
+
+# A whole-DB dump also re-creates spock's own node/subscription objects, and
+# restoring those into a fresh standalone DB emits unrelated errors -- so we
+# can't use --exit-on-error (it would abort before the reserved_object COPY
+# runs).  Instead capture the outcome: tolerate that noise, but surface the
+# output on any non-zero exit and assert below that the catalog actually came
+# back, so a broken round-trip can't pass silently.
+my $restore_out = `$bin/pg_restore -h $host -p $port -U $user -d $rtdb $dumpfile 2>&1`;
+my $restore_rc  = $? >> 8;
+diag("pg_restore exited $restore_rc; output follows:\n$restore_out")
+    if $restore_rc != 0;
+
+is($rt->("SELECT to_regclass('spock.reserved_object') IS NOT NULL"), 't',
+   'pg_restore recreated the spock.reserved_object catalog');
 is($rt->("SELECT count(*) FROM spock.reserved_object WHERE builtin"), '7',
    'restore re-seeded exactly 7 built-in rows (no duplicates)');
 is($rt->("SELECT count(*) FROM spock.reserved_object WHERE NOT builtin"), '4',

--- a/tests/tap/t/034_reserved_object_ddl.pl
+++ b/tests/tap/t/034_reserved_object_ddl.pl
@@ -1,0 +1,120 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query psql_or_bail wait_for_sub_status
+);
+
+# =============================================================================
+# Test: 034_reserved_object_ddl.pl
+#
+# Verifies that Spock's AutoDDL machinery treats the built-in pgedge_ace
+# schema as node-local: DDL that targets only pgedge_ace (replicate_ddl=false
+# in spock.reserved_object) must run locally on the node where it is issued,
+# but must NOT be shipped to subscribers, and pgedge_ace tables must never be
+# auto-added to a replication set (block_in_repset=true for that schema).
+#
+# This is Spock-only: it does not invoke the real pgEdge ACE utility. Plain
+# CREATE SCHEMA/CREATE TABLE DDL against the reserved "pgedge_ace" name is
+# enough to exercise the classifier. The 2-node cluster from create_cluster()
+# runs with spock.enable_ddl_replication=on and spock.include_ddl_repset=on,
+# which is exactly the AutoDDL configuration this test needs to be
+# meaningful: without it, DDL would never be a candidate for replication in
+# the first place.
+# =============================================================================
+
+create_cluster(2, 'Create 2-node cluster for reserved-object DDL test');
+
+my $cfg   = get_test_config();
+my $host  = $cfg->{host};
+my $db    = $cfg->{db_name};
+my $user  = $cfg->{db_user};
+my $pass  = $cfg->{db_password};
+my $ports = $cfg->{node_ports};
+
+my $prov_dsn = "host=$host dbname=$db port=$ports->[0] user=$user password=$pass";
+my $sub_name = 'sub_n1_n2';
+
+# --------------------------------------------------------------------------
+# Step 1: on the provider (n1), create the reserved pgedge_ace schema and a
+# table in it. This must succeed locally...
+# --------------------------------------------------------------------------
+psql_or_bail(1, "CREATE SCHEMA pgedge_ace");
+psql_or_bail(1, "CREATE TABLE pgedge_ace.ace_state (id int primary key, v text)");
+
+is(scalar_query(1, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgedge_ace')"),
+   't', 'pgedge_ace schema created locally on the provider');
+
+# ...but must never be auto-added to a replication set: pgedge_ace is
+# block_in_repset=true in spock.reserved_object.
+is(scalar_query(1,
+    "SELECT count(*) FROM spock.tables WHERE nspname = 'pgedge_ace' AND set_name IS NOT NULL"),
+   '0', 'pgedge_ace.ace_state was not auto-added to any replication set');
+
+# --------------------------------------------------------------------------
+# Step 2: an ordinary public table is our control -- it DOES get picked up
+# by AutoDDL and DOES replicate.
+# --------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE public.ace_ctrl (id int primary key, v text)");
+
+is(scalar_query(1,
+    "SELECT set_name FROM spock.tables WHERE nspname = 'public' AND relname = 'ace_ctrl'"),
+   'default', 'control table public.ace_ctrl was auto-added to the default replication set');
+
+# --------------------------------------------------------------------------
+# Step 3: subscribe n2 to n1 with structure AND data sync.  If pgedge_ace's
+# DDL had been captured for replication, or if the structure dump had not
+# excluded pgedge_ace (exclude_from_dump=true), this sync would try to
+# recreate it -- and either fail (schema already handled specially) or leak
+# it onto the subscriber. Neither should happen.
+# --------------------------------------------------------------------------
+psql_or_bail(2,
+    "SELECT spock.sub_create('$sub_name', '$prov_dsn', ARRAY['default'], true, true)");
+
+ok(wait_for_sub_status(2, $sub_name, 'replicating', 60),
+   'subscription reached replicating (structure+data sync completed)');
+
+is(scalar_query(2, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgedge_ace')"),
+   'f', 'pgedge_ace schema is ABSENT on the subscriber after structure sync');
+
+is(scalar_query(2,
+    "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'ace_ctrl')"),
+   't', 'control table public.ace_ctrl IS present on the subscriber');
+
+# --------------------------------------------------------------------------
+# Step 4: post-subscription DDL. Create another pgedge_ace table (schema-
+# qualified, so the classifier can identify it) and confirm normal DDL/DML
+# keeps flowing for the replicating repset while the pgedge_ace DDL stays
+# node-local.
+# --------------------------------------------------------------------------
+psql_or_bail(1, "CREATE TABLE pgedge_ace.local_t (id int primary key)");
+
+is(scalar_query(1, "SELECT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'pgedge_ace' AND c.relname = 'local_t')"),
+   't', 'pgedge_ace.local_t created locally on the provider after subscribe');
+
+# Fence row through the still-replicating control table.
+psql_or_bail(1, "INSERT INTO public.ace_ctrl (id, v) VALUES (1, 'fence')");
+
+my $fenced = 0;
+for (1 .. 30) {
+    my $v = scalar_query(2, "SELECT v FROM public.ace_ctrl WHERE id = 1");
+    if (defined $v && $v eq 'fence') { $fenced = 1; last; }
+    sleep(1);
+}
+ok($fenced, 'fence row replicated after node-local pgedge_ace DDL was skipped');
+
+# The pgedge_ace DDL issued after subscribe must still not have been shipped.
+is(scalar_query(2, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgedge_ace')"),
+   'f', 'pgedge_ace schema is still ABSENT on the subscriber after post-subscription DDL');
+
+# The subscription itself must be healthy -- the pgedge_ace DDL must not have
+# broken or disabled replication.
+ok(wait_for_sub_status(2, $sub_name, 'replicating', 30),
+   'subscription is still enabled/replicating after the fence row');
+
+destroy_cluster('Destroy 2-node reserved-object DDL test cluster');
+
+done_testing();

--- a/tests/tap/t/034_reserved_object_ddl.pl
+++ b/tests/tap/t/034_reserved_object_ddl.pl
@@ -65,6 +65,22 @@ is(scalar_query(1,
    'default', 'control table public.ace_ctrl was auto-added to the default replication set');
 
 # --------------------------------------------------------------------------
+# Step 2b: an OPERATOR-added reserved schema (not a built-in). Reserve it on
+# both nodes -- node-local config, applied per node -- so its table never
+# joins a repset on the provider (block_in_repset) and the structure dump
+# excludes it (exclude_from_dump). It must therefore be absent on the
+# subscriber after the structure sync below.
+# --------------------------------------------------------------------------
+psql_or_bail(1, "SELECT spock.reserved_object_add('op_local', 'schema')");
+psql_or_bail(2, "SELECT spock.reserved_object_add('op_local', 'schema')");
+psql_or_bail(1, "CREATE SCHEMA op_local");
+psql_or_bail(1, "CREATE TABLE op_local.t (id int primary key, v text)");
+
+is(scalar_query(1,
+    "SELECT count(*) FROM spock.tables WHERE nspname = 'op_local' AND set_name IS NOT NULL"),
+   '0', 'operator-reserved op_local.t was not auto-added to any replication set');
+
+# --------------------------------------------------------------------------
 # Step 3: subscribe n2 to n1 with structure AND data sync.  If pgedge_ace's
 # DDL had been captured for replication, or if the structure dump had not
 # excluded pgedge_ace (exclude_from_dump=true), this sync would try to
@@ -79,6 +95,9 @@ ok(wait_for_sub_status(2, $sub_name, 'replicating', 60),
 
 is(scalar_query(2, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgedge_ace')"),
    'f', 'pgedge_ace schema is ABSENT on the subscriber after structure sync');
+
+is(scalar_query(2, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'op_local')"),
+   'f', 'operator-reserved op_local schema is ABSENT on the subscriber (exclude_from_dump)');
 
 is(scalar_query(2,
     "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'ace_ctrl')"),


### PR DESCRIPTION
Spock keeps certain schemas and extensions out of the structure synchronization dump, and forbids their tables from being added to a replication set.  This set was fixed and could only be changed by rebuilding the extension, and the two behaviours were maintained independently, so they could drift apart.

Keep the set in a catalog instead, seeded with the same defaults as before: spock and snowflake are both excluded from the dump and blocked from replication sets, while lolor is excluded from the dump but still allowed in replication sets so that large objects survive dropping the extension on every node.  The seeded entries are protected and cannot be removed, and an operator can now reserve additional schemas or extensions without rebuilding.  Such additions are preserved across dump and restore, while the built-in entries are always re-created.

SPOC-581
SPOC-582
SPOC-615
SPOC-614