### PR TITLE
docs: document spock.failover_slots_naptime GUCs

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -308,6 +308,32 @@ given LSN before logical replication is allowed to proceed. The default
 spock.standby_slots_min_confirmed = -1
 ```
 
+### `spock.failover_slots_naptime`
+
+How long the `spock_failover_slots` worker sleeps between slot-synchronization
+passes, in milliseconds. A smaller value keeps the standby's synchronized slots
+closer to the primary — narrowing the window in which a promotion can find a
+stale slot — at the cost of more frequent sync passes. Default: `1000` (1s).
+Range: `1000`–`3600000`. Settable at runtime with `SIGHUP` (reload).
+
+```ini
+spock.failover_slots_naptime = 1000
+```
+
+Used on PostgreSQL 15, 16, and 17 (when `sync_replication_slots` is not
+enabled).
+
+### `spock.failover_slots_feedback_naptime`
+
+Shorter retry interval, in milliseconds, used instead of
+`spock.failover_slots_naptime` while the standby has not yet received or fed
+back the WAL a slot needs. Default: `10000` (10s). Range: `1000`–`3600000`.
+Settable at runtime with `SIGHUP` (reload).
+
+```ini
+spock.failover_slots_feedback_naptime = 10000
+```
+
 ### `spock.include_ddl_repset`
 
 `spock.include_ddl_repset` enables spock to automatically add tables to

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -92,6 +92,8 @@ on the standby and periodically copies slot state from the primary.
 | `spock.primary_dsn` | `''` | DSN to connect to primary (falls back to `primary_conninfo`) |
 | `spock.pg_standby_slot_names` | `''` | Physical slots that must confirm LSN before logical replication advances |
 | `spock.standby_slots_min_confirmed` | `-1` | How many slots from `pg_standby_slot_names` must confirm (`-1` = all) |
+| `spock.failover_slots_naptime` | `1000` | Worker sleep between slot-sync passes, in ms (SIGHUP; range 1000–3600000) |
+| `spock.failover_slots_feedback_naptime` | `10000` | Shorter retry, in ms, while waiting for standby WAL feedback (SIGHUP; range 1000–3600000) |
 
 ### Example (`postgresql.conf` on standby)
 

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -1,5 +1,26 @@
 # Spock Release Notes
 
+## Spock 5.0.11
+
+### New Features
+* Sync failover slots to the standby every 1s by default instead of a
+  hard-coded 60s, shrinking the window in which a promotion can find a stale
+  slot. The interval is now tunable via `spock.failover_slots_naptime` (and the
+  feedback-wait retry via `spock.failover_slots_feedback_naptime`), both
+  SIGHUP-settable in milliseconds
+
+* Never copy the `pgedge_ace` schema to a node joining via `add_node`. ACE
+  state is node-local, so its objects are now excluded from both the schema
+  copy and the data sync, even when an ACE table belongs to a replication set.
+
+### Bug Fixes
+
+* Fixed a bug where a transient provider connection loss could incorrectly
+  disable a subscription under SUB_DISABLE exception handling. A transaction
+  retransmitted after a reconnect is no longer misclassified as an apply
+  failure, so replication resumes normally instead of stopping.
+
+
 ## Spock 5.0.10
 
 ### Bug Fixes


### PR DESCRIPTION
Add configuring.md entries and a logical_slot_failover.md table row for spock.failover_slots_naptime and spock.failover_slots_feedback_naptime, and note the change in the 5.0.11 release notes. Covers defaults (1s / 10s), the 1000-3600000 ms range, and SIGHUP reloadability, following commit 550adf4.