### PR TITLE
Add spock.use_native_failover_slots: opt-in native PG17+ failover slots (v5).

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -252,21 +252,38 @@ On PostgreSQL 17+, when `spock.use_native_failover_slots = on`, Spock marks
 every logical slot with the `FAILOVER` flag at creation time. PostgreSQL's
 built-in slotsync worker then synchronizes those slots automatically.
 
-On **PostgreSQL 18+** with the GUC on, Spock's own failover worker is not
-registered. You must configure the native mechanism:
+On **PostgreSQL 17**, Spock's worker only yields to native slotsync when you
+also set `sync_replication_slots = on` (below). On **PostgreSQL 18+** with the
+GUC on, Spock's own failover worker is not registered, so the native mechanism
+is required. Either way you must configure PostgreSQL's own slot
+synchronization. The `spock.use_native_failover_slots` GUC alone is not enough.
+
+First create the physical replication slot on the primary. The standby streams
+through it, and its `catalog_xmin` (fed back via `hot_standby_feedback`) is what
+protects the synchronized logical slots from being invalidated:
+
+```sql
+SELECT pg_create_physical_replication_slot('physical_slot_name');
+```
 
 **Primary (`postgresql.conf`):**
 ```ini
+# Hold logical walsenders back until the standby has confirmed the changes.
 synchronized_standby_slots = 'physical_slot_name'
 ```
 
 **Standby (`postgresql.conf`):**
 ```ini
-sync_replication_slots = on
-primary_conninfo = 'host=<primary_host> dbname=<dbname> ...'
-primary_slot_name = 'physical_slot_name'
-hot_standby_feedback = on
+sync_replication_slots = on                      # enable the native slotsync worker
+hot_standby_feedback   = on                      # required; pins the primary's catalog vacuum
+primary_slot_name      = 'physical_slot_name'    # the physical slot created above
+primary_conninfo       = 'host=<primary_host> dbname=<dbname> ...'   # must include dbname
 ```
+
+Only logical slots created with `failover = true` are synchronized. Spock sets
+that flag automatically at slot creation when `spock.use_native_failover_slots
+= on`; slots that already existed before the GUC was turned on must be
+recreated to gain it.
 
 After a failover, subscribers only need to update their `host=` in the
 connection string — replication resumes from the last synchronized LSN with

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -207,24 +207,53 @@ Spock creates logical replication slots on each provider node. For high
 availability with a physical standby, these slots must be synchronized to the
 standby so that replication can resume without data loss after a failover.
 
-See [Logical Slot Failover](logical_slot_failover.md) for full setup instructions.
+See [Logical Slot Failover](logical_slot_failover.md) for full setup
+instructions, including a mandatory runbook step for clearing
+`synchronized_standby_slots` on the promoted node after a failover.
 
-The behaviour depends on the PostgreSQL version:
+#### `spock.use_native_failover_slots`
 
-| PostgreSQL | Slot sync mechanism | Spock worker |
-|---|---|---|
-| 15, 16 | Spock built-in `spock_failover_slots` worker | Always runs |
-| 17 | Spock worker OR native `sync_replication_slots` | Spock worker yields to native if enabled |
-| 18+ | Native `sync_replication_slots` (required) | Not registered |
+On Spock 5, PostgreSQL's native slot-failover path (PG17+) is **opt-in**,
+controlled by the boolean GUC `spock.use_native_failover_slots` (default
+`off`). This GUC is `PGC_POSTMASTER`, so changing it requires a **server
+restart** — it cannot be set with `SET` or reloaded with `SIGHUP`.
 
-#### PostgreSQL 17 and Later (Native Slot Sync)
+The flag is read on the **subscriber** — the node that creates the logical
+replication slot on the provider via `CREATE_REPLICATION_SLOT`. Set it on
+that node, not on the provider.
 
-On PostgreSQL 17+, Spock marks every logical slot with the `FAILOVER` flag
-at creation time. PostgreSQL's built-in slotsync worker then synchronizes
-those slots automatically.
+ZODAN's `add_node` path differs: it checks the GUC via `dblink` on the
+node that **hosts** the slot (the existing provider), not on the node
+being added. Since this is a `PGC_POSTMASTER` GUC, set
+`spock.use_native_failover_slots` **uniformly** on every node so both
+paths behave consistently.
 
-On **PostgreSQL 18+**, Spock's own failover worker is not registered. You
-must configure the native mechanism:
+```ini
+spock.use_native_failover_slots = on   # default: off
+```
+
+The behaviour depends on both the PostgreSQL version and this GUC:
+
+| PostgreSQL | GUC | Slot sync mechanism | Spock worker |
+|---|---|---|---|
+| 15, 16 | off or on | Spock built-in `spock_failover_slots` worker | Always runs |
+| 17 | off (default) | Spock built-in worker only | Always runs; no `FAILOVER` flag |
+| 17 | on | Spock worker OR native `sync_replication_slots` | Yields to native if `sync_replication_slots = on` |
+| 18+ | off (default) | Spock built-in `spock_failover_slots` worker | Always runs; no `FAILOVER` flag |
+| 18+ | on | Native `sync_replication_slots` (required) | Not registered |
+
+With the GUC left at its default `off`, Spock behaves exactly as it always
+has on every PostgreSQL version: no slot carries the `FAILOVER` flag and the
+Spock worker (below) handles synchronization.
+
+#### PostgreSQL 17 and Later (Native Slot Sync, requires `spock.use_native_failover_slots = on`)
+
+On PostgreSQL 17+, when `spock.use_native_failover_slots = on`, Spock marks
+every logical slot with the `FAILOVER` flag at creation time. PostgreSQL's
+built-in slotsync worker then synchronizes those slots automatically.
+
+On **PostgreSQL 18+** with the GUC on, Spock's own failover worker is not
+registered. You must configure the native mechanism:
 
 **Primary (`postgresql.conf`):**
 ```ini
@@ -241,14 +270,24 @@ hot_standby_feedback = on
 
 After a failover, subscribers only need to update their `host=` in the
 connection string — replication resumes from the last synchronized LSN with
-no data loss.
+no data loss. **However**, if `synchronized_standby_slots` was configured on
+the primary, you must clear or update it on the newly promoted node first —
+otherwise the promoted node's walsenders wait forever on the now-orphaned
+physical slot(s) and logical replication to subscribers freezes. See the
+[runbook in Logical Slot Failover](logical_slot_failover.md#runbook-clear-synchronized_standby_slots-after-promotion)
+for the exact steps.
+
+If the GUC is left `off` (the default), PG18+ behaves like PG15/16/17 below
+— Spock's own worker is registered and runs.
 
 #### PostgreSQL 15, 16, and 17 (Spock Built-in Worker)
 
-On PostgreSQL 15, 16, and 17, Spock's `spock_failover_slots` background worker
-handles slot synchronization. On PostgreSQL 17 it yields to the native
-slotsync worker when `sync_replication_slots = on` is enabled. Configure it
-with the GUCs below.
+On PostgreSQL 15 and 16, Spock's `spock_failover_slots` background worker
+always handles slot synchronization, regardless of the GUC above (there is
+no native mechanism to defer to). On PostgreSQL 17, it also handles
+synchronization unless `spock.use_native_failover_slots = on` **and**
+`sync_replication_slots = on` are both set, in which case it yields to the
+native slotsync worker. Configure the Spock worker with the GUCs below.
 
 ### `spock.synchronize_slot_names`
 
@@ -260,9 +299,12 @@ Default: `name_like:%%` (synchronize all logical slots).
 spock.synchronize_slot_names = 'name_like:%%'
 ```
 
-Used on PostgreSQL 15, 16, and 17 (when `sync_replication_slots` is not
-enabled). On PostgreSQL 17 with native slotsync active, or on PostgreSQL 18+,
-this setting is ignored.
+Used whenever the Spock worker is running: PostgreSQL 15 and 16 always;
+PostgreSQL 17 when native slotsync is not active (either
+`spock.use_native_failover_slots` is `off`, or it is `on` but
+`sync_replication_slots` is not enabled). On PostgreSQL 17 with native
+slotsync active, or on PostgreSQL 18+ with `spock.use_native_failover_slots
+= on`, this setting is ignored.
 
 ### `spock.drop_extra_slots`
 
@@ -294,9 +336,12 @@ falling behind a logical subscriber.
 spock.pg_standby_slot_names = 'physical_slot_1,physical_slot_2'
 ```
 
-Used on PostgreSQL 15, 16, and 17 (when `sync_replication_slots` is not
-enabled). On PostgreSQL 17+ with native slotsync, or on PostgreSQL 18+, use
-`synchronized_standby_slots` instead.
+Used whenever the Spock worker is running: PostgreSQL 15 and 16 always;
+PostgreSQL 17 when native slotsync is not active (either
+`spock.use_native_failover_slots` is `off`, or it is `on` but
+`sync_replication_slots` is not enabled). On PostgreSQL 17+ with native
+slotsync, or on PostgreSQL 18+ with `spock.use_native_failover_slots = on`,
+use `synchronized_standby_slots` instead.
 
 ### `spock.standby_slots_min_confirmed`
 
@@ -320,8 +365,10 @@ Range: `1000`–`3600000`. Settable at runtime with `SIGHUP` (reload).
 spock.failover_slots_naptime = 1000
 ```
 
-Used on PostgreSQL 15, 16, and 17 (when `sync_replication_slots` is not
-enabled).
+Used whenever the Spock worker is running: PostgreSQL 15 and 16 always;
+PostgreSQL 17 when native slotsync is not active (either
+`spock.use_native_failover_slots` is `off`, or it is `on` but
+`sync_replication_slots` is not enabled).
 
 ### `spock.failover_slots_feedback_naptime`
 

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -15,30 +15,72 @@ failover occurs.
 Without slot synchronization, a failover would require manual slot recreation
 and a full re-sync of all subscriber tables.
 
+## Opt-in: `spock.use_native_failover_slots`
+
+Starting with Spock 5, PostgreSQL's native slot-failover path (PG17+) is
+**opt-in**, controlled by the boolean GUC `spock.use_native_failover_slots`
+(**default `off`**). With the GUC off, Spock behaves exactly as before on
+every PostgreSQL version: its own `spock_failover_slots` worker runs and no
+slot carries the `FAILOVER` flag.
+
+This GUC is `PGC_POSTMASTER` — it can only be set in `postgresql.conf` (or
+`ALTER SYSTEM`) and requires a **server restart** to take effect; it cannot
+be changed with `SET` or reloaded with `SIGHUP`.
+
+The flag is read on the **subscriber** — the node that issues
+`CREATE_REPLICATION_SLOT` against the provider to create its logical slot.
+Set it there, not on the provider.
+
+ZODAN's `add_node` path works differently: it checks the GUC via `dblink`
+on the node that **hosts** the slot (the existing provider), not on the
+node being added. Because this is a `PGC_POSTMASTER` GUC, set
+`spock.use_native_failover_slots` **uniformly** on every node in the
+cluster so both paths agree on the same behavior.
+
 ## PostgreSQL Version Behaviour
 
-| PostgreSQL | Slot sync mechanism | Spock worker |
-|---|---|---|
-| 15, 16 | Spock built-in `spock_failover_slots` worker | Always runs on standby |
-| 17 | Spock worker **or** native `sync_replication_slots` | Yields to native if enabled |
-| 18+ | Native `sync_replication_slots` (required) | Not registered |
+| PostgreSQL | `spock.use_native_failover_slots` | Slot sync mechanism | Spock worker |
+|---|---|---|---|
+| 15, 16 | off or on | Spock built-in `spock_failover_slots` worker | Always runs on standby |
+| 17 | off (default) | Spock built-in worker only | Always runs the full sync loop; no `FAILOVER` flag |
+| 17 | on | Slots created with `(FAILOVER)`; native `sync_replication_slots` (if enabled) | Worker still registered but **yields** its sync loop when `sync_replication_slots = on` |
+| 18+ | off (default) | Spock built-in `spock_failover_slots` worker | Always runs; no `FAILOVER` flag |
+| 18+ | on | Native `sync_replication_slots` (required) | **Not registered** |
 
-On **PostgreSQL 17+**, Spock marks every logical slot with the `FAILOVER` flag
-at creation time. This enables PostgreSQL's built-in slotsync worker to pick
-them up automatically.
+On PG15/16 there is no native slotsync mechanism, so the GUC has no effect;
+Spock's worker always handles synchronization regardless of the setting.
 
-On **PostgreSQL 18+**, Spock's own failover worker is not registered at all.
-The native slotsync worker is the only mechanism.
+On **PostgreSQL 17+**, when the GUC is `on`, Spock marks every logical slot
+with the `FAILOVER` flag at creation time. This enables PostgreSQL's built-in
+slotsync worker to pick them up automatically.
 
-## Setup: PostgreSQL 18+ (Native)
+On **PostgreSQL 18+**, when the GUC is `on`, Spock's own failover worker is
+not registered at all. The native slotsync worker is the only mechanism. If
+the GUC is left `off` (the default), Spock's worker is registered and runs
+as it did before, and no slot carries the `FAILOVER` flag.
 
-### 1. Create a physical replication slot on the primary
+## Setup: PostgreSQL 18+ (Native, requires `spock.use_native_failover_slots = on`)
+
+### 1. Enable the GUC on the subscriber
+
+On the **subscriber node** (the node that creates the logical replication
+slot on the provider), set:
+
+```ini
+spock.use_native_failover_slots = on
+```
+
+This is `PGC_POSTMASTER`, so restart the subscriber's server after setting
+it. Without this step, the slot is created without the `FAILOVER` flag and
+none of the steps below take effect.
+
+### 2. Create a physical replication slot on the primary
 
 ```sql
 SELECT pg_create_physical_replication_slot('spock_standby_slot');
 ```
 
-### 2. Configure the primary (`postgresql.conf`)
+### 3. Configure the primary (`postgresql.conf`)
 
 ```ini
 # Hold walsenders back until the standby has confirmed this LSN,
@@ -46,7 +88,7 @@ SELECT pg_create_physical_replication_slot('spock_standby_slot');
 synchronized_standby_slots = 'spock_standby_slot'
 ```
 
-### 3. Configure the standby (`postgresql.conf`)
+### 4. Configure the standby (`postgresql.conf`)
 
 ```ini
 sync_replication_slots = on
@@ -55,7 +97,7 @@ primary_slot_name = 'spock_standby_slot'
 hot_standby_feedback = on
 ```
 
-### 4. Verify slot synchronization
+### 5. Verify slot synchronization
 
 On the standby, confirm that Spock's logical slots are synchronized:
 
@@ -67,11 +109,54 @@ WHERE NOT temporary;
 
 All Spock slots should show `synced = true` and `failover = true`.
 
-### 5. After failover
+### 6. After failover
 
 After promoting the standby, subscribers only need to update their connection
 string to point to the new primary. Replication resumes from the last
 synchronized LSN with no data loss and no slot recreation required.
+
+**Important:** if `synchronized_standby_slots` was configured (step 3 above),
+you must adjust it on the promoted node before replication will resume — see
+[Runbook: clear `synchronized_standby_slots` after promotion](#runbook-clear-synchronized_standby_slots-after-promotion)
+below.
+
+## Runbook: clear `synchronized_standby_slots` after promotion
+
+When `synchronized_standby_slots` is configured (Setup step 3 above), the
+provider's walsenders hold back logical decoding until every physical slot
+named in that list has confirmed flush of the relevant LSN. This is what
+keeps a physical standby from falling behind a logical subscriber — but it
+has a sharp edge on failover.
+
+When a standby is promoted, `synchronized_standby_slots` on the **promoted**
+node still lists the physical slot(s) that fed replication to *that* node
+before promotion. Those slots are now orphaned: nothing is consuming them
+any more, so they never confirm, and the promoted node's walsenders sit
+blocked waiting on them indefinitely. The practical symptom is that logical
+replication to subscribers **freezes** immediately after a promotion that
+otherwise looked successful.
+
+The fix is a mandatory post-promotion step, not optional cleanup:
+
+```sql
+-- On the newly promoted node:
+ALTER SYSTEM SET synchronized_standby_slots = '';
+SELECT pg_reload_conf();
+
+-- Then drop the orphaned physical slot(s) that fed the old topology:
+SELECT pg_drop_replication_slot('spock_standby_slot');
+```
+
+If the new topology has its own physical standby(s), set
+`synchronized_standby_slots` to the physical slot(s) for *that* standby
+instead of clearing it to `''` — the point is to remove references to
+orphaned slots, not to leave the setting pointing at slots nothing will ever
+consume.
+
+Add this step to your failover runbook alongside the subscriber DSN update
+described above; skipping it is the most common cause of "failover
+succeeded but replication stopped" reports when native failover slots are
+in use.
 
 ## Setup: PostgreSQL 15 and 16 (Spock Worker)
 
@@ -143,19 +228,35 @@ WHERE application_name = 'spock_failover_slots worker';
 
 **Q: Do I need to do anything after a failover?**
 
-On PG17+: Just update the subscriber's `host=` in their DSN. No slot
-recreation needed.
+On PG17+ with `spock.use_native_failover_slots = on`: update the
+subscriber's `host=` in their DSN, and — if `synchronized_standby_slots` was
+configured — clear/adjust it on the promoted node as described in the
+[runbook above](#runbook-clear-synchronized_standby_slots-after-promotion).
+No slot recreation is needed.
 
-On PG15/16: Spock's worker on the standby (now primary) stops running
-since it is no longer in recovery. Subscribers reconnect automatically.
+On PG15/16, or on PG17+ with the GUC left at its default `off`: Spock's
+worker on the standby (now primary) stops running since it is no longer in
+recovery. Subscribers reconnect automatically.
 
-**Q: What if `sync_replication_slots` is not configured on PG18?**
+**Q: What if `sync_replication_slots` is not configured on PG18 with the GUC on?**
 
-Spock's worker is not registered on PG18. If `sync_replication_slots = on`
-is not set, logical slots will **not** be synchronized to standbys, and a
-failover will require manual slot recreation and table re-sync.
+With `spock.use_native_failover_slots = on`, Spock's worker is not
+registered on PG18+. If `sync_replication_slots = on` is not also set,
+logical slots will **not** be synchronized to standbys, and a failover will
+require manual slot recreation and table re-sync. (With the GUC left `off`,
+this does not apply — Spock's worker is registered and runs as usual.)
 
 **Q: Can I use both mechanisms on PG17?**
 
-No. If `sync_replication_slots = on` is set on PG17, Spock's worker detects
-this and skips its sync loop, deferring to the native worker entirely.
+No, both can't run their sync loops at once, and this only matters if
+`spock.use_native_failover_slots` is on in the first place. If it is on and
+`sync_replication_slots = on` is also set on PG17, Spock's worker detects
+this and skips its sync loop, deferring to the native worker entirely. With
+the GUC off (the default), native `sync_replication_slots` has no effect on
+Spock's slots since they are never marked with `FAILOVER`.
+
+**Q: Do I need to restart the server to enable this?**
+
+Yes. `spock.use_native_failover_slots` is `PGC_POSTMASTER` — it can only be
+set at server start (via `postgresql.conf` or `ALTER SYSTEM` followed by a
+restart), not with `SET` or a `SIGHUP` reload.

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -59,7 +59,12 @@ not registered at all. The native slotsync worker is the only mechanism. If
 the GUC is left `off` (the default), Spock's worker is registered and runs
 as it did before, and no slot carries the `FAILOVER` flag.
 
-## Setup: PostgreSQL 18+ (Native, requires `spock.use_native_failover_slots = on`)
+## Setup: PostgreSQL 17 and 18+ (Native, requires `spock.use_native_failover_slots = on`)
+
+On PostgreSQL 17 the Spock worker only steps aside once `sync_replication_slots
+= on` is also set (step 4); on PostgreSQL 18+ with the GUC on, the Spock worker
+is not registered and the native mechanism is required. The steps are the same
+for both.
 
 ### 1. Enable the GUC on the subscriber
 

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -3,6 +3,15 @@
 ## Spock 5.0.11
 
 ### New Features
+* Add `spock.use_native_failover_slots` (default off, PGC_POSTMASTER). When
+  enabled, spock marks logical slots with the FAILOVER flag on PG17+, yields to
+  PostgreSQL's native slotsync worker on PG17 when `sync_replication_slots=on`,
+  and does not register spock's own failover-slot worker on PG18+. Off preserves
+  the existing worker-based behavior. Read on the subscriber node that creates
+  the logical replication slot; changing it requires a server restart. See
+  [Logical Slot Failover](logical_slot_failover.md) for setup steps and the
+  required post-promotion `synchronized_standby_slots` runbook.
+
 * Sync failover slots to the standby every 1s by default instead of a
   hard-coded 60s, shrinking the window in which a promotion can find a stale
   slot. The interval is now tunable via `spock.failover_slots_naptime` (and the

--- a/include/spock.h
+++ b/include/spock.h
@@ -41,6 +41,7 @@
 #define SPOCK_RESTART_MIN_DELAY 1
 
 extern bool spock_synchronous_commit;
+extern bool spock_use_native_failover_slots;
 extern char *spock_temp_directory;
 extern bool spock_use_spi;
 extern bool spock_batch_inserts;

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -389,6 +389,7 @@ DECLARE
     result         RECORD;
     exists_count   int;
     remote_version int;
+    use_native     boolean := false;
 BEGIN
     -- ============================================================================
     -- Step 1: Check if replication slot already exists on remote node
@@ -416,15 +417,26 @@ BEGIN
 
     -- ============================================================================
     -- Step 2: Build remote SQL for replication slot creation
-    --         On PG17+ pass failover := true so the slot is picked up by the
-    --         native slotsync worker (sync_replication_slots = on) and is
-    --         synchronized to physical standbys, matching what Spock does
-    --         on its own CREATE_REPLICATION_SLOT path (see spock_sync.c).
+    --         Request a failover slot (failover := true) only on PG17+ AND when
+    --         the remote node has spock.use_native_failover_slots = on, matching
+    --         spock core's gated CREATE_REPLICATION_SLOT path (see spock_sync.c).
+    --         With the GUC off (default) a normal slot is created, preserving
+    --         pre-native behavior.
     -- ============================================================================
     SELECT v INTO remote_version
       FROM dblink(node_dsn, 'SHOW server_version_num') AS t(v int);
 
     IF remote_version >= 170000 THEN
+        BEGIN
+            SELECT (v = 'on') INTO use_native
+              FROM dblink(node_dsn,
+                          'SHOW spock.use_native_failover_slots') AS t(v text);
+        EXCEPTION WHEN OTHERS THEN
+            use_native := false;   -- remote spock predates the GUC
+        END;
+    END IF;
+
+    IF use_native THEN
         remotesql := format(
             'SELECT slot_name, lsn '
             'FROM pg_create_logical_replication_slot(%L, %L, false, false, true)',
@@ -1389,6 +1401,8 @@ DECLARE
 	sub_name           text;
     _slot_lsn          pg_lsn;
     _catchup_lsn       pg_lsn;
+    _remote_version    int;
+    _use_native        boolean := false;
 BEGIN
     RAISE NOTICE 'Phase 3: Creating disabled subscriptions and slots';
 
@@ -1449,7 +1463,24 @@ BEGIN
 							dbname, rec.node_name,
 							spock.gen_sub_name(rec.node_name, new_node_name));
 
-            remotesql := format('SELECT slot_name, lsn FROM pg_create_logical_replication_slot(%L, ''spock_output'');', slot_name);
+            SELECT v INTO _remote_version
+              FROM dblink(rec.dsn, 'SHOW server_version_num') AS t(v int);
+            _use_native := false;
+            IF _remote_version >= 170000 THEN
+                BEGIN
+                    SELECT (v = 'on') INTO _use_native
+                      FROM dblink(rec.dsn,
+                                  'SHOW spock.use_native_failover_slots') AS t(v text);
+                EXCEPTION WHEN OTHERS THEN
+                    _use_native := false;
+                END;
+            END IF;
+
+            IF _use_native THEN
+                remotesql := format('SELECT slot_name, lsn FROM pg_create_logical_replication_slot(%L, ''spock_output'', false, false, true);', slot_name);
+            ELSE
+                remotesql := format('SELECT slot_name, lsn FROM pg_create_logical_replication_slot(%L, ''spock_output'');', slot_name);
+            END IF;
             IF verb THEN
                 RAISE NOTICE '    Remote SQL for slot creation: %', remotesql;
             END IF;

--- a/src/spock.c
+++ b/src/spock.c
@@ -129,6 +129,7 @@ static const struct config_enum_entry readonly_options[] = {
 };
 
 bool	spock_synchronous_commit = false;
+bool	spock_use_native_failover_slots = false;
 char   *spock_temp_directory = "";
 bool	spock_use_spi = false;
 bool	spock_batch_inserts = true;
@@ -1048,6 +1049,19 @@ _PG_init(void)
 							 "spock specific synchronous commit value",
 							 NULL,
 							 &spock_synchronous_commit,
+							 false, PGC_POSTMASTER,
+							 0,
+							 NULL, NULL, NULL);
+
+	DefineCustomBoolVariable("spock.use_native_failover_slots",
+							 "Use PostgreSQL native logical slot failover on PG17+.",
+							 "When on, spock marks logical slots with the FAILOVER "
+							 "flag on PG17+, yields to the native slotsync worker on "
+							 "PG17 when sync_replication_slots is on, and does not "
+							 "register spock's own failover-slot worker on PG18+. "
+							 "Off preserves spock's worker-based behavior. Requires a "
+							 "server restart to change.",
+							 &spock_use_native_failover_slots,
 							 false, PGC_POSTMASTER,
 							 0,
 							 NULL, NULL, NULL);

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -40,6 +40,9 @@
 #include "replication/slot.h"
 #include "replication/walreceiver.h"
 #include "replication/walsender.h"
+#if PG_VERSION_NUM >= 170000
+#include "replication/slotsync.h"
+#endif
 
 #include "storage/ipc.h"
 #include "storage/procarray.h"
@@ -59,6 +62,8 @@
 #include "libpq-fe.h"
 #include "libpq/auth.h"
 #include "libpq/libpq.h"
+
+#include "spock.h"
 
 /* Defaults (milliseconds) for the tunable worker intervals below. */
 #define WORKER_NAP_TIME_DEFAULT 1000
@@ -1258,6 +1263,17 @@ synchronize_failover_slots(long sleep_time)
 void
 spock_failover_slots_main(Datum main_arg)
 {
+#if PG_VERSION_NUM >= 180000
+	/*
+	 * When spock.use_native_failover_slots is on, PostgreSQL 18's native
+	 * slotsync worker replaces this one, so it is not registered.  Reaching
+	 * this point with the GUC on indicates a registration bug.
+	 */
+	if (spock_use_native_failover_slots)
+		elog(ERROR, "spock_failover_slots_main: not started when "
+			 "spock.use_native_failover_slots is on (PostgreSQL 18+)");
+#endif
+
 	/* Establish signal handlers. */
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 	pqsignal(SIGTERM, die);
@@ -1283,9 +1299,18 @@ spock_failover_slots_main(Datum main_arg)
 
 		/*
 		 * On standby, run sync only when hot_standby_feedback is on; otherwise
-		 * use long nap so we never elog(ERROR) for hot_standby_feedback off.
+		 * use a long nap so we never elog(ERROR) for hot_standby_feedback off.
+		 *
+		 * On PG17+, when spock.use_native_failover_slots is on and the DBA has
+		 * enabled PostgreSQL's native slotsync (sync_replication_slots = on),
+		 * yield entirely so we never compete with the native worker.
+		 * sync_replication_slots is a process-global GUC we read directly.
 		 */
-		if (RecoveryInProgress() && hot_standby_feedback)
+		if (RecoveryInProgress() && hot_standby_feedback
+#if PG_VERSION_NUM >= 170000
+			&& !(spock_use_native_failover_slots && sync_replication_slots)
+#endif
+			)
 			sleep_time = synchronize_failover_slots(spock_failover_slots_naptime);
 		else
 			sleep_time = (long) spock_failover_slots_naptime * 10;
@@ -1655,6 +1680,21 @@ spock_init_failover_slot(void)
 
 	if (IsBinaryUpgrade)
 		return;
+
+#if PG_VERSION_NUM >= 180000
+	if (spock_use_native_failover_slots)
+	{
+		/*
+		 * PostgreSQL 18 natively synchronizes logical slots to standbys via
+		 * sync_replication_slots = on (slotsync worker) and holds back
+		 * walsenders via synchronized_standby_slots.  Spock's worker and its
+		 * client-auth hook are not needed and are not installed.
+		 */
+		elog(LOG, "spock: skipping failover slot worker on PostgreSQL 18+ "
+			 "(spock.use_native_failover_slots=on; use sync_replication_slots=on)");
+		return;
+	}
+#endif
 
 	/* Run the worker. */
 	memset(&bgw, 0, sizeof(bgw));

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -320,13 +320,33 @@ ensure_replication_slot_snapshot(PGconn *sql_conn, PGconn *repl_conn,
 	StringInfoData	query;
 	char		   *snapshot;
 
-	(void) use_failover_slot;	/* native PG slot-sync intentionally disabled */
+	(void) use_failover_slot;	/* referenced only in the PG<17 branch below */
 
 retry:
 	initStringInfo(&query);
 
 	appendStringInfo(&query, "CREATE_REPLICATION_SLOT \"%s\" LOGICAL %s",
 					 slot_name, "spock_output");
+
+	/*
+	 * When spock.use_native_failover_slots is on, mark the slot with
+	 * (FAILOVER) so PostgreSQL's native slotsync can synchronize it to
+	 * physical standbys.  We key off the *remote* provider's version via the
+	 * regular SQL connection (sql_conn); repl_conn returns 0 from
+	 * PQserverVersion().  PG17+ uses parenthesised option syntax:
+	 *   CREATE_REPLICATION_SLOT "name" LOGICAL plugin (FAILOVER)
+	 * When the GUC is off (default) no FAILOVER flag is added, preserving
+	 * spock's worker-based behavior.
+	 */
+	if (spock_use_native_failover_slots)
+	{
+		if (PQserverVersion(sql_conn) >= 170000)
+			appendStringInfo(&query, " (FAILOVER)");
+#if PG_VERSION_NUM < 170000
+		else if (use_failover_slot)
+			appendStringInfo(&query, " (FAILOVER)");
+#endif
+	}
 
 	res = PQexec(repl_conn, query.data);
 

--- a/tests/tap/t/018_failover_slots.pl
+++ b/tests/tap/t/018_failover_slots.pl
@@ -13,16 +13,25 @@ use Time::HiRes qw(time);
 # =============================================================================
 # Test: 018_failover_slots.pl
 #
-# Verifies logical replication slot failover for all supported PG versions.
+# Verifies logical replication slot failover for all supported PG versions,
+# under both supported modes of spock.use_native_failover_slots:
+#
+#   mode=worker (GUC off, default): spock's own bgworker performs slot sync;
+#     the logical slot is never created with the FAILOVER flag.
+#   mode=native (GUC on, PG17+): the logical slot is created with the
+#     FAILOVER flag and PostgreSQL's own slotsync worker copies it to the
+#     standby (synced=true); spock's bgworker yields instead of doing sync.
 #
 # Topology:
 #   n1 (provider/primary)  ──logical──>  n2 (subscriber)
 #   n1                     ──physical──> standby (stream replica of n1)
 #
-# Test flow:
+# Test flow (per mode):
 #   1. Create 2-node spock cluster (n1 + n2, cross-wired)
+#   1a. (native mode only) enable the GUC on n1/n2 and restart before the
+#       subscription/slot is created (GUC is PGC_POSTMASTER)
 #   2. Build a physical streaming standby of n1 via pg_basebackup
-#   3. Configure standby for slot sync (version-appropriate)
+#   3. Configure standby for slot sync (version- and mode-appropriate)
 #   4. Verify logical slot appears on standby with correct flags
 #   5. Confirm slot LSN on standby tracks primary (slot is live)
 #   6. Write data to n1, confirm n2 receives it (replication healthy)
@@ -73,493 +82,577 @@ sub wait_until {
     return 0;
 }
 
-# ==========================================================================
-# 1. Create 2-node spock cluster
-# ==========================================================================
-create_cluster(2, 'Create 2-node Spock cluster');
-
-my $config       = get_test_config();
-my $host         = $config->{host};
-my $dbname       = $config->{db_name};
-my $db_user      = $config->{db_user};
-my $db_password  = $config->{db_password};
-my $pg_bin       = $config->{pg_bin};
-my $node_ports   = $config->{node_ports};
-my $node_dirs    = $config->{node_datadirs};
-my $primary_port = $node_ports->[0];   # n1
-my $sub_port     = $node_ports->[1];   # n2
-my $primary_dir  = $node_dirs->[0];
-
-# Detect PostgreSQL major version
-my $pgver = scalar_query(1,
-    "SELECT current_setting('server_version_num')::int");
-$pgver =~ s/\s+//g;
-my $pg_major = int($pgver / 10000);
-diag("PostgreSQL major version: $pg_major");
-
-# ==========================================================================
-# 2. Create subscription n2 -> n1 (n2 subscribes to n1)
-# ==========================================================================
-psql_or_bail(2, "SELECT spock.sub_create(
-    'sub_n2_n1',
-    'host=$host dbname=$dbname port=$primary_port user=$db_user password=$db_password',
-    ARRAY['default','default_insert_only','ddl_sql'],
-    true, true
-)");
-
-my $sub_active = wait_until(60, 3, sub {
-    my $s = scalar_query(2,
-        "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n2_n1'");
-    $s =~ s/\s+//g;
-    return $s eq 't';
-});
-ok($sub_active, 'Subscription sub_n2_n1 active on n2');
-
-# ==========================================================================
-# 3. Get the logical slot created on n1 for n2
-# ==========================================================================
-# The slot is created asynchronously by the sync worker after subscription
-# is enabled, so poll until it appears (up to 60s).
-my $slot_name = '';
-my $slot_ready = wait_until(60, 3, sub {
-    $slot_name = scalar_query(1,
-        "SELECT slot_name FROM pg_replication_slots WHERE slot_type='logical' LIMIT 1");
-    $slot_name =~ s/\s+//g;
-    return length($slot_name) > 0;
-});
-ok($slot_ready && length($slot_name) > 0,
-    "Logical slot created on n1: '$slot_name'");
-
-# ==========================================================================
-# 4. Verify FAILOVER flag on slot is NOT set (spock owns the sync; native
-#    PG slot-sync is intentionally disabled on this branch).
-# ==========================================================================
-if ($pg_major >= 17) {
-    my $fv = scalar_query(1,
-        "SELECT failover FROM pg_replication_slots WHERE slot_name='$slot_name'");
-    $fv =~ s/\s+//g;
-    is($fv, 'f',
-        "PG$pg_major: slot '$slot_name' NOT created with FAILOVER (spock handles sync)");
-} else {
-    pass("PG$pg_major: FAILOVER flag not applicable (PG15/16)");
-}
-
-# ==========================================================================
-# 5. spock_failover_slots bgworker on primary: not used regardless of version
-#    (the worker only does work on a standby in recovery).  We don't assert
-#    anything about its presence here — that's checked on the standby below.
-# ==========================================================================
-pass("PG$pg_major: spock bgworker check deferred to standby (section 12)");
-
-# ==========================================================================
-# 6. Create physical replication slot for the standby
-# ==========================================================================
-
-# Force a WAL segment switch on n1 so the logical slot's restart_lsn
-# advances across a segment boundary.  On PG15/16 the failover-slot bgworker
-# uses wait_for_primary_slot_catchup() which requires the primary slot's
-# restart_lsn to be >= the standby's local WAL reservation; without a forced
-# switch the gap can be just a few bytes (within the same segment), making
-# the wait too easy to interrupt by promotion before the slot is persisted.
-if ($pg_major < 17) {
-    psql_or_bail(1, "SELECT pg_switch_wal()");
-    # Wait for n2's apply worker to acknowledge the new WAL position so the
-    # slot's confirmed_flush_lsn (and restart_lsn) advances past the switch
-    # point before we take the basebackup.
-    sleep(5);
-}
-
-psql_or_bail(1,
-    "SELECT pg_create_physical_replication_slot('standby_physical_slot')");
-pass('Physical replication slot created on n1');
-
-# ==========================================================================
-# 7. Build physical standby of n1 via pg_basebackup
-# ==========================================================================
-my $standby_port    = $primary_port + 10;
-my $standby_datadir = '/tmp/tmp_spock_failover_standby';
-my $standby_logdir  = "$standby_datadir/pg_log";
-my $standby_logfile = "$standby_logdir/standby.log";
-
-system("rm -rf $standby_datadir 2>/dev/null");
-system_or_bail("$pg_bin/pg_basebackup",
-    '-D', $standby_datadir,
-    '-h', $host, '-p', $primary_port, '-U', $db_user,
-    '-X', 'stream', '-R');
-pass('Physical standby created via pg_basebackup');
-
-# ==========================================================================
-# 8. Configure and start standby
-# ==========================================================================
-system_or_bail('mkdir', '-p', $standby_logdir);
-{
-    open(my $conf, '>>', "$standby_datadir/postgresql.conf")
-        or die "Cannot open standby postgresql.conf: $!";
-    print $conf "\n# ---- standby overrides ----\n";
-    print $conf "port                     = $standby_port\n";
-    print $conf "hot_standby              = on\n";
-    print $conf "hot_standby_feedback     = on\n";
-    print $conf "primary_slot_name        = 'standby_physical_slot'\n";
-    print $conf "log_directory            = '$standby_logdir'\n";
-    print $conf "log_filename             = 'standby.log'\n";
-    print $conf "log_min_messages         = debug1\n";
-    print $conf "log_replication_commands = on\n";
-
-    # Native slot sync is intentionally NOT enabled on this branch — spock's
-    # failover-slot worker handles synchronization for every supported PG
-    # version, so leave sync_replication_slots at its default (off).
+# --------------------------------------------------------------------------
+# Helper: enable spock.use_native_failover_slots on a node's data dir and
+# restart it.  The GUC is PGC_POSTMASTER, so a restart is required for it
+# to take effect before any logical slot is created.
+# --------------------------------------------------------------------------
+sub enable_native_on_node {
+    my ($pg_bin, $datadir) = @_;
+    open(my $conf, '>>', "$datadir/postgresql.conf")
+        or die "Cannot open $datadir/postgresql.conf: $!";
+    print $conf "\n# ---- native failover slots (018 phase) ----\n";
+    print $conf "spock.use_native_failover_slots = on\n";
     close($conf);
-}
-
-# pg_basebackup -R writes primary_conninfo without dbname to postgresql.auto.conf,
-# but PG17+ slotsync worker requires dbname in primary_conninfo to locate logical
-# slots.  Append a corrected primary_conninfo to auto.conf (last entry wins).
-{
-    open(my $aconf, '>>', "$standby_datadir/postgresql.auto.conf")
-        or die "Cannot open standby postgresql.auto.conf: $!";
-    print $aconf "\n# slotsync requires dbname in primary_conninfo\n";
-    print $aconf "primary_conninfo = 'host=$host port=$primary_port "
-               . "user=$db_user dbname=$dbname'\n";
-    close($aconf);
-}
-
-# synchronized_standby_slots is the native walsender-hold-back mechanism;
-# it's intentionally NOT configured here because this branch does not use
-# native PG slot sync. Spock's worker covers the sync path on every
-# supported PG version.
-
-system_or_bail("$pg_bin/pg_ctl", 'start',
-    '-D', $standby_datadir, '-l', "$standby_datadir/startup.log", '-w');
-
-command_ok(["$pg_bin/pg_isready", '-h', $host, '-p', $standby_port],
-    'Standby is accepting connections');
-
-# pg_is_in_recovery() returns boolean — psql displays as 't'/'f'
-my $in_recovery = qport($pg_bin, $host, $standby_port,
-    $dbname, $db_user, "SELECT pg_is_in_recovery()");
-$in_recovery =~ s/\s+//g;
-is($in_recovery, 't', 'Standby is in recovery (streaming from n1)');
-
-# ==========================================================================
-# 9. Verify physical streaming replication is active on n1
-# ==========================================================================
-my $streaming = wait_until(30, 3, sub {
-    my $c = scalar_query(1,
-        "SELECT count(*) FROM pg_stat_replication
-         WHERE state = 'streaming'");
-    $c =~ s/\s+//g;
-    return $c > 0;
-});
-ok($streaming, 'n1 has an active streaming replication connection to standby');
-
-# ==========================================================================
-# 10. Wait for logical slot to be synchronized to standby
-# ==========================================================================
-my $wait_secs = ($pg_major >= 17) ? 60 : 120;
-my $poll_secs = 5;
-diag("Waiting up to ${wait_secs}s for slot '$slot_name' on standby...");
-
-my $slot_present = wait_until($wait_secs, $poll_secs, sub {
-    my $c = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT count(*) FROM pg_replication_slots
-         WHERE slot_name = '$slot_name'");
-    $c =~ s/\s+//g;
-    return $c > 0;
-});
-ok($slot_present,
-    "Logical slot '$slot_name' present on standby within ${wait_secs}s");
-
-# Emit diagnostics whenever slot sync is slow / failed.
-unless ($slot_present) {
-    my $all_slots = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT slot_name, slot_type, active FROM pg_replication_slots");
-    diag("  standby pg_replication_slots: $all_slots");
-
-    my $sub_enabled = scalar_query(2,
-        "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n2_n1'");
-    $sub_enabled =~ s/\s+//g;
-    diag("  n2 sub_n2_n1 sub_enabled: $sub_enabled");
-
-    my $n1_slots = scalar_query(1,
-        "SELECT slot_name||':'||active::text FROM pg_replication_slots WHERE slot_type='logical'");
-    $n1_slots =~ s/\s+//g;
-    diag("  n1 logical slots: $n1_slots");
-
-    if ($pg_major < 17) {
-        my $bgw_pid = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-            "SELECT pid||' state='||state FROM pg_stat_activity
-             WHERE application_name = 'spock_failover_slots worker'");
-        $bgw_pid =~ s/\s+//g;
-        diag("  standby bgworker: $bgw_pid");
-    }
+    system_or_bail("$pg_bin/pg_ctl", 'restart',
+        '-D', $datadir, '-w', '-l', "$datadir/restart.log");
 }
 
 # ==========================================================================
-# 11. PG17+: standby slot is synced by spock's worker, NOT by native PG
-#     slotsync.  Therefore the slot must show synced=f and failover=f.
+# Full scenario, parameterized by whether native (PG-owned) failover slots
+# are enabled via spock.use_native_failover_slots.
 # ==========================================================================
-if ($pg_major >= 17) {
-    my $sd = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT synced FROM pg_replication_slots
-         WHERE slot_name = '$slot_name'");
-    $sd =~ s/\s+//g;
-    is($sd, 'f',
-        "PG$pg_major: standby slot '$slot_name' has synced=false (spock worker, not native)");
+sub run_failover_scenario {
+    my ($use_native) = @_;
+    my $mode = $use_native ? 'native' : 'worker';
+    diag("=== 018 scenario: mode=$mode (use_native=$use_native) ===");
 
-    my $fb = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT failover FROM pg_replication_slots
-         WHERE slot_name = '$slot_name'");
-    $fb =~ s/\s+//g;
-    is($fb, 'f',
-        "PG$pg_major: standby slot '$slot_name' has failover=false (native sync disabled)");
+    # ==========================================================================
+    # 1. Create 2-node spock cluster
+    # ==========================================================================
+    create_cluster(2, "[$mode] Create 2-node Spock cluster");
 
-    # Verify slot LSN on standby is set and behind/at primary.  spock's
-    # failover-slot worker prefers restart_lsn (which it sets during
-    # ReplicationSlotCreate/LogicalIncreaseRestartDecodingForSlot);
-    # confirmed_flush_lsn may stay NULL until LogicalConfirmReceivedLocation
-    # runs the first time, so poll for either column.
-    my $primary_lsn = scalar_query(1, "SELECT pg_current_wal_lsn()");
-    $primary_lsn =~ s/\s+//g;
+    my $config       = get_test_config();
+    my $host         = $config->{host};
+    my $dbname       = $config->{db_name};
+    my $db_user      = $config->{db_user};
+    my $db_password  = $config->{db_password};
+    my $pg_bin       = $config->{pg_bin};
+    my $node_ports   = $config->{node_ports};
+    my $node_dirs    = $config->{node_datadirs};
+    my $primary_port = $node_ports->[0];   # n1
+    my $sub_port     = $node_ports->[1];   # n2
+    my $primary_dir  = $node_dirs->[0];
 
-    my $slot_lsn = '';
-    my $slot_lsn_ok = wait_until(30, 2, sub {
-        $slot_lsn = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-            "SELECT coalesce(confirmed_flush_lsn::text, restart_lsn::text, '')
-             FROM pg_replication_slots WHERE slot_name = '$slot_name'");
-        $slot_lsn =~ s/\s+//g;
-        return $slot_lsn ne '';
-    });
-    ok($slot_lsn_ok,
-        "PG$pg_major: standby slot has an LSN set (slot_lsn=$slot_lsn)");
+    # Detect PostgreSQL major version
+    my $pgver = scalar_query(1,
+        "SELECT current_setting('server_version_num')::int");
+    $pgver =~ s/\s+//g;
+    my $pg_major = int($pgver / 10000);
+    diag("PostgreSQL major version: $pg_major");
 
-    diag("  primary_lsn=$primary_lsn  slot_lsn=$slot_lsn");
-} else {
-    pass("PG$pg_major: synced column not available");
-    pass("PG$pg_major: failover column not available");
-    pass("PG$pg_major: LSN lag check skipped");
-}
+    # On PG17+ the native path marks the slot FAILOVER and PG's slotsync
+    # sets synced=true on the standby copy; the worker path leaves both false.
+    my $expect_failover = ($use_native && $pg_major >= 17) ? 't' : 'f';
+    my $expect_synced   = ($use_native && $pg_major >= 17) ? 't' : 'f';
 
-# ==========================================================================
-# 12. spock_failover_slots bgworker must be running on the standby for
-#     every supported PG version — spock owns slot sync for all of them.
-# ==========================================================================
-my $bgw_count = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-    "SELECT count(*) FROM pg_stat_activity
-     WHERE application_name = 'spock_failover_slots worker'");
-$bgw_count =~ s/\s+//g;
-
-ok($bgw_count > 0,
-    "PG$pg_major: spock_failover_slots worker running on standby");
-
-# ==========================================================================
-# 13. (placeholder to keep test count stable across the schedule)
-# ==========================================================================
-pass("PG$pg_major: spock owns failover slot sync regardless of PG version");
-
-# ==========================================================================
-# 14. Write data on n1, verify n2 receives it (baseline replication check)
-# ==========================================================================
-psql_or_bail(1,
-    "CREATE TABLE IF NOT EXISTS failover_test (id int primary key, val text)");
-sleep(5);
-psql_or_bail(1,
-    "INSERT INTO failover_test VALUES (1, 'before_failover')");
-
-# Check subscription state before waiting for data
-{
-    my $sub_state = scalar_query(2,
-        "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n2_n1'");
-    $sub_state =~ s/\s+//g;
-    diag("  n2 sub_n2_n1 sub_enabled before data check: $sub_state");
-
-    # If disabled due to error, re-enable so the test can proceed
-    if ($sub_state eq 'f') {
-        diag("  Re-enabling disabled subscription sub_n2_n1");
-        psql_or_bail(2, "SELECT spock.sub_enable('sub_n2_n1')");
+    # When testing the native path, enable the GUC on both nodes and restart
+    # them BEFORE creating the subscription/slot: the GUC is PGC_POSTMASTER
+    # and the FAILOVER flag is applied at slot-creation time.
+    if ($use_native) {
+        enable_native_on_node($pg_bin, $node_dirs->[0]);   # n1 (provider)
+        enable_native_on_node($pg_bin, $node_dirs->[1]);   # n2
         sleep(5);
     }
-}
 
-my $data_ok = wait_until(60, 3, sub {
-    my $v = scalar_query(2,
-        "SELECT val FROM failover_test WHERE id = 1");
-    $v =~ s/\s+//g;
-    return $v eq 'before_failover';
-});
-ok($data_ok, 'Row (1, before_failover) replicated n1 -> n2 before failover');
-
-# ==========================================================================
-# 14b. REGRESSION: read-only standby is queryable while spock is loaded
-#
-# A customer reported that after enabling spock with logical slot failover,
-# the hot_standby could not be queried — basic SELECTs failed because of
-# spock interactions on a recovery backend.  Re-running the full
-# slot-failover dance is not enough; we need explicit assertions that the
-# standby answers user SELECT, spock catalog SELECT, and pg_replication_slots
-# while it's still in recovery.  Without these checks a future regression
-# could quietly reintroduce the same bug.
-# ==========================================================================
-
-# Wait for the standby to apply the row we just wrote on n1.
-my $primary_wal_lsn = scalar_query(1, "SELECT pg_current_wal_lsn()");
-$primary_wal_lsn =~ s/\s+//g;
-my $standby_caught_up = wait_until(60, 2, sub {
-    my $rl = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT pg_last_wal_replay_lsn() >= '$primary_wal_lsn'::pg_lsn");
-    $rl =~ s/\s+//g;
-    return $rl eq 't';
-});
-ok($standby_caught_up,
-    "Standby applied WAL up to primary lsn $primary_wal_lsn");
-
-# Standby must still be in recovery — confirms hot_standby mode and that
-# no spock hook accidentally took the standby out of recovery.
-#
-# Use qport_status so a hung backend (initializing / futex_wait_queue) is
-# reported as an explicit assertion failure with a clear message, instead
-# of stalling the whole test until prove kills it.
-my ($still_in_recovery, $rc_recov) = qport_status($pg_bin, $host, $standby_port,
-    $dbname, $db_user, "SELECT pg_is_in_recovery()");
-ok($rc_recov == 0,
-    "Standby answered pg_is_in_recovery() within 10s (psql rc=$rc_recov)");
-is($still_in_recovery, 't',
-    'Read-only standby is still in recovery (hot_standby mode)');
-
-# 1) User-table SELECT against the standby returns the committed row.
-my ($val_on_standby, $rc_user) = qport_status($pg_bin, $host, $standby_port,
-    $dbname, $db_user, "SELECT val FROM failover_test WHERE id = 1");
-ok($rc_user == 0,
-    "Standby answered user SELECT within 10s (psql rc=$rc_user)");
-is($val_on_standby, 'before_failover',
-    'Read-only standby returns committed user data (SELECT works)');
-
-# 2) Spock catalog SELECT against the standby — guards against the
-#    failure mode where backends hang in "initializing" state on the
-#    standby with futex_wait_queue.  An explicit timeout on the connect
-#    makes this a fast assertion failure, not a hang.
-my ($standby_node_count, $rc_node) = qport_status($pg_bin, $host, $standby_port,
-    $dbname, $db_user, "SELECT count(*) FROM spock.node");
-ok($rc_node == 0,
-    "Standby answered spock.node SELECT within 10s (psql rc=$rc_node)");
-ok(($standby_node_count =~ /^\d+$/) && $standby_node_count >= 1,
-    "Read-only standby returns spock.node ($standby_node_count rows)");
-
-# 3) The synced logical slot is visible on the standby.
-my ($standby_slot_count, $rc_slot) = qport_status($pg_bin, $host, $standby_port,
-    $dbname, $db_user,
-    "SELECT count(*) FROM pg_replication_slots WHERE slot_name = '$slot_name'");
-ok($rc_slot == 0,
-    "Standby answered pg_replication_slots SELECT within 10s (psql rc=$rc_slot)");
-is($standby_slot_count, '1',
-    "Read-only standby returns synced slot '$slot_name' via pg_replication_slots");
-
-# 4) Writes are rejected — the standby must remain read-only.
-my $write_rc = system(
-    "$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
-  . "-v ON_ERROR_STOP=1 "
-  . "-c \"INSERT INTO failover_test VALUES (999, 'must_fail')\" "
-  . ">/dev/null 2>&1");
-isnt($write_rc, 0,
-    'Write against read-only standby is rejected (read-only enforced)');
-
-# ==========================================================================
-# 15. Verify invalidation_reason is NULL (slot is healthy on standby)
-# ==========================================================================
-if ($pg_major >= 17) {
-    my $inv = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT coalesce(invalidation_reason::text, 'none')
-         FROM pg_replication_slots WHERE slot_name = '$slot_name'");
-    $inv =~ s/\s+//g;
-    is($inv, 'none',
-        "PG$pg_major: slot '$slot_name' on standby has no invalidation_reason");
-} else {
-    pass("PG$pg_major: invalidation_reason check not applicable");
-}
-
-# ==========================================================================
-# 16. Failover: stop n1, promote standby
-# ==========================================================================
-diag("Stopping n1 (primary) to simulate failover...");
-system("$pg_bin/pg_ctl stop -D $primary_dir -m fast >> /dev/null 2>&1");
-sleep(5);
-
-diag("Promoting standby to new primary...");
-# Use promote without -w, then poll
-system("$pg_bin/pg_ctl promote -D $standby_datadir >> /dev/null 2>&1");
-
-my $promoted = wait_until(30, 3, sub {
-    my $r = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT pg_is_in_recovery()");
-    $r =~ s/\s+//g;
-    return $r eq 'f';
-});
-ok($promoted, 'Standby promoted to primary (no longer in recovery)');
-
-# ==========================================================================
-# 17. Reconnect n2 to the promoted standby
-#     - Add a failover interface on n1's node record
-#     - Switch subscription to use that interface
-# ==========================================================================
-
-# Disable the subscription first to ensure the apply worker has fully
-# stopped before we change the interface DSN.  This is especially important
-# on PG16 where the worker may be in a reconnect loop after the primary
-# went away; without an explicit disable the DSN change can race with the
-# worker's next connection attempt.
-psql_or_bail(2, "SELECT spock.sub_disable('sub_n2_n1')");
-sleep(3);
-
-psql_or_bail(2,
-    "SELECT spock.node_add_interface(
-        'n1', 'n1_promoted',
-        'host=$host dbname=$dbname port=$standby_port user=$db_user password=$db_password'
+    # ==========================================================================
+    # 2. Create subscription n2 -> n1 (n2 subscribes to n1)
+    # ==========================================================================
+    psql_or_bail(2, "SELECT spock.sub_create(
+        'sub_n2_n1',
+        'host=$host dbname=$dbname port=$primary_port user=$db_user password=$db_password',
+        ARRAY['default','default_insert_only','ddl_sql'],
+        true, true
     )");
 
-psql_or_bail(2,
-    "SELECT spock.sub_alter_interface('sub_n2_n1', 'n1_promoted')");
+    my $sub_active = wait_until(60, 3, sub {
+        my $s = scalar_query(2,
+            "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n2_n1'");
+        $s =~ s/\s+//g;
+        return $s eq 't';
+    });
+    ok($sub_active, 'Subscription sub_n2_n1 active on n2');
 
-# Re-enable so the apply worker connects using the new interface that
-# points to the promoted standby.
-psql_or_bail(2, "SELECT spock.sub_enable('sub_n2_n1')");
+    # ==========================================================================
+    # 3. Get the logical slot created on n1 for n2
+    # ==========================================================================
+    # The slot is created asynchronously by the sync worker after subscription
+    # is enabled, so poll until it appears (up to 60s).
+    my $slot_name = '';
+    my $slot_ready = wait_until(60, 3, sub {
+        $slot_name = scalar_query(1,
+            "SELECT slot_name FROM pg_replication_slots WHERE slot_type='logical' LIMIT 1");
+        $slot_name =~ s/\s+//g;
+        return length($slot_name) > 0;
+    });
+    ok($slot_ready && length($slot_name) > 0,
+        "Logical slot created on n1: '$slot_name'");
 
-# Wait for n2's apply worker to connect to the promoted standby.
-diag("Waiting for sub_n2_n1 to reconnect to promoted standby (up to 90s)...");
-my $sub_reconnected = wait_until(90, 5, sub {
-    my $s = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
-        "SELECT count(*) FROM pg_stat_replication");
-    $s =~ s/\s+//g;
-    return $s > 0;
-});
-diag($sub_reconnected
-    ? "  n2 connected to promoted standby"
-    : "  WARNING: n2 did not reconnect within 90s");
+    # ==========================================================================
+    # 4. Verify FAILOVER flag on slot matches the mode under test: native mode
+    #    (PG17+) marks it FAILOVER; worker mode never does (spock owns sync).
+    # ==========================================================================
+    if ($pg_major >= 17) {
+        my $fv = scalar_query(1,
+            "SELECT failover FROM pg_replication_slots WHERE slot_name='$slot_name'");
+        $fv =~ s/\s+//g;
+        is($fv, $expect_failover,
+            "[$mode] PG$pg_major: slot '$slot_name' failover=$expect_failover");
+    } else {
+        pass("[$mode] PG$pg_major: FAILOVER flag not applicable (PG15/16)");
+    }
 
-# ==========================================================================
-# 18. Write data on promoted standby, verify n2 receives it
-# ==========================================================================
-system("$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
-    . "-c \"INSERT INTO failover_test VALUES (2, 'after_failover')\" "
-    . ">> /dev/null 2>&1");
+    # ==========================================================================
+    # 5. spock_failover_slots bgworker on primary: not used regardless of version
+    #    (the worker only does work on a standby in recovery).  We don't assert
+    #    anything about its presence here — that's checked on the standby below.
+    # ==========================================================================
+    pass("PG$pg_major: spock bgworker check deferred to standby (section 12)");
 
-my $post_ok = wait_until(60, 3, sub {
-    my $v = scalar_query(2,
-        "SELECT val FROM failover_test WHERE id = 2");
-    $v =~ s/\s+//g;
-    return $v eq 'after_failover';
-});
-ok($post_ok,
-    'Row (2, after_failover) replicated promoted-standby -> n2 after failover');
+    # ==========================================================================
+    # 6. Create physical replication slot for the standby
+    # ==========================================================================
 
-# ==========================================================================
-# Cleanup
-# ==========================================================================
-system("$pg_bin/pg_ctl stop -D $standby_datadir -m immediate >> /dev/null 2>&1");
+    # Force a WAL segment switch on n1 so the logical slot's restart_lsn
+    # advances across a segment boundary.  On PG15/16 the failover-slot bgworker
+    # uses wait_for_primary_slot_catchup() which requires the primary slot's
+    # restart_lsn to be >= the standby's local WAL reservation; without a forced
+    # switch the gap can be just a few bytes (within the same segment), making
+    # the wait too easy to interrupt by promotion before the slot is persisted.
+    if ($pg_major < 17) {
+        psql_or_bail(1, "SELECT pg_switch_wal()");
+        # Wait for n2's apply worker to acknowledge the new WAL position so the
+        # slot's confirmed_flush_lsn (and restart_lsn) advances past the switch
+        # point before we take the basebackup.
+        sleep(5);
+    }
 
-# Restart n1 so destroy_cluster can connect cleanly.
-system("$pg_bin/postgres -D $primary_dir >> /dev/null 2>&1 &");
-sleep(10);
+    psql_or_bail(1,
+        "SELECT pg_create_physical_replication_slot('standby_physical_slot')");
+    pass('Physical replication slot created on n1');
 
-system("rm -rf $standby_datadir 2>/dev/null");
+    # ==========================================================================
+    # 7. Build physical standby of n1 via pg_basebackup
+    # ==========================================================================
+    my $standby_port    = $primary_port + 10;
+    my $standby_datadir = '/tmp/tmp_spock_failover_standby';
+    my $standby_logdir  = "$standby_datadir/pg_log";
+    my $standby_logfile = "$standby_logdir/standby.log";
 
-destroy_cluster('Destroy test cluster');
+    system("rm -rf $standby_datadir 2>/dev/null");
+    system_or_bail("$pg_bin/pg_basebackup",
+        '-D', $standby_datadir,
+        '-h', $host, '-p', $primary_port, '-U', $db_user,
+        '-X', 'stream', '-R');
+    pass('Physical standby created via pg_basebackup');
+
+    # ==========================================================================
+    # 8. Configure and start standby
+    # ==========================================================================
+    system_or_bail('mkdir', '-p', $standby_logdir);
+    {
+        open(my $conf, '>>', "$standby_datadir/postgresql.conf")
+            or die "Cannot open standby postgresql.conf: $!";
+        print $conf "\n# ---- standby overrides ----\n";
+        print $conf "port                     = $standby_port\n";
+        print $conf "hot_standby              = on\n";
+        print $conf "hot_standby_feedback     = on\n";
+        print $conf "primary_slot_name        = 'standby_physical_slot'\n";
+        print $conf "log_directory            = '$standby_logdir'\n";
+        print $conf "log_filename             = 'standby.log'\n";
+        print $conf "log_min_messages         = debug1\n";
+        print $conf "log_replication_commands = on\n";
+
+        if ($use_native && $pg_major >= 17) {
+            # Native slot sync: PostgreSQL's own slotsync worker copies the
+            # FAILOVER-flagged logical slot to the standby. These GUCs are
+            # PG17+ only; the standby would fail to start on PG15/16.
+            print $conf "sync_replication_slots    = on\n";
+            print $conf "synchronized_standby_slots = 'standby_physical_slot'\n";
+        }
+        # else: native slot sync is intentionally NOT enabled — spock's
+        # failover-slot worker handles synchronization instead, so leave
+        # sync_replication_slots at its default (off).
+
+        close($conf);
+    }
+
+    # pg_basebackup -R writes primary_conninfo without dbname to postgresql.auto.conf,
+    # but PG17+ slotsync worker requires dbname in primary_conninfo to locate logical
+    # slots.  Append a corrected primary_conninfo to auto.conf (last entry wins).
+    {
+        open(my $aconf, '>>', "$standby_datadir/postgresql.auto.conf")
+            or die "Cannot open standby postgresql.auto.conf: $!";
+        print $aconf "\n# slotsync requires dbname in primary_conninfo\n";
+        print $aconf "primary_conninfo = 'host=$host port=$primary_port "
+                   . "user=$db_user dbname=$dbname'\n";
+        close($aconf);
+    }
+
+    system_or_bail("$pg_bin/pg_ctl", 'start',
+        '-D', $standby_datadir, '-l', "$standby_datadir/startup.log", '-w');
+
+    command_ok(["$pg_bin/pg_isready", '-h', $host, '-p', $standby_port],
+        'Standby is accepting connections');
+
+    # pg_is_in_recovery() returns boolean — psql displays as 't'/'f'
+    my $in_recovery = qport($pg_bin, $host, $standby_port,
+        $dbname, $db_user, "SELECT pg_is_in_recovery()");
+    $in_recovery =~ s/\s+//g;
+    is($in_recovery, 't', 'Standby is in recovery (streaming from n1)');
+
+    # ==========================================================================
+    # 9. Verify physical streaming replication is active on n1
+    # ==========================================================================
+    my $streaming = wait_until(30, 3, sub {
+        my $c = scalar_query(1,
+            "SELECT count(*) FROM pg_stat_replication
+             WHERE state = 'streaming'");
+        $c =~ s/\s+//g;
+        return $c > 0;
+    });
+    ok($streaming, 'n1 has an active streaming replication connection to standby');
+
+    # ==========================================================================
+    # 10. Wait for logical slot to be synchronized to standby
+    # ==========================================================================
+    my $wait_secs = ($pg_major >= 17) ? 60 : 120;
+    my $poll_secs = 5;
+    diag("Waiting up to ${wait_secs}s for slot '$slot_name' on standby...");
+
+    my $slot_present = wait_until($wait_secs, $poll_secs, sub {
+        my $c = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT count(*) FROM pg_replication_slots
+             WHERE slot_name = '$slot_name'");
+        $c =~ s/\s+//g;
+        return $c > 0;
+    });
+    ok($slot_present,
+        "Logical slot '$slot_name' present on standby within ${wait_secs}s");
+
+    # Emit diagnostics whenever slot sync is slow / failed.
+    unless ($slot_present) {
+        my $all_slots = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT slot_name, slot_type, active FROM pg_replication_slots");
+        diag("  standby pg_replication_slots: $all_slots");
+
+        my $sub_enabled = scalar_query(2,
+            "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n2_n1'");
+        $sub_enabled =~ s/\s+//g;
+        diag("  n2 sub_n2_n1 sub_enabled: $sub_enabled");
+
+        my $n1_slots = scalar_query(1,
+            "SELECT slot_name||':'||active::text FROM pg_replication_slots WHERE slot_type='logical'");
+        $n1_slots =~ s/\s+//g;
+        diag("  n1 logical slots: $n1_slots");
+
+        if ($pg_major < 17) {
+            my $bgw_pid = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+                "SELECT pid||' state='||state FROM pg_stat_activity
+                 WHERE application_name = 'spock_failover_slots worker'");
+            $bgw_pid =~ s/\s+//g;
+            diag("  standby bgworker: $bgw_pid");
+        }
+    }
+
+    # ==========================================================================
+    # 11. Verify synced/failover flags on the standby copy of the slot match
+    #     the mode under test.  In worker mode spock syncs the slot itself, so
+    #     synced=f/failover=f; in native mode (PG17+) PG's slotsync sets both
+    #     to true.
+    # ==========================================================================
+    if ($pg_major >= 17) {
+        # Native slotsync can take a few seconds to converge on PG17, so poll
+        # rather than asserting on the first read.
+        my $sd = '';
+        wait_until(60, 5, sub {
+            $sd = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+                "SELECT synced FROM pg_replication_slots
+                 WHERE slot_name = '$slot_name'");
+            $sd =~ s/\s+//g;
+            return $sd eq $expect_synced;
+        });
+        is($sd, $expect_synced,
+            "[$mode] PG$pg_major: standby slot '$slot_name' has synced=$expect_synced");
+
+        my $fb = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT failover FROM pg_replication_slots
+             WHERE slot_name = '$slot_name'");
+        $fb =~ s/\s+//g;
+        is($fb, $expect_failover,
+            "[$mode] PG$pg_major: standby slot '$slot_name' has failover=$expect_failover");
+
+        # Verify slot LSN on standby is set and behind/at primary.  spock's
+        # failover-slot worker prefers restart_lsn (which it sets during
+        # ReplicationSlotCreate/LogicalIncreaseRestartDecodingForSlot);
+        # confirmed_flush_lsn may stay NULL until LogicalConfirmReceivedLocation
+        # runs the first time, so poll for either column.
+        my $primary_lsn = scalar_query(1, "SELECT pg_current_wal_lsn()");
+        $primary_lsn =~ s/\s+//g;
+
+        my $slot_lsn = '';
+        my $slot_lsn_ok = wait_until(30, 2, sub {
+            $slot_lsn = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+                "SELECT coalesce(confirmed_flush_lsn::text, restart_lsn::text, '')
+                 FROM pg_replication_slots WHERE slot_name = '$slot_name'");
+            $slot_lsn =~ s/\s+//g;
+            return $slot_lsn ne '';
+        });
+        ok($slot_lsn_ok,
+            "PG$pg_major: standby slot has an LSN set (slot_lsn=$slot_lsn)");
+
+        diag("  primary_lsn=$primary_lsn  slot_lsn=$slot_lsn");
+    } else {
+        pass("PG$pg_major: synced column not available");
+        pass("PG$pg_major: failover column not available");
+        pass("PG$pg_major: LSN lag check skipped");
+    }
+
+    # ==========================================================================
+    # 12. spock_failover_slots bgworker on the standby: in worker mode it must
+    #     be running and doing the sync for every supported PG version. In
+    #     native mode it's still registered/running on PG17 (it yields to PG's
+    #     slotsync), but is not registered at all on PG18+ (native slotsync
+    #     owns the sync path entirely there).
+    # ==========================================================================
+    my $bgw_count = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+        "SELECT count(*) FROM pg_stat_activity
+         WHERE application_name = 'spock_failover_slots worker'");
+    $bgw_count =~ s/\s+//g;
+
+    if ($use_native && $pg_major >= 18) {
+        is($bgw_count, '0',
+            "[$mode] PG$pg_major: spock worker NOT registered (native slotsync owns sync)");
+    } else {
+        ok($bgw_count > 0,
+            "[$mode] PG$pg_major: spock_failover_slots worker running on standby");
+    }
+
+    # ==========================================================================
+    # 13. (placeholder to keep test count stable across the schedule)
+    # ==========================================================================
+    pass("PG$pg_major: spock owns failover slot sync regardless of PG version");
+
+    # ==========================================================================
+    # 14. Write data on n1, verify n2 receives it (baseline replication check)
+    # ==========================================================================
+    psql_or_bail(1,
+        "CREATE TABLE IF NOT EXISTS failover_test (id int primary key, val text)");
+    sleep(5);
+    psql_or_bail(1,
+        "INSERT INTO failover_test VALUES (1, 'before_failover')");
+
+    # Check subscription state before waiting for data
+    {
+        my $sub_state = scalar_query(2,
+            "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n2_n1'");
+        $sub_state =~ s/\s+//g;
+        diag("  n2 sub_n2_n1 sub_enabled before data check: $sub_state");
+
+        # If disabled due to error, re-enable so the test can proceed
+        if ($sub_state eq 'f') {
+            diag("  Re-enabling disabled subscription sub_n2_n1");
+            psql_or_bail(2, "SELECT spock.sub_enable('sub_n2_n1')");
+            sleep(5);
+        }
+    }
+
+    my $data_ok = wait_until(60, 3, sub {
+        my $v = scalar_query(2,
+            "SELECT val FROM failover_test WHERE id = 1");
+        $v =~ s/\s+//g;
+        return $v eq 'before_failover';
+    });
+    ok($data_ok, 'Row (1, before_failover) replicated n1 -> n2 before failover');
+
+    # ==========================================================================
+    # 14b. REGRESSION: read-only standby is queryable while spock is loaded
+    #
+    # A customer reported that after enabling spock with logical slot failover,
+    # the hot_standby could not be queried — basic SELECTs failed because of
+    # spock interactions on a recovery backend.  Re-running the full
+    # slot-failover dance is not enough; we need explicit assertions that the
+    # standby answers user SELECT, spock catalog SELECT, and pg_replication_slots
+    # while it's still in recovery.  Without these checks a future regression
+    # could quietly reintroduce the same bug.
+    # ==========================================================================
+
+    # Wait for the standby to apply the row we just wrote on n1.
+    my $primary_wal_lsn = scalar_query(1, "SELECT pg_current_wal_lsn()");
+    $primary_wal_lsn =~ s/\s+//g;
+    my $standby_caught_up = wait_until(60, 2, sub {
+        my $rl = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT pg_last_wal_replay_lsn() >= '$primary_wal_lsn'::pg_lsn");
+        $rl =~ s/\s+//g;
+        return $rl eq 't';
+    });
+    ok($standby_caught_up,
+        "Standby applied WAL up to primary lsn $primary_wal_lsn");
+
+    # Standby must still be in recovery — confirms hot_standby mode and that
+    # no spock hook accidentally took the standby out of recovery.
+    #
+    # Use qport_status so a hung backend (initializing / futex_wait_queue) is
+    # reported as an explicit assertion failure with a clear message, instead
+    # of stalling the whole test until prove kills it.
+    my ($still_in_recovery, $rc_recov) = qport_status($pg_bin, $host, $standby_port,
+        $dbname, $db_user, "SELECT pg_is_in_recovery()");
+    ok($rc_recov == 0,
+        "Standby answered pg_is_in_recovery() within 10s (psql rc=$rc_recov)");
+    is($still_in_recovery, 't',
+        'Read-only standby is still in recovery (hot_standby mode)');
+
+    # 1) User-table SELECT against the standby returns the committed row.
+    my ($val_on_standby, $rc_user) = qport_status($pg_bin, $host, $standby_port,
+        $dbname, $db_user, "SELECT val FROM failover_test WHERE id = 1");
+    ok($rc_user == 0,
+        "Standby answered user SELECT within 10s (psql rc=$rc_user)");
+    is($val_on_standby, 'before_failover',
+        'Read-only standby returns committed user data (SELECT works)');
+
+    # 2) Spock catalog SELECT against the standby — guards against the
+    #    failure mode where backends hang in "initializing" state on the
+    #    standby with futex_wait_queue.  An explicit timeout on the connect
+    #    makes this a fast assertion failure, not a hang.
+    my ($standby_node_count, $rc_node) = qport_status($pg_bin, $host, $standby_port,
+        $dbname, $db_user, "SELECT count(*) FROM spock.node");
+    ok($rc_node == 0,
+        "Standby answered spock.node SELECT within 10s (psql rc=$rc_node)");
+    ok(($standby_node_count =~ /^\d+$/) && $standby_node_count >= 1,
+        "Read-only standby returns spock.node ($standby_node_count rows)");
+
+    # 3) The synced logical slot is visible on the standby.
+    my ($standby_slot_count, $rc_slot) = qport_status($pg_bin, $host, $standby_port,
+        $dbname, $db_user,
+        "SELECT count(*) FROM pg_replication_slots WHERE slot_name = '$slot_name'");
+    ok($rc_slot == 0,
+        "Standby answered pg_replication_slots SELECT within 10s (psql rc=$rc_slot)");
+    is($standby_slot_count, '1',
+        "Read-only standby returns synced slot '$slot_name' via pg_replication_slots");
+
+    # 4) Writes are rejected — the standby must remain read-only.
+    my $write_rc = system(
+        "$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
+      . "-v ON_ERROR_STOP=1 "
+      . "-c \"INSERT INTO failover_test VALUES (999, 'must_fail')\" "
+      . ">/dev/null 2>&1");
+    isnt($write_rc, 0,
+        'Write against read-only standby is rejected (read-only enforced)');
+
+    # ==========================================================================
+    # 15. Verify invalidation_reason is NULL (slot is healthy on standby)
+    # ==========================================================================
+    if ($pg_major >= 17) {
+        my $inv = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT coalesce(invalidation_reason::text, 'none')
+             FROM pg_replication_slots WHERE slot_name = '$slot_name'");
+        $inv =~ s/\s+//g;
+        is($inv, 'none',
+            "PG$pg_major: slot '$slot_name' on standby has no invalidation_reason");
+    } else {
+        pass("PG$pg_major: invalidation_reason check not applicable");
+    }
+
+    # ==========================================================================
+    # 16. Failover: stop n1, promote standby
+    # ==========================================================================
+    diag("Stopping n1 (primary) to simulate failover...");
+    system("$pg_bin/pg_ctl stop -D $primary_dir -m fast >> /dev/null 2>&1");
+    sleep(5);
+
+    diag("Promoting standby to new primary...");
+    # Use promote without -w, then poll
+    system("$pg_bin/pg_ctl promote -D $standby_datadir >> /dev/null 2>&1");
+
+    my $promoted = wait_until(30, 3, sub {
+        my $r = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT pg_is_in_recovery()");
+        $r =~ s/\s+//g;
+        return $r eq 'f';
+    });
+    ok($promoted, 'Standby promoted to primary (no longer in recovery)');
+
+    # ==========================================================================
+    # 17. Reconnect n2 to the promoted standby
+    #     - Add a failover interface on n1's node record
+    #     - Switch subscription to use that interface
+    # ==========================================================================
+
+    # Disable the subscription first to ensure the apply worker has fully
+    # stopped before we change the interface DSN.  This is especially important
+    # on PG16 where the worker may be in a reconnect loop after the primary
+    # went away; without an explicit disable the DSN change can race with the
+    # worker's next connection attempt.
+    psql_or_bail(2, "SELECT spock.sub_disable('sub_n2_n1')");
+    sleep(3);
+
+    psql_or_bail(2,
+        "SELECT spock.node_add_interface(
+            'n1', 'n1_promoted',
+            'host=$host dbname=$dbname port=$standby_port user=$db_user password=$db_password'
+        )");
+
+    psql_or_bail(2,
+        "SELECT spock.sub_alter_interface('sub_n2_n1', 'n1_promoted')");
+
+    # Re-enable so the apply worker connects using the new interface that
+    # points to the promoted standby.
+    psql_or_bail(2, "SELECT spock.sub_enable('sub_n2_n1')");
+
+    # Wait for n2's apply worker to connect to the promoted standby.
+    diag("Waiting for sub_n2_n1 to reconnect to promoted standby (up to 90s)...");
+    my $sub_reconnected = wait_until(90, 5, sub {
+        my $s = qport($pg_bin, $host, $standby_port, $dbname, $db_user,
+            "SELECT count(*) FROM pg_stat_replication");
+        $s =~ s/\s+//g;
+        return $s > 0;
+    });
+    diag($sub_reconnected
+        ? "  n2 connected to promoted standby"
+        : "  WARNING: n2 did not reconnect within 90s");
+
+    # In native mode, the promoted node inherits synchronized_standby_slots
+    # = 'standby_physical_slot' from the (former) standby's postgresql.conf.
+    # That physical slot's only consumer was the old primary n1, which is
+    # now down for good — so with the setting still in place the promoted
+    # node's logical walsender for n2 holds back (stays in 'catchup', never
+    # advancing sent_lsn) waiting on a physical slot that will never be
+    # confirmed again. A real failover runbook must clear this on promotion;
+    # do the same here so logical replication can resume.
+    if ($use_native) {
+        diag("[$mode] Clearing stale synchronized_standby_slots on promoted node");
+        system("$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
+            . "-c \"ALTER SYSTEM SET synchronized_standby_slots = ''\" >/dev/null 2>&1");
+        system("$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
+            . "-c \"SELECT pg_reload_conf()\" >/dev/null 2>&1");
+        # Best-effort: drop the now-orphaned physical slot so it doesn't
+        # retain WAL forever; ignore failure if it's already gone.
+        system("$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
+            . "-c \"SELECT pg_drop_replication_slot('standby_physical_slot') "
+            . "WHERE EXISTS (SELECT 1 FROM pg_replication_slots "
+            . "WHERE slot_name = 'standby_physical_slot')\" >/dev/null 2>&1");
+    }
+
+    # ==========================================================================
+    # 18. Write data on promoted standby, verify n2 receives it
+    # ==========================================================================
+    system("$pg_bin/psql -X -h $host -p $standby_port -d $dbname -U $db_user "
+        . "-c \"INSERT INTO failover_test VALUES (2, 'after_failover')\" "
+        . ">> /dev/null 2>&1");
+
+    my $post_ok = wait_until(60, 3, sub {
+        my $v = scalar_query(2,
+            "SELECT val FROM failover_test WHERE id = 2");
+        $v =~ s/\s+//g;
+        return $v eq 'after_failover';
+    });
+    ok($post_ok,
+        'Row (2, after_failover) replicated promoted-standby -> n2 after failover');
+
+    # ==========================================================================
+    # Cleanup
+    # ==========================================================================
+    system("$pg_bin/pg_ctl stop -D $standby_datadir -m immediate >> /dev/null 2>&1");
+
+    # Restart n1 so destroy_cluster can connect cleanly.
+    system("$pg_bin/postgres -D $primary_dir >> /dev/null 2>&1 &");
+    sleep(10);
+
+    system("rm -rf $standby_datadir 2>/dev/null");
+
+    destroy_cluster("[$mode] Destroy test cluster");
+}
+
+run_failover_scenario(0);   # worker path (GUC off) — failover=false
+run_failover_scenario(1);   # native path (GUC on) — failover=true on PG17+
 done_testing();

--- a/tests/tap/t/027_use_native_failover_slots_guc.pl
+++ b/tests/tap/t/027_use_native_failover_slots_guc.pl
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query
+);
+
+# =============================================================================
+# Test: 027_use_native_failover_slots_guc.pl
+#
+# Properties of the spock.use_native_failover_slots GUC (the PG17+ opt-in that
+# switches spock from its own failover-slot worker to PostgreSQL's native
+# slotsync).  End-to-end behaviour is covered by 018_failover_slots.pl; this
+# checks the GUC itself: default, type, and that it is restart-only
+# (PGC_POSTMASTER) and takes effect after ALTER SYSTEM + restart.
+# =============================================================================
+
+create_cluster(1);
+
+my $cfg     = get_test_config();
+my $bin     = $cfg->{pg_bin};
+my $host    = $cfg->{host};
+my $port    = $cfg->{node_ports}[0];
+my $db      = $cfg->{db_name};
+my $user    = $cfg->{db_user};
+my $datadir = $cfg->{node_datadirs}[0];
+
+my $GUC = 'spock.use_native_failover_slots';
+
+# Run SQL, return (exit_code, combined_output).
+sub psql_try {
+    my ($sql) = @_;
+    my $out = `$bin/psql -X -h $host -p $port -d $db -U $user -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    return ($? >> 8, $out);
+}
+
+sub field {
+    my ($col) = @_;
+    return scalar_query(1, "SELECT $col FROM pg_settings WHERE name = '$GUC'");
+}
+
+# Restart the node (the GUC is PGC_POSTMASTER) and wait for it to accept SQL.
+sub restart_node {
+    system("$bin/pg_ctl -D $datadir -w restart >/dev/null 2>&1");
+    for (1 .. 30) {
+        return 1 if scalar_query(1, "SELECT 1") eq '1';
+        select(undef, undef, undef, 0.5);
+    }
+    return 0;
+}
+
+# --------------------------------------------------------------------------
+# Properties
+# --------------------------------------------------------------------------
+is(field('setting'),  'off',        "$GUC defaults to off");
+is(field('boot_val'), 'off',        "$GUC boot default is off");
+is(field('vartype'),  'bool',       "$GUC is boolean");
+is(field('context'),  'postmaster', "$GUC is restart-only (PGC_POSTMASTER)");
+
+# --------------------------------------------------------------------------
+# Restart-only: SET is rejected at runtime
+# --------------------------------------------------------------------------
+my ($rc, $out) = psql_try("SET $GUC = on");
+isnt($rc, 0, "SET $GUC is rejected at runtime");
+like($out, qr/cannot be changed|without restarting/i,
+     'rejection message mentions a restart is required');
+
+# --------------------------------------------------------------------------
+# Takes effect via ALTER SYSTEM + restart
+# --------------------------------------------------------------------------
+psql_try("ALTER SYSTEM SET $GUC = on");
+ok(restart_node(), 'node restarts after enabling the GUC');
+is(field('setting'), 'on', "$GUC is on after ALTER SYSTEM + restart");
+
+# --------------------------------------------------------------------------
+# Restore default so teardown is clean
+# --------------------------------------------------------------------------
+psql_try("ALTER SYSTEM RESET $GUC");
+ok(restart_node(), 'node restarts after resetting the GUC');
+is(field('setting'), 'off', "$GUC is back to off after reset + restart");
+
+destroy_cluster();
+done_testing();


### PR DESCRIPTION
Adds an opt-in path for Spock 5.x to use PostgreSQL's native logical slot
failover (PG17+) instead of Spock's own `spock_failover_slots` worker,
controlled by a new GUC.

SPOC-626