### PR TITLE
Centralize CI PostgreSQL ref selection via postgres-build.conf

### DIFF
--- a/.github/workflows/pg-stable-test.yml
+++ b/.github/workflows/pg-stable-test.yml
@@ -1,10 +1,10 @@
-name: Regression and TAP against PG stable-branch tips
-run-name: Check spock against fresh stable PostgreSQL branches
+name: Regression and TAP against configured PostgreSQL ref
+run-name: Check spock against the PostgreSQL ref from postgres-build.conf
 
-# Builds PostgreSQL from the live tip of REL_${PGVER}_STABLE (not a tagged
-# release) with stock configure flags, applies spock's version-specific
-# patches per the README, builds spock per the README, and runs the
-# regression and TAP suites.
+# Builds PostgreSQL from the ref selected per major in
+# tests/postgres-build.conf (tag, tip of REL_${PGVER}_STABLE, or an explicit
+# pin) with stock configure flags, applies spock's version-specific patches
+# and builds spock per the README, and runs the regression and TAP suites.
 
 on:
   workflow_dispatch:
@@ -45,12 +45,18 @@ jobs:
             libreadline-dev zlib1g-dev \
             libipc-run-perl libtest-simple-perl
 
-      - name: Clone PostgreSQL stable-branch tip
+      - name: Resolve and fetch PostgreSQL source
         run: |
-          git clone --branch REL_${{ matrix.pgver }}_STABLE --depth 1 \
-            https://github.com/postgres/postgres.git "$PG_SRCDIR"
-          cd "$PG_SRCDIR"
-          echo "Cloned $(git rev-parse --short HEAD) on REL_${{ matrix.pgver }}_STABLE"
+          PG_REF=$(spock/tests/resolve-pg-ref.sh "${{ matrix.pgver }}")
+          echo "PG ${{ matrix.pgver }} resolved to $PG_REF"
+          # fetch + checkout (not clone --branch) so an explicit commit-SHA
+          # pin works as well as a branch or tag name.
+          git init "$PG_SRCDIR"
+          git -C "$PG_SRCDIR" remote add origin \
+            https://github.com/postgres/postgres.git
+          git -C "$PG_SRCDIR" fetch --depth 1 origin "$PG_REF"
+          git -C "$PG_SRCDIR" checkout --detach FETCH_HEAD
+          echo "Checked out $(git -C "$PG_SRCDIR" rev-parse --short HEAD) ($PG_REF)"
 
       # README step 2: apply spock patches in numerical order.  Glob
       # expansion gives us "pgN-000-...", "pgN-015-...", etc., in order.

--- a/tests/docker/Dockerfile-step-1.el9
+++ b/tests/docker/Dockerfile-step-1.el9
@@ -50,6 +50,11 @@ ARG DBPASSWD=testpass
 ARG DBNAME=demo
 ARG DBPORT=5432
 ARG MAKE_JOBS=4
+# Optional override for the PostgreSQL source ref.  Normally left empty, in
+# which case resolve-pg-ref.sh picks the ref from tests/postgres-build.conf.
+# If set (e.g. by a workflow that resolves the ref on the runner to key a
+# layer cache), it is used verbatim and the config is not consulted.
+ARG PG_REF=
 # When set to any non-empty value, Spock is compiled with -DSPOCK_RANDOM_DELAYS,
 # injecting random 1-100 ms delays at every transaction begin, worker start,
 # and worker finish.  Used by the random-delays-regress workflow.
@@ -127,23 +132,20 @@ WORKDIR /home/pgedge
 # Clone PostgreSQL Source
 # ==============================================================================
 
-# Determine the PostgreSQL source ref for the requested major version:
-# the latest REL_${PGVER}_* tag.  Version sort places BETA/RC tags before
-# numeric point releases, so a pre-GA major resolves to its newest beta/RC
-# tag (currently REL_19_BETA1 for PG19) and switches to GA point releases
-# automatically once they are tagged.  Building from a tag instead of a
-# branch tip keeps CI reproducible between runs.
+# Determine the PostgreSQL source ref for the requested major version.
+# tests/resolve-pg-ref.sh maps tests/postgres-build.conf (tag | branch |
+# explicit pin, per major) to a concrete ref.  A tag is reproducible; a
+# branch tracks the untagged upcoming release.  The PG_REF build-arg, if set,
+# overrides the config and is used verbatim.
 RUN set -eux && \
-	PG_REF=$(git ls-remote --tags https://github.com/postgres/postgres.git | \
-	grep "refs/tags/REL_${PGVER}_" | \
-	sed 's|.*refs/tags/||' | \
-	tr '_' '.' | \
-	sort -V | \
-	tail -n 1 | \
-	tr '.' '_') && \
-	echo "Cloning PostgreSQL tag: ${PG_REF}" && \
-	git clone --branch "${PG_REF}" --depth 1 \
-	https://github.com/postgres/postgres.git /home/pgedge/postgres && \
+	PG_REF="${PG_REF:-$(/home/pgedge/spock/tests/resolve-pg-ref.sh "${PGVER}")}" && \
+	echo "Fetching PostgreSQL ref: ${PG_REF}" && \
+	git init /home/pgedge/postgres && \
+	git -C /home/pgedge/postgres remote add origin \
+	https://github.com/postgres/postgres.git && \
+	git -C /home/pgedge/postgres fetch --depth 1 origin "${PG_REF}" && \
+	git -C /home/pgedge/postgres checkout --detach FETCH_HEAD && \
+	echo "Checked out $(git -C /home/pgedge/postgres rev-parse --short HEAD) (${PG_REF})" && \
 	echo "export PG_SRCDIR=/home/pgedge/postgres" >> /home/pgedge/.bashrc
 
 

--- a/tests/postgres-build.conf
+++ b/tests/postgres-build.conf
@@ -1,0 +1,25 @@
+# postgres-build.conf -- which PostgreSQL source ref CI builds against, per major.
+#
+# Read by tests/resolve-pg-ref.sh, which is called from:
+#   - tests/docker/Dockerfile-step-1.el9      (installcheck, nightly_tap,
+#                                               spockbench, random-delays)
+#   - .github/workflows/pg-stable-test.yml
+#   - tests/run-single-pg18-installcheck.sh
+#
+# Each value is one of:
+#   branch          HEAD of REL_<major>_STABLE -- the untagged, upcoming
+#                   release.  Builds fresh tips; NOT reproducible between runs,
+#                   and may need a spock patch refresh.  Use to get ahead of an
+#                   upcoming point release.
+#   tag             newest REL_<major>_* tag -- reproducible; the normal case.
+#                   Pre-GA majors resolve to their newest beta/RC tag and switch
+#                   to GA point releases automatically once those are tagged.
+#   <explicit ref>  pin exactly, e.g. REL_16_9 (reproducing a bug).
+#
+# Flip a value in a reviewed PR.  A `branch`->`tag` change and a patch refresh
+# often need to ship together.
+pg15_ref=tag
+pg16_ref=tag
+pg17_ref=tag
+pg18_ref=tag
+pg19_ref=tag

--- a/tests/resolve-pg-ref.sh
+++ b/tests/resolve-pg-ref.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Resolve the PostgreSQL source ref to build for a given major version,
+# per tests/postgres-build.conf.
+#
+# Prints the concrete ref (e.g. REL_17_STABLE or REL_16_9) to stdout.  All
+# diagnostics go to stderr, so callers can safely capture the ref with
+# `PG_REF=$(resolve-pg-ref.sh 17)`.
+#
+# Usage: resolve-pg-ref.sh <pg-major>
+#
+# Environment:
+#   POSTGRES_BUILD_CONF  path to the config file
+#                        (default: postgres-build.conf beside this script)
+#   PG_GIT_REMOTE        remote queried for `tag` resolution
+#                        (default: https://github.com/postgres/postgres.git)
+set -eu
+
+PG_GIT_REMOTE="${PG_GIT_REMOTE:-https://github.com/postgres/postgres.git}"
+
+die() { echo "resolve-pg-ref: $1" >&2; exit "${2:-1}"; }
+
+[ "$#" -eq 1 ] || die "usage: $(basename "$0") <pg-major>" 2
+
+major="$1"
+case "${major}" in
+	'' | *[!0-9]*) die "major version must be numeric, got '${major}'" 2 ;;
+esac
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+conf="${POSTGRES_BUILD_CONF:-${script_dir}/postgres-build.conf}"
+[ -f "${conf}" ] || die "config not found: ${conf}"
+
+# Extract the value of pg<major>_ref=, tolerating surrounding whitespace and
+# trailing inline comments.  Last matching line wins.
+mode="$(sed -n "s/^[[:space:]]*pg${major}_ref[[:space:]]*=[[:space:]]*//p" \
+		"${conf}" \
+	| sed 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' \
+	| tail -n 1)"
+
+[ -n "${mode}" ] || die "no entry 'pg${major}_ref=' in ${conf}"
+
+case "${mode}" in
+	branch)
+		ref="REL_${major}_STABLE"
+		;;
+	tag)
+		# Capture the remote listing first and check its status: a pipeline
+		# only reports the last stage's exit code, so a failed or partial
+		# ls-remote would otherwise feed a truncated list into the sort and
+		# silently resolve an older/wrong tag.
+		if ! tags="$(git ls-remote --tags --refs "${PG_GIT_REMOTE}" \
+				"REL_${major}_*")"; then
+			# Don't echo PG_GIT_REMOTE -- it may embed credentials.
+			die "failed to query the configured remote (PG_GIT_REMOTE) for REL_${major}_* tags"
+		fi
+		# Newest tag by version sort (not lexical) so REL_16_10 beats
+		# REL_16_9; the _._ round-trip lets sort -V compare the fields.
+		ref="$(printf '%s\n' "${tags}" \
+				| sed 's|.*refs/tags/||' \
+				| tr '_' '.' \
+				| sort -V \
+				| tail -n 1 \
+				| tr '.' '_')"
+		[ -n "${ref}" ] || die "no REL_${major}_* tag at the configured remote (PG_GIT_REMOTE)"
+		;;
+	*)
+		# Explicit pin: a PostgreSQL ref name (REL_*) or a commit SHA
+		# (7-40 hex).  Reject anything else so a typo like "tga" fails
+		# here with a clear message instead of as an obscure fetch error.
+		if printf '%s' "${mode}" \
+				| grep -Eq '^(REL_[0-9].*|[0-9a-fA-F]{7,40})$'; then
+			ref="${mode}"
+		else
+			die "invalid pg${major}_ref '${mode}': expected tag, branch, a REL_* ref, or a commit SHA"
+		fi
+		;;
+esac
+
+echo "resolve-pg-ref: pg${major}_ref=${mode} -> ${ref}" >&2
+printf '%s\n' "${ref}"

--- a/tests/resolve-pg-ref.test.sh
+++ b/tests/resolve-pg-ref.test.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+# Tests for resolve-pg-ref.sh.
+#
+# The offline cases are deterministic (they use a temp config via
+# POSTGRES_BUILD_CONF and never touch the network).  The `tag` case needs
+# to reach a Postgres git remote; if the network is unavailable it is
+# reported as SKIP rather than failing the suite.
+#
+# Usage: tests/resolve-pg-ref.test.sh
+# Exit:  0 all assertions passed (skips allowed), non-zero otherwise.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESOLVER="${SCRIPT_DIR}/resolve-pg-ref.sh"
+
+pass=0
+fail=0
+skip=0
+
+ok()   { pass=$((pass + 1)); echo "ok   - $1"; }
+no()   { fail=$((fail + 1)); echo "FAIL - $1"; }
+skipt(){ skip=$((skip + 1)); echo "skip - $1"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+CONF="${WORK}/postgres-build.conf"
+cat > "${CONF}" <<'EOF'
+# sample config for tests
+pg15_ref=branch
+pg16_ref=REL_16_9
+pg17_ref=tag
+pg18_ref = branch
+pg20_ref=tga
+pg21_ref=bb0a3ca8d218b6c0792235d7306117e5bc36294a
+EOF
+
+# ---- branch mode --------------------------------------------------------
+out="$(POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 15 2>/dev/null)"
+if [ "${out}" = "REL_15_STABLE" ]; then
+	ok "branch -> REL_15_STABLE"
+else
+	no "branch -> REL_15_STABLE (got '${out}')"
+fi
+
+# ---- explicit pin emitted verbatim -------------------------------------
+out="$(POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 16 2>/dev/null)"
+if [ "${out}" = "REL_16_9" ]; then
+	ok "explicit pin -> REL_16_9"
+else
+	no "explicit pin -> REL_16_9 (got '${out}')"
+fi
+
+# ---- a commit-SHA pin is emitted verbatim ------------------------------
+out="$(POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 21 2>/dev/null)"
+if [ "${out}" = "bb0a3ca8d218b6c0792235d7306117e5bc36294a" ]; then
+	ok "commit-SHA pin emitted verbatim"
+else
+	no "commit-SHA pin emitted verbatim (got '${out}')"
+fi
+
+# ---- an unknown value (typo) is rejected, not treated as a pin ---------
+if POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 20 >/dev/null 2>&1; then
+	no "unknown ref value is rejected"
+else
+	ok "unknown ref value is rejected"
+fi
+
+# ---- surrounding whitespace tolerated ----------------------------------
+out="$(POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 18 2>/dev/null)"
+if [ "${out}" = "REL_18_STABLE" ]; then
+	ok "whitespace around '=' tolerated"
+else
+	no "whitespace around '=' tolerated (got '${out}')"
+fi
+
+# ---- missing major -> non-zero -----------------------------------------
+if POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 99 >/dev/null 2>&1; then
+	no "missing major exits non-zero"
+else
+	ok "missing major exits non-zero"
+fi
+
+# ---- non-numeric arg -> non-zero ---------------------------------------
+if POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" abc >/dev/null 2>&1; then
+	no "non-numeric major exits non-zero"
+else
+	ok "non-numeric major exits non-zero"
+fi
+
+# ---- no arg -> non-zero -------------------------------------------------
+if POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" >/dev/null 2>&1; then
+	no "missing arg exits non-zero"
+else
+	ok "missing arg exits non-zero"
+fi
+
+# ---- missing config file -> non-zero -----------------------------------
+if POSTGRES_BUILD_CONF="${WORK}/does-not-exist.conf" "${RESOLVER}" 15 \
+		>/dev/null 2>&1; then
+	no "missing config file exits non-zero"
+else
+	ok "missing config file exits non-zero"
+fi
+
+# ---- stdout stays clean (diagnostics go to stderr) ---------------------
+out="$(POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 15 2>/dev/null)"
+lines="$(printf '%s' "${out}" | wc -l)"
+if [ "${out}" = "REL_15_STABLE" ] && [ "${lines}" -eq 0 ]; then
+	ok "stdout carries only the ref"
+else
+	no "stdout carries only the ref (got '${out}')"
+fi
+
+# ---- tag mode (needs network; skips gracefully) ------------------------
+out="$(POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 17 2>/dev/null)"
+rc=$?
+if [ "${rc}" -ne 0 ] || [ -z "${out}" ]; then
+	skipt "tag -> newest REL_17_* (network unavailable)"
+elif echo "${out}" | grep -Eq '^REL_17_[0-9]+$'; then
+	ok "tag -> newest REL_17_* (${out})"
+else
+	no "tag -> newest REL_17_* (got '${out}')"
+fi
+
+# ---- tag mode fails closed when ls-remote errors (stubbed git) ---------
+stubdir="${WORK}/stubbin"
+mkdir -p "${stubdir}"
+cat > "${stubdir}/git" <<'GIT'
+#!/bin/sh
+# Emit some tags, then fail partway -- a partial/dropped remote listing.
+if [ "$1" = "ls-remote" ]; then
+	printf '%s\trefs/tags/REL_17_1\n' 0000000000000000000000000000000000000000
+	printf '%s\trefs/tags/REL_17_2\n' 1111111111111111111111111111111111111111
+	exit 1
+fi
+exit 0
+GIT
+chmod +x "${stubdir}/git"
+if PATH="${stubdir}:${PATH}" POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 17 \
+		>/dev/null 2>&1; then
+	no "tag mode fails closed when ls-remote errors"
+else
+	ok "tag mode fails closed when ls-remote errors"
+fi
+
+# ---- a credentialed remote URL is never written to logs ----------------
+leakdir="${WORK}/leakbin"
+mkdir -p "${leakdir}"
+cat > "${leakdir}/git" <<'GIT'
+#!/bin/sh
+# ls-remote succeeds but lists no matching tags, so the resolver hits its
+# "no tag found" error path.
+exit 0
+GIT
+chmod +x "${leakdir}/git"
+err="$(PATH="${leakdir}:${PATH}" \
+	PG_GIT_REMOTE="https://u:SECRETTOKEN@example.invalid/pg.git" \
+	POSTGRES_BUILD_CONF="${CONF}" "${RESOLVER}" 17 2>&1 >/dev/null)"
+if printf '%s' "${err}" | grep -q "SECRETTOKEN"; then
+	no "credentialed remote URL is not logged"
+else
+	ok "credentialed remote URL is not logged"
+fi
+
+echo "---"
+echo "pass=${pass} fail=${fail} skip=${skip}"
+[ "${fail}" -eq 0 ]

--- a/tests/run-single-pg18-installcheck.sh
+++ b/tests/run-single-pg18-installcheck.sh
@@ -227,11 +227,15 @@ psql_on() {
 # Build pipeline: clone + build PG + build Spock (once, shared by all nodes)
 # ---------------------------------------------------------------------------
 
+# PG_REF is the concrete ref to build (a tag or a branch); resolved by
+# clone_pg from tests/postgres-build.conf before these helpers run.
+# Pick the first reachable mirror.  Reachability is checked generically
+# (HEAD), not by looking up PG_REF, because PG_REF may be a raw commit SHA
+# rather than a ref name; a bad ref is caught loudly by the fetch below.
 pick_pg_remote() {
 	local r
 	for r in ${PG_GIT_REMOTES}; do
-		if git ls-remote --exit-code --heads "${r}" "REL_${PG_VER}_STABLE" \
-				>/dev/null 2>&1; then
+		if git ls-remote --exit-code "${r}" HEAD >/dev/null 2>&1; then
 			echo "${r}"
 			return 0
 		fi
@@ -239,29 +243,50 @@ pick_pg_remote() {
 	return 1
 }
 
+# fetch + checkout (not clone --branch) so an explicit commit-SHA pin works
+# as well as a branch or tag name.  The && chain ensures a mid-sequence
+# failure propagates and the reuse marker is only written on full success.
 _do_clone_pg() {
 	local remote="$1"
-	local branch="REL_${PG_VER}_STABLE"
-	rm -rf "${SRC}"
-	git clone --depth=1 --single-branch --branch "${branch}" \
-		"${remote}" "${SRC}"
+	rm -rf "${SRC}" && \
+	git init "${SRC}" && \
+	git -C "${SRC}" remote add origin "${remote}" && \
+	git -C "${SRC}" fetch --depth 1 origin "${PG_REF}" && \
+	git -C "${SRC}" checkout --detach FETCH_HEAD && \
+	printf '%s\n' "${PG_REF}" > "${SRC}/.spock-pg-ref"
 }
 
 clone_pg() {
-	local branch="REL_${PG_VER}_STABLE"
+	# Resolve first: the reuse checks below must know which ref is wanted.
+	# tag | branch | explicit pin, per tests/postgres-build.conf.
+	PG_REF="$("${SCRIPT_DIR}/resolve-pg-ref.sh" "${PG_VER}")" \
+		|| fail "PG${PG_VER}: could not resolve PostgreSQL ref from config" 5
+
+	# A cached checkout built for a different ref (config changed since)
+	# forces a full rebuild, so the new ref takes effect in the pg-build and
+	# spock-build phases too -- all three phases gate on FORCE_REBUILD.  A
+	# moved branch tip (same ref name, new commits) is deliberately NOT
+	# detected here; use --force for that.
+	if [ "${FORCE_REBUILD}" -eq 0 ] \
+		&& [ -d "${SRC}/.git" ] \
+		&& [ "$(cat "${SRC}/.spock-pg-ref" 2>/dev/null)" != "${PG_REF}" ]; then
+		log "pg${PG_VER}: [pg-clone] cached source is for a different ref;" \
+			"rebuilding for ${PG_REF}"
+		FORCE_REBUILD=1
+	fi
 
 	if [ "${FORCE_REBUILD}" -eq 0 ] \
 		&& [ -d "${SRC}/.git" ] \
 		&& [ -f "${SRC}/src/test/regress/parallel_schedule" ]; then
-		log "pg${PG_VER}: [pg-clone] source already present, skipping"
+		log "pg${PG_VER}: [pg-clone] source for ${PG_REF} already present, skipping"
 		return 0
 	fi
 
 	local remote
 	remote="$(pick_pg_remote)" \
-		|| fail "PG${PG_VER}: no reachable git remote for ${branch}" 5
+		|| fail "PG${PG_VER}: no reachable git remote for ${PG_REF}" 5
 
-	log "pg${PG_VER}: [pg-clone] ${branch} from ${remote}"
+	log "pg${PG_VER}: [pg-clone] ${PG_REF} from ${remote}"
 	run_phase "pg${PG_VER}" pg-clone _do_clone_pg "${remote}"
 }
 


### PR DESCRIPTION
Resolve the PG source ref (tag | branch | pin) per major from one config plus resolver script, used by all three build sites: `Dockerfile-step-1.el9`, `pg-stable-test.yml`, and `run-single-pg18-installcheck.sh`. Default 15-19 to "tag".

The purpose is to build against the most recent release tag most of the time, but allow for building against HEAD of Postgres major stable branches as we near new releases (before they have been stamped) by modifying `tests/postgres-build.conf`. The default values in that file are:

```
pg15_ref=tag
pg16_ref=tag
pg17_ref=tag
pg18_ref=tag
pg19_ref=tag
```

To build against the head of branches, replace `tag` with `branch` here. As mentioned above, one can also pin to a certain commit/ref.

Also, Dockerfile keeps an optional PG_REF build-arg so ref resolution can later move to the runner for layer caching without further Dockerfile changes. It also allows for flexible building locally.