### PR TITLE
Forward-port configurable failover-slot sync intervals to main

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -340,6 +340,32 @@ the primary and read slot state. If empty, `primary_conninfo` from
 spock.primary_dsn = ''
 ```
 
+### `spock.failover_slots_naptime`
+
+How long the `spock_failover_slots` worker sleeps between slot-synchronization
+passes, in milliseconds. A smaller value keeps the standby's synchronized slots
+closer to the primary, narrowing the window in which promotion can find stale
+slot state, at the cost of more frequent sync passes. Default: `1000` (1s).
+Range: `1000`–`3600000`. Reloadable with `SIGHUP`.
+
+```ini
+spock.failover_slots_naptime = 1000
+```
+
+This applies on PostgreSQL 15, 16, and 17 when native
+`sync_replication_slots` is not enabled.
+
+### `spock.failover_slots_feedback_naptime`
+
+Shorter retry interval, in milliseconds, used instead of
+`spock.failover_slots_naptime` while the standby has not yet received or fed
+back the WAL needed by a slot. Default: `10000` (10s). Range:
+`1000`–`3600000`. Reloadable with `SIGHUP`.
+
+```ini
+spock.failover_slots_feedback_naptime = 10000
+```
+
 ### `spock.pg_standby_slot_names`
 
 Comma-separated list of physical replication slot names that must confirm
@@ -464,5 +490,4 @@ for schema synchronization are written. This path needs to exist and be
 writable by the user running Postgres. The default is `empty`, which tells
 Spock to use the default temporary directory based on environment or
 operating system settings.
-
 

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -161,6 +161,8 @@ on the standby and periodically copies slot state from the primary.
 | `spock.primary_dsn` | `''` | DSN to connect to primary (falls back to `primary_conninfo`) |
 | `spock.pg_standby_slot_names` | `''` | Physical slots that must confirm LSN before logical replication advances |
 | `spock.standby_slots_min_confirmed` | `-1` | How many slots from `pg_standby_slot_names` must confirm (`-1` = all) |
+| `spock.failover_slots_naptime` | `1000` | Worker sleep between slot-sync passes, in ms (SIGHUP; range 1000–3600000) |
+| `spock.failover_slots_feedback_naptime` | `10000` | Shorter retry, in ms, while waiting for standby WAL feedback (SIGHUP; range 1000–3600000) |
 
 ### Example (`postgresql.conf` on standby)
 

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -21,6 +21,10 @@ see *Upgrading* below before running `ALTER EXTENSION spock UPDATE`.
   `wal_sender_timeout` workaround; new `spock.apply_idle_timeout` GUC.
 * **Logical slot failover** uses native PostgreSQL slotsync on PG17+ /
   PG18+.
+* **Tunable failover-slot synchronization on PostgreSQL 15–17** —
+  `spock.failover_slots_naptime` and
+  `spock.failover_slots_feedback_naptime` replace the fixed worker intervals;
+  the slot-sync pass now defaults to 1 second and both settings are reloadable.
 * **Rolling upgrade support** — protocol negotiation (v4 for 5.0.x, v5 for
   6.0+) enables zero-downtime rolling upgrades.
 * **Exception handling refactor** — stable behaviour under TRANSDISCARD /

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -60,8 +60,9 @@
 #include "libpq/auth.h"
 #include "libpq/libpq.h"
 
-#define WORKER_NAP_TIME 60000L
-#define WORKER_WAIT_FEEDBACK 10000L
+/* Defaults (milliseconds) for the tunable worker intervals below. */
+#define WORKER_NAP_TIME_DEFAULT 1000
+#define WORKER_WAIT_FEEDBACK_DEFAULT 10000
 
 /*
  * PostgreSQL 19 replaced ReplicationSlot.active_pid (an int pid, 0 when the
@@ -111,6 +112,16 @@ static char *spock_failover_slot_names;
 static char *spock_failover_slot_names_str = NULL;
 static List *spock_failover_slot_names_list = NIL;
 static bool spock_failover_slots_drop = true;
+
+/*
+ * How long the worker sleeps between slot-sync passes, and the shorter retry
+ * used while it is still waiting for the standby to receive/feedback WAL.
+ * Both are in milliseconds and settable at runtime (SIGHUP).  A smaller
+ * naptime narrows the window in which the standby's synced slots lag the
+ * primary, at the cost of more frequent sync passes.
+ */
+static int	spock_failover_slots_naptime = WORKER_NAP_TIME_DEFAULT;
+static int	spock_failover_slots_feedback_naptime = WORKER_WAIT_FEEDBACK_DEFAULT;
 
 void		spock_init_failover_slot(void);
 
@@ -1180,7 +1191,7 @@ synchronize_failover_slots(long sleep_time)
 							"cannot synchronize replication slot positions yet because feedback was not sent yet")));
 			was_lsn_safe = false;
 			PQfinish(conn);
-			return Min(sleep_time, WORKER_WAIT_FEEDBACK);
+			return Min(sleep_time, spock_failover_slots_feedback_naptime);
 		}
 		else if (WalRcv->latestWalEnd < lsn)
 		{
@@ -1193,7 +1204,7 @@ synchronize_failover_slots(long sleep_time)
 							(uint32) (WalRcv->latestWalEnd))));
 			was_lsn_safe = false;
 			PQfinish(conn);
-			return Min(sleep_time, WORKER_WAIT_FEEDBACK);
+			return Min(sleep_time, spock_failover_slots_feedback_naptime);
 		}
 
 		foreach(lc, slots)
@@ -1290,7 +1301,7 @@ spock_failover_slots_main(Datum main_arg)
 	while (true)
 	{
 		int			rc;
-		long		sleep_time = WORKER_NAP_TIME;
+		long		sleep_time = spock_failover_slots_naptime;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -1309,9 +1320,9 @@ spock_failover_slots_main(Datum main_arg)
 			&& !sync_replication_slots
 #endif
 			)
-			sleep_time = synchronize_failover_slots(WORKER_NAP_TIME);
+			sleep_time = synchronize_failover_slots(spock_failover_slots_naptime);
 		else
-			sleep_time = WORKER_NAP_TIME * 10;
+			sleep_time = (long) spock_failover_slots_naptime * 10;
 
 		rc =
 			WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
@@ -1825,6 +1836,24 @@ spock_init_failover_slot(void)
 							   "if empty, uses the defaults to primary_conninfo",
 							   &spock_failover_slots_dsn, "", PGC_SIGHUP, GUC_SUPERUSER_ONLY, NULL, NULL,
 							   NULL);
+
+	DefineCustomIntVariable(
+		"spock.failover_slots_naptime",
+		"time the failover slot worker sleeps between slot synchronization passes",
+		"A smaller value keeps the standby's synchronized slots closer to the "
+		"primary, at the cost of more frequent sync passes.",
+		&spock_failover_slots_naptime, WORKER_NAP_TIME_DEFAULT,
+		1000, 3600000,
+		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"spock.failover_slots_feedback_naptime",
+		"shorter retry interval used while waiting for standby WAL feedback",
+		"The worker retries this often (instead of failover_slots_naptime) while "
+		"the standby has not yet received or fed back the WAL a slot needs.",
+		&spock_failover_slots_feedback_naptime, WORKER_WAIT_FEEDBACK_DEFAULT,
+		1000, 3600000,
+		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 
 	if (IsBinaryUpgrade)

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -48,6 +48,7 @@ test: 022_rmgr_progress_post_checkpoint_crash
 test: 022_apply_mem_context
 test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
+test: 026_failover_slots_naptime_guc
 test: 030_autoddl_repset_stickiness
 test: 032_lolor_largeobject_repset
 test: 044_apply_change_logging

--- a/tests/tap/t/026_failover_slots_naptime_guc.pl
+++ b/tests/tap/t/026_failover_slots_naptime_guc.pl
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query
+);
+
+# =============================================================================
+# Test: 026_failover_slots_naptime_guc.pl
+#
+# Verifies the tunable failover-slot worker interval GUCs:
+#   spock.failover_slots_naptime
+#   spock.failover_slots_feedback_naptime
+#
+# These control how often the spock_failover_slots worker syncs slot state to
+# a physical standby.  A smaller naptime narrows the window in which the
+# standby's synchronized slots lag the primary.
+#
+# The test checks defaults, unit, bounds, reloadability, that a new value
+# takes effect on reload, and that out-of-range values are rejected.
+# =============================================================================
+
+create_cluster(1);
+
+my $cfg  = get_test_config();
+my $bin  = $cfg->{pg_bin};
+my $host = $cfg->{host};
+my $port = $cfg->{node_ports}[0];
+my $db   = $cfg->{db_name};
+my $user = $cfg->{db_user};
+
+# Run SQL and return (exit_code, combined_output).  ON_ERROR_STOP makes psql
+# exit non-zero when the server rejects the statement.
+sub psql_try {
+    my ($sql) = @_;
+    my $out = `$bin/psql -X -h $host -p $port -d $db -U $user -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    return ($? >> 8, $out);
+}
+
+sub setting_of {
+    my ($name) = @_;
+    return scalar_query(1,
+        "SELECT setting FROM pg_settings WHERE name = '$name'");
+}
+
+# --------------------------------------------------------------------------
+# Defaults (pg_settings reports the value in the base unit, ms)
+# --------------------------------------------------------------------------
+is(setting_of('spock.failover_slots_naptime'), '1000',
+   'failover_slots_naptime default is 1000 ms');
+is(setting_of('spock.failover_slots_feedback_naptime'), '10000',
+   'failover_slots_feedback_naptime default is 10000 ms');
+
+# --------------------------------------------------------------------------
+# Unit, bounds, and context
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT unit FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   'ms', 'naptime unit is ms');
+is(scalar_query(1, "SELECT min_val||'/'||max_val FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   '1000/3600000', 'naptime bounds are 1000..3600000 ms');
+is(scalar_query(1, "SELECT context FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   'sighup', 'naptime is reloadable (sighup), no restart needed');
+
+# --------------------------------------------------------------------------
+# A new value takes effect on reload
+# --------------------------------------------------------------------------
+my ($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '5s'");
+is($rc, 0, "ALTER SYSTEM accepts '5s'") or diag($out);
+psql_try("SELECT pg_reload_conf()");
+
+# Reload is asynchronous; poll briefly for the change to land.
+my $val = '';
+for (1 .. 20) {
+    $val = setting_of('spock.failover_slots_naptime');
+    last if $val eq '5000';
+    select(undef, undef, undef, 0.25);
+}
+is($val, '5000', "naptime becomes 5000 ms after reload");
+
+# --------------------------------------------------------------------------
+# Out-of-range values are rejected
+# --------------------------------------------------------------------------
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '10ms'");
+isnt($rc, 0, "ALTER SYSTEM rejects 10ms (below the 1s minimum)");
+like($out, qr/outside the valid range|invalid value/i,
+     "rejection message mentions the valid range");
+
+# Restore the default so the node is clean for teardown.
+psql_try("ALTER SYSTEM RESET spock.failover_slots_naptime");
+psql_try("SELECT pg_reload_conf()");
+
+destroy_cluster();
+done_testing();


### PR DESCRIPTION
## Summary

Forward-port the accepted v5 implementation from #527 to `main`.

- add `spock.failover_slots_naptime` with the accepted 1-second default;
- add `spock.failover_slots_feedback_naptime` with the 10-second feedback-wait default;
- preserve the PostgreSQL 17 guard that yields to native `sync_replication_slots`;
- document both reloadable GUCs; and
- add the existing TAP test to the default schedule so CI executes it.

## Root cause and evidence

`main` still hard-codes the Spock failover-slot worker interval to 60 seconds for PostgreSQL 15-17. During that interval, the synchronized standby slot can lag the primary slot; promotion inside that window can therefore expose stale logical-slot state. PR #527 addressed the same code path on `v5_STABLE` and was included in `v5.0.11-rc.1`, but its implementation is absent from `main`.

PostgreSQL 18+ remains unaffected because `main` does not register this worker there and uses native logical slot synchronization.

## Validation

- PostgreSQL 16 build: PASS
- `PROVE_TESTS=t/026_failover_slots_naptime_guc.pl make check_prove`: PASS (13 assertions)
- validated defaults, units, bounds, SIGHUP reload, and out-of-range rejection

## Related

- #527
- #532 (the separate v5 backport of #525; no duplicate backport is needed)

GenAI-Compliance: REFINED_BY_USER
GenAI-Context: AI assisted with upstream comparison, mainline adaptation, focused testing, and PR documentation; the changes were reviewed and customized by the author.
GenAI-Usage: 41-100%