### PR TITLE
Remap filtered rows to relation descriptor for dropped columns

### DIFF
--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -3040,11 +3040,21 @@ spock_table_data_filtered(PG_FUNCTION_ARGS)
 		for (i = 0; i < SPI_processed; i++)
 		{
 			HeapTuple	tup = SPI_tuptable->vals[i];
+			HeapTuple	remapped = NULL;
 
 			if (map != NULL)
-				tup = execute_attr_map_tuple(tup, map);
+				tup = remapped = execute_attr_map_tuple(tup, map);
 
 			tuplestore_puttuple(tupstore, tup);
+
+			/*
+			 * execute_attr_map_tuple() allocates a fresh tuple for every row.
+			 * tuplestore_puttuple() copies it, so free the remapped tuple to
+			 * avoid accumulating them for the whole result set. The original
+			 * SPI tuple is owned by SPI and must not be freed here.
+			 */
+			if (remapped != NULL)
+				heap_freetuple(remapped);
 		}
 
 		if (map != NULL)

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -17,6 +17,7 @@
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/sysattr.h"
+#include "access/tupconvert.h"
 #include "access/xact.h"
 #include "access/xlog.h"
 #include "access/xlogrecovery.h"
@@ -3019,11 +3020,35 @@ spock_table_data_filtered(PG_FUNCTION_ARGS)
 	if (rc != SPI_OK_SELECT)
 		elog(ERROR, "SPOCK: SPI_execute() failed");
 
-	for (i = 0; i < SPI_processed; i++)
+	/*
+	 * "SELECT *" leaves out dropped columns, so the result tuples produced by
+	 * SPI carry only the live attributes. Storing them directly against the
+	 * relation descriptor (which still counts the dropped attributes) makes
+	 * every attribute after a dropped one read at the wrong offset, yielding
+	 * corrupt rows or a crash when a misaligned varlena is detoasted. Remap
+	 * each tuple to the relation descriptor, which fills NULLs at the dropped
+	 * positions, when the two descriptors differ.
+	 */
+	if (SPI_processed > 0)
 	{
-		HeapTuple	tup = SPI_tuptable->vals[i];
+		TupleConversionMap *map;
 
-		tuplestore_puttuple(tupstore, tup);
+		map = convert_tuples_by_position(SPI_tuptable->tupdesc, tupdesc,
+										 "SPOCK: filtered row type does not "
+										 "match relation");
+
+		for (i = 0; i < SPI_processed; i++)
+		{
+			HeapTuple	tup = SPI_tuptable->vals[i];
+
+			if (map != NULL)
+				tup = execute_attr_map_tuple(tup, map);
+
+			tuplestore_puttuple(tupstore, tup);
+		}
+
+		if (map != NULL)
+			free_conversion_map(map);
 	}
 
 	/* Cleanup. */


### PR DESCRIPTION
`spock_table_data_filtered()` runs `SELECT * FROM <rel>` through SPI and puts the result tuples straight into the tuplestore, whose descriptor is the full relation descriptor. `SELECT *` omits dropped columns, so those tuples only carry the live attributes and every attribute past a dropped position is then read at the wrong offset, giving corrupt/NULL data on the subscriber or a provider crash when a misread varlena is detoasted (#528).

This remaps each SPI tuple to the relation descriptor with `convert_tuples_by_position()` / `execute_attr_map_tuple()`, which inserts NULLs at the dropped positions; when the descriptors already match, `convert_tuples_by_position()` returns NULL and the tuples are stored unchanged.

Reproducing and adding the row-filter regression case both need a running provider/subscriber cluster, which I could not spin up locally, so I verified the change compiles clean against the PG server headers but did not run the sync suite. A minimal SQL repro from the issue:

```sql
CREATE TABLE public.tdf_repro (id int PRIMARY KEY, a text, junk text, b text);
INSERT INTO public.tdf_repro VALUES (1, 'aa', 'xx', 'bb');
ALTER TABLE public.tdf_repro DROP COLUMN junk;
-- before: spock.table_data_filtered() returns b as NULL / misaligned; after: correct rows
```
