### PR TITLE
spock_apply: advance forwarded origin using pre-created disabled subscription

### DIFF
--- a/docs/spock_functions/functions/spock_sub_alter_options.md
+++ b/docs/spock_functions/functions/spock_sub_alter_options.md
@@ -52,6 +52,9 @@ options
         element is the string "all". Pass an empty array ([]) to disable
         origin forwarding.
 
+        See [Origin Forwarding](../sub_mgmt.md#origin-forwarding) for the
+        restriction on combining this with other enabled subscriptions.
+
     apply_delay
 
         A PostgreSQL interval string (e.g. "2 seconds", "500ms", "0")

--- a/docs/spock_functions/functions/spock_sub_create.md
+++ b/docs/spock_functions/functions/spock_sub_create.md
@@ -71,6 +71,9 @@ forward_origins
     replication to avoid forwarding changes in a loop). Use {all} to replicate all
     changes regardless of origin. The default is `{}` (local-origin changes only).
 
+    See [Origin Forwarding](../sub_mgmt.md#origin-forwarding) for the
+    restriction on combining this with other enabled subscriptions.
+
 apply_delay
 
     An interval specifying how long to delay applying changes from the

--- a/docs/spock_functions/functions/spock_sub_enable.md
+++ b/docs/spock_functions/functions/spock_sub_enable.md
@@ -13,6 +13,10 @@ spock.sub_enable(subscription_name name, immediate boolean)
 
 The `spock.sub_enable()` function enables a subscription.
 
+This fails if another subscription on this node already has origin
+forwarding active; see
+[Origin Forwarding](../sub_mgmt.md#origin-forwarding).
+
 ## Arguments
 
 The function accepts the following arguments:

--- a/docs/spock_functions/sub_mgmt.md
+++ b/docs/spock_functions/sub_mgmt.md
@@ -45,11 +45,9 @@ Parameters include:
   `false`.
 - `synchronize_data` specifies if Spock should synchronize data from
   provider to the subscriber; the default is `false`.
-- `forward_origins` is an array of origin names to forward. Currently, the
-  only supported values are an empty array meaning don't forward any changes
-  that didn't originate on provider node (this is useful for two-way
-  replication between the nodes), or `{all}` which means replicate all changes
-  no matter what is their origin. The default is `{}` (an empty array, meaning only local changes are forwarded).
+- `forward_origins` is an array of origin names to forward. See
+  [Origin Forwarding](#origin-forwarding) below for supported values and the
+  restriction on combining this with other enabled subscriptions.
 - `apply_delay` specifies how long to delay replication; the default is `0`
   seconds.
 - set `force_text_transfer` to `true` to force the provider to replicate all
@@ -100,6 +98,36 @@ Drops a subscription named `accts`; if the subscription does not exist, an
 error message will be suppressed by the `true` trailing parameter (`ifexists =
 true`).
 
+## Origin Forwarding
+
+`forward_origins` controls whether a subscription's apply worker also
+processes transactions that did not originate on the immediate provider, but
+were relayed through it from a peer further upstream (a cascade or multi-hop
+topology). `{}` (the default) forwards only the provider's own
+locally-originated changes — the setting used for ordinary bidirectional
+replication between two nodes, since forwarding a peer's changes back to
+itself would loop. `{all}` forwards every change regardless of origin.
+
+A forwarding worker advances the replication origin of the local subscription
+matching the peer it's relaying (for example, a subscription to that peer
+created disabled ahead of time, so it can later start from the right
+position instead of a full resync). At most one local subscription may match
+a given peer; if more than one does, replication fails with an ambiguous-match
+error. If the matching subscription is also enabled, its own apply worker
+owns the same origin, and the two would conflict. Spock avoids this by
+requiring that a subscription with forwarding active be the only enabled
+subscription on the node:
+
+- Enabling forwarding (`{all}`) on a subscription — via `spock.sub_create`
+  with `enabled := true`, `spock.sub_enable`, or `spock.sub_alter_options`
+  on an already-enabled subscription — fails if another subscription is
+  already enabled on this node.
+- Enabling a subscription (`spock.sub_create` with `enabled := true`, or
+  `spock.sub_enable`) fails if another subscription on this node already has
+  forwarding active.
+- Changing `forward_origins` on a subscription that stays disabled is always
+  allowed; the restriction is only checked once the subscription is actually
+  enabled.
 
 ## Subscription Management Functions
 
@@ -127,11 +155,9 @@ Parameters:
   structure from the provider to the subscriber; the default is `false`.
 - `synchronize_data` tells Spock to synchronize data from provider to the
   subscriber; the default is `false`.
-- `forward_origins` is an array of origin names to forward. Currently, the
-  only supported values are an empty array meaning don't forward any changes
-  that didn't originate on the provider node (this is useful for two-way
-  replication between the nodes), or `{all}` which means replicate all
-  changes regardless of their origin. The default is `{}` (an empty array, meaning only local changes are forwarded).
+- `forward_origins` is an array of origin names to forward. See
+  [Origin Forwarding](#origin-forwarding) above for supported values and the
+  restriction on combining this with other enabled subscriptions.
 - `apply_delay` is the number of seconds to delay replication; the default
   is `0` seconds.
 - `force_text_transfer` forces the provider to replicate all columns using
@@ -191,6 +217,9 @@ Parameters:
 - `immediate` tells Spock when to start the subscription. If set to `true`,
   the subscription is started immediately; if set to `false` (the default),
   it will only be started at the end of the current transaction.
+
+This fails if another subscription on this node already has forwarding
+active; see [Origin Forwarding](#origin-forwarding) above.
 
 ### spock.sub_alter_interface
 

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -168,6 +168,13 @@ included in ORIGIN messages when the protocol version is 5 or higher.
 This ensures that conflict evaluation on Node C has accurate origin
 information even when changes pass through intermediate Node B.
 
+A subscription cannot activate `forward_origins` while another subscription
+is already enabled on the same node, and a subscription cannot be enabled
+while another has forwarding active; clear `forward_origins`
+(`spock.sub_alter_options`) or disable the other subscription first.  See
+[Origin Forwarding](spock_functions/sub_mgmt.md#origin-forwarding) for
+details.
+
 ### Per-subscription conflict statistics
 
 On PostgreSQL 18+, Spock registers a custom pgstat kind

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -102,12 +102,12 @@ static TimeOffset apply_delay = 0;
 static TimestampTz required_commit_ts = 0;
 
 /*
- * Cache for forwarded origin lookup. The remote_origin_id (Spock node ID)
- * is consistent across the cluster, so we can use it as a cache key to
- * avoid repeated slot name generation and origin lookups.
+ * Local origin for the current forwarded transaction's peer, if any.
+ * Resolved fresh per ORIGIN message (handle_origin()), not cached --
+ * a cached RepOriginId can be silently reassigned to an unrelated
+ * origin once its subscription is dropped.
  */
-static RepOriginId cached_forward_remote_id = InvalidRepOriginId;
-static RepOriginId cached_forward_local_id = InvalidRepOriginId;
+static RepOriginId forwarded_local_origin_id = InvalidRepOriginId;
 
 static Oid	QueueRelid = InvalidOid;
 
@@ -274,7 +274,9 @@ static void append_feedback_position(XLogRecPtr local_commit_lsn,
 static void get_feedback_position(XLogRecPtr *recvpos, XLogRecPtr *writepos,
 								  XLogRecPtr *flushpos, XLogRecPtr *max_recvpos);
 static void UpdateWorkerStats(XLogRecPtr last_received, XLogRecPtr last_inserted);
-static void maybe_advance_forwarded_origin(XLogRecPtr end_lsn, bool xact_had_exception);
+static RepOriginId resolve_forward_peer_origin(RepOriginId remote_origin_id);
+static void resolve_forwarded_origin_for_transaction(RepOriginId remote_origin_id);
+static void maybe_advance_forwarded_origin(XLogRecPtr local_lsn, bool xact_had_exception);
 static ApplyReplayEntry *apply_replay_queue_next_entry(void);
 static bool apply_replay_queue_append_entry(ApplyReplayEntry **entry_p,
 							StringInfo *msg_p);
@@ -836,6 +838,7 @@ handle_commit(StringInfo s)
 	XLogRecPtr	end_lsn;
 	TimestampTz commit_time;
 	XLogRecPtr	remote_insert_lsn;
+	XLogRecPtr	local_commit_lsn = InvalidXLogRecPtr;
 
 	errcallback_arg.action_name = "COMMIT";
 	xact_action_counter++;
@@ -1026,6 +1029,7 @@ handle_commit(StringInfo s)
 		flushpos = (SPKFlushPosition *) palloc(sizeof(SPKFlushPosition));
 		flushpos->local_end = XactLastCommitEnd;
 		flushpos->remote_end = end_lsn;
+		local_commit_lsn = XactLastCommitEnd;
 
 		dlist_push_tail(&lsn_mapping, &flushpos->node);
 		MemoryContextSwitchTo(MessageContext);
@@ -1050,10 +1054,12 @@ handle_commit(StringInfo s)
 
 	/*
 	 * For forwarded transactions, advance the replication origin for the
-	 * original source node. This is done outside the IsTransactionState()
-	 * block because it starts its own transaction.
+	 * original source node.  The local LSN passed here must be OUR commit
+	 * position (XactLastCommitEnd), not end_lsn — end_lsn is the provider's
+	 * WAL position, a different WAL space entirely.  For an empty forwarded
+	 * transaction there is no local commit, so InvalidXLogRecPtr is passed.
 	 */
-	maybe_advance_forwarded_origin(end_lsn, xact_had_exception);
+	maybe_advance_forwarded_origin(local_commit_lsn, xact_had_exception);
 
 	/* Update the entry in the progress table. */
 	elog(DEBUG1, "SPOCK %s: updating progress table for node_id %d" \
@@ -1176,6 +1182,39 @@ handle_commit(StringInfo s)
 }
 
 /*
+ * Resolve a forwarding peer to its local subscription origin.
+ *
+ * Forwarded transactions may arrive before, or without, a direct subscription
+ * to that peer. Return InvalidRepOriginId if none exists. If found, its origin
+ * records progress for a later enable without requiring a full resync.
+ *
+ * Multiple matches are ambiguous -- sub_create() doesn't prevent a second
+ * subscription to the same peer. This only affects pre-positioning for a
+ * later sub_enable(), not data apply, so warn and skip rather than erroring
+ * on every forwarded transaction from that peer.
+ */
+static RepOriginId
+resolve_forward_peer_origin(RepOriginId remote_origin_id)
+{
+	List	   *subs;
+
+	subs = get_node_subscriptions((Oid) remote_origin_id, true);
+	if (subs == NIL)
+		return InvalidRepOriginId;
+
+	if (list_length(subs) > 1)
+	{
+		elog(WARNING, "SPOCK %s: ambiguous forwarded origin: more than one "
+			 "local subscription matches peer node (origin id %u), "
+			 "skipping forwarded-origin advance",
+			 MySubscription->name, remote_origin_id);
+		return InvalidRepOriginId;
+	}
+
+	return replorigin_by_name(((SpockSubscription *) linitial(subs))->slot_name, true);
+}
+
+/*
  * Handle ORIGIN message.
  */
 static void
@@ -1211,6 +1250,32 @@ handle_origin(StringInfo s)
 	 */
 	remote_origin_id = spock_read_origin(s, &remote_origin_lsn, &remote_origin_name);
 	replorigin_session_origin = remote_origin_id;
+
+	resolve_forwarded_origin_for_transaction(remote_origin_id);
+}
+
+/*
+ * Resolve the local subscription origin for remote_origin_id, if one
+ * exists, for use by maybe_advance_forwarded_origin() at commit time.
+ * Called for every ORIGIN message.
+ *
+ * ORIGIN may also identify the direct provider's own transactions, so
+ * ignore invalid and direct-provider origins -- there's nothing to
+ * forward in that case.
+ */
+static void
+resolve_forwarded_origin_for_transaction(RepOriginId remote_origin_id)
+{
+	forwarded_local_origin_id = InvalidRepOriginId;
+
+	if (remote_origin_id == InvalidRepOriginId ||
+		remote_origin_id == (RepOriginId) MySubscription->origin->id)
+		return;
+
+	StartTransactionCommand();
+	forwarded_local_origin_id = resolve_forward_peer_origin(remote_origin_id);
+	CommitTransactionCommand();
+	MemoryContextSwitchTo(MessageContext);
 }
 
 /*
@@ -4867,101 +4932,36 @@ apply_replay_queue_start_replay(void)
 /*
  * Advance the replication origin for forwarded transactions.
  *
- * In cascade replication (A -> B -> C with forward_origins='all'), when C
- * receives transactions that originated on A (forwarded through B), we track
- * C's position relative to A by maintaining a separate replication origin.
+ * forwarded_local_origin_id was resolved fresh for this transaction in
+ * handle_origin(). If no matching subscription exists, no advance is
+ * needed. remote_origin_lsn is in the peer's WAL space; local_lsn is this
+ * node's commit position, or InvalidXLogRecPtr for an empty transaction.
+ * Never use the provider's end_lsn as the local value, as that breaks
+ * recovery ordering.
  *
- * This enables seamless switchover: if C later subscribes directly to A,
- * the origin will already exist with the correct LSN, so C knows where to
- * start receiving from A.
- *
- * The origin is named using slot name format (spk_<db>_<source>_<subscriber>)
- * for consistency with direct subscriptions.
- *
- * We cache the remote_origin_id -> local_origin_id mapping since the Spock
- * node ID is stable across the cluster (set by commit f60484e).
+ * wal_log=true makes the resume position durable. Because the advance is
+ * logged separately after the data commit, a crash may lose the latest
+ * advance and cause one transaction to be replayed, preserving at-least-once
+ * semantics. last_update_wins handles the duplicate; delta-apply idempotency
+ * is tracked separately.
  */
 static void
-maybe_advance_forwarded_origin(XLogRecPtr end_lsn, bool xact_had_exception)
+maybe_advance_forwarded_origin(XLogRecPtr local_lsn, bool xact_had_exception)
 {
-	RepOriginId	forwarded_origin;
-
-	/*
-	 * Only advance for forwarded transactions (origin differs from our direct
-	 * provider) that completed without exceptions.
-	 */
 	if (xact_had_exception ||
 		remote_origin_id == InvalidRepOriginId ||
-		remote_origin_id == MySubscription->origin->id ||
-		remote_origin_name == NULL)
+		remote_origin_id == (RepOriginId) MySubscription->origin->id ||
+		remote_origin_name == NULL ||
+		forwarded_local_origin_id == InvalidRepOriginId)
 		return;
 
-	/*
-	 * Check cache first. The remote_origin_id (Spock node ID) is stable
-	 * for a given source node, so we can reuse the local origin ID.
-	 */
-	if (remote_origin_id == cached_forward_remote_id &&
-		cached_forward_local_id != InvalidRepOriginId)
-	{
-		forwarded_origin = cached_forward_local_id;
+	elog(DEBUG2, "SPOCK %s: advancing forwarded origin (oid %u) "
+		 "remote_lsn %X/%X local_lsn %X/%X",
+		 MySubscription->name,
+		 forwarded_local_origin_id,
+		 (uint32) (remote_origin_lsn >> 32), (uint32) remote_origin_lsn,
+		 (uint32) (local_lsn >> 32), (uint32) local_lsn);
 
-		elog(DEBUG2, "SPOCK %s: advancing forwarded origin (cached, oid %u) "
-			 "remote_lsn %X/%X end_lsn %X/%X",
-			 MySubscription->name,
-			 forwarded_origin,
-			 (uint32) (remote_origin_lsn >> 32), (uint32) remote_origin_lsn,
-			 (uint32) (end_lsn >> 32), (uint32) end_lsn);
-	}
-	else
-	{
-		/*
-		 * Cache miss - look up or create the origin. Use slot name format
-		 * (spk_<db>_<provider>_<subscription>) for consistency with direct
-		 * subscriptions.
-		 */
-		Relation	replorigin_rel;
-		NameData	slot_name;
-		char	   *dbname;
-
-		StartTransactionCommand();
-
-		dbname = get_database_name(MyDatabaseId);
-		gen_slot_name(&slot_name, dbname, remote_origin_name,
-					  MySubscription->name);
-
-		elog(DEBUG2, "SPOCK %s: advancing forwarded origin '%s' (from node '%s') "
-			 "remote_lsn %X/%X end_lsn %X/%X",
-			 MySubscription->name,
-			 NameStr(slot_name),
-			 remote_origin_name,
-			 (uint32) (remote_origin_lsn >> 32), (uint32) remote_origin_lsn,
-			 (uint32) (end_lsn >> 32), (uint32) end_lsn);
-
-		replorigin_rel = table_open(ReplicationOriginRelationId, RowExclusiveLock);
-		forwarded_origin = replorigin_by_name(NameStr(slot_name), true);
-
-		if (forwarded_origin == InvalidRepOriginId)
-		{
-			forwarded_origin = replorigin_create(NameStr(slot_name));
-			elog(DEBUG2, "SPOCK %s: created replication origin '%s' (oid %u) "
-				 "for forwarded transactions from node '%s'",
-				 MySubscription->name, NameStr(slot_name), forwarded_origin,
-				 remote_origin_name);
-		}
-
-		table_close(replorigin_rel, RowExclusiveLock);
-		CommitTransactionCommand();
-		MemoryContextSwitchTo(MessageContext);
-
-		/* Update cache */
-		cached_forward_remote_id = remote_origin_id;
-		cached_forward_local_id = forwarded_origin;
-	}
-
-	/* Advance the origin */
-	StartTransactionCommand();
-	replorigin_advance(forwarded_origin, remote_origin_lsn,
-					   end_lsn, false, false);
-	CommitTransactionCommand();
-	MemoryContextSwitchTo(MessageContext);
+	replorigin_advance(forwarded_local_origin_id, remote_origin_lsn,
+					   local_lsn, false, true);
 }

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -463,6 +463,70 @@ spock_alter_node_drop_interface(PG_FUNCTION_ARGS)
 }
 
 /*
+ * Reject changes that enable forwarding alongside another enabled
+ * subscription on this node.
+ *
+ * A forwarding worker advances matching local subscription origins. If that
+ * subscription is enabled, its apply worker owns the origin and a subsequent
+ * advance fails with ERRCODE_OBJECT_IN_USE, disabling the forwarder.
+ *
+ * Check creates, enables, and non-empty forward_origins changes. The target's
+ * pending state is passed explicitly because its catalog state may not yet
+ * reflect the change. The check covers all subscriptions because forwarding
+ * may relay any origin.
+ *
+ * This catalog check cannot prevent worker races or direct catalog changes.
+ * maybe_advance_forwarded_origin() leaves ownership errors uncaught so they
+ * remain visible.
+ */
+static void
+enforce_forwarding_exclusivity(Oid target_sub_id, const char *target_sub_name,
+								bool target_enabled, List *target_forward_origins)
+{
+	SpockLocalNode *localnode = get_local_node(true, false);
+	List	   *subs;
+	ListCell   *lc;
+	bool		target_forwards = target_enabled && list_length(target_forward_origins) > 0;
+
+	if (!target_enabled)
+		return;		/* a disabled target can never conflict with anything */
+
+	subs = get_node_subscriptions(localnode->node->id, false);
+	foreach(lc, subs)
+	{
+		SpockSubscription *sub = (SpockSubscription *) lfirst(lc);
+		bool		other_forwards;
+
+		if (sub->id == target_sub_id || !sub->enabled)
+			continue;
+
+		other_forwards = list_length(sub->forward_origins) > 0;
+
+		if (!target_forwards && !other_forwards)
+			continue;
+
+		if (target_forwards)
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("cannot activate forwarding on subscription \"%s\" "
+							"while subscription \"%s\" is enabled on this node",
+							target_sub_name, sub->name),
+					 errhint("clear forward_origins on \"%s\", or disable "
+							 "\"%s\" first",
+							 target_sub_name, sub->name)));
+		else
+			ereport(ERROR,
+					(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+					 errmsg("cannot enable subscription \"%s\" while "
+							"subscription \"%s\" has forwarding active",
+							target_sub_name, sub->name),
+					 errhint("clear forward_origins on \"%s\" "
+							 "(spock.sub_alter_options) before enabling \"%s\"",
+							 sub->name, target_sub_name)));
+	}
+}
+
+/*
  * Connect two existing nodes.
  */
 Datum
@@ -488,11 +552,16 @@ spock_create_subscription(PG_FUNCTION_ARGS)
 	SpockInterface targetif;
 	List	   *replication_sets;
 	List	   *other_subs;
+	List	   *new_forward_origins;
 	ListCell   *lc;
 	NameData	slot_name;
 
 	/* Check that this is actually a node. */
 	localnode = get_local_node(true, false);
+
+	new_forward_origins = textarray_to_list(forward_origin_names);
+	if (enabled)
+		enforce_forwarding_exclusivity(InvalidOid, sub_name, true, new_forward_origins);
 
 	/* Now, fetch info about remote node. */
 	conn = spock_connect(provider_dsn, sub_name, "create");
@@ -608,7 +677,7 @@ spock_create_subscription(PG_FUNCTION_ARGS)
 	sub.origin_if = &originif;
 	sub.target_if = &targetif;
 	sub.replication_sets = replication_sets;
-	sub.forward_origins = textarray_to_list(forward_origin_names);
+	sub.forward_origins = new_forward_origins;
 	sub.enabled = enabled;
 	gen_slot_name(&slot_name, get_database_name(MyDatabaseId),
 				  origin->name, sub_name);
@@ -833,6 +902,8 @@ spock_alter_subscription_enable(PG_FUNCTION_ARGS)
 	/* XXX: Only used for locking purposes. */
 	(void) get_local_node(true, false);
 
+	enforce_forwarding_exclusivity(sub->id, sub->name, true, sub->forward_origins);
+
 	sub->enabled = true;
 
 	alter_subscription(sub);
@@ -1030,7 +1101,10 @@ spock_alter_subscription_options(PG_FUNCTION_ARGS)
 			}
 
 			if (strcmp(key, "forward_origins") == 0)
+			{
+				enforce_forwarding_exclusivity(sub->id, sub->name, sub->enabled, result);
 				sub->forward_origins = result;
+			}
 			else
 				sub->skip_schema = result;
 			changed = true;

--- a/tests/tap/t/015_forward_origin_advance.pl
+++ b/tests/tap/t/015_forward_origin_advance.pl
@@ -2,29 +2,40 @@
 # =============================================================================
 # Test: 015_forward_origin_advance.pl - Verify Forward Origin Tracking
 # =============================================================================
-# This test verifies that when forward_origins='all' is set, the subscriber
-# creates and advances a replication origin for the original source node.
+# This test verifies that when forward_origins='all' is set and a disabled
+# subscription is pre-created on the new node to a peer, the apply worker
+# on the new node correctly advances that pre-created origin as the peer's
+# forwarded transactions arrive during catchup.
 #
 # Topology:
-#   A (n1) -> B (n2) -> C (n3)
-#            forward_origins='all' on both subscriptions
+#   n2 -> n1 -> n3
+#         forward_origins='all' only on n3's subscription to n1 -- that is
+#         what tells n1 to relay transactions it received from n2, rather
+#         than only its own
+#
+# Roles:
+#   n1 = source   — the node n3 actively subscribes to for catchup (enabled,
+#                   forward_origins='all'); forwards n2's changes to n3
+#   n2 = peer     — existing cluster member whose changes are forwarded
+#                   through n1 to n3
+#   n3 = new_node — the node being added to the cluster
 #
 # Expected behavior:
-# - A inserts data
-# - B receives from A and forwards to C
-# - C should create a replication origin using slot name format:
-#   spk_<db>_<source>_<subscriber> (e.g., "spk_regression_n1_n3")
-# - C should advance that origin's LSN as it receives forwarded transactions
-#
-# This test FAILS on 'main' branch (origin not created)
-# This test PASSES on 'task/SPOC-228/physical-to-logical-replica' branch
+# - Before catchup: n3 pre-creates a disabled subscription to n2 (sub_n3_n2).
+#   This creates a named replication origin at LSN 0/0.
+# - n2 inserts data; n1 receives it (via sub_n1_n2) and forwards it to n3
+#   (via the enabled sub_n3_n1, forward_origins='all')
+# - n3 advances the pre-created sub_n3_n2 origin LSN as forwarded n2
+#   transactions arrive
+# - When sub_enable('sub_n3_n2') fires, the apply worker starts from
+#   the correct position — no duplicates, no gaps
 # =============================================================================
 
 use strict;
 use warnings;
-use Test::More tests => 22;
+use Test::More tests => 34;
 use lib '.';
-use SpockTest qw(create_cluster destroy_cluster system_or_bail system_maybe command_ok get_test_config scalar_query psql_or_bail);
+use SpockTest qw(create_cluster destroy_cluster system_or_bail get_test_config scalar_query psql_or_bail wait_for_sub_status);
 
 # =============================================================================
 # SETUP: Create 3-node cluster
@@ -32,15 +43,13 @@ use SpockTest qw(create_cluster destroy_cluster system_or_bail system_maybe comm
 
 create_cluster(3, 'Create 3-node cluster');
 
-my $config = get_test_config();
+my $config     = get_test_config();
 my $node_ports = $config->{node_ports};
-my $pg_bin = $config->{pg_bin};
-my $dbname = $config->{db_name};
-my $host = $config->{host};
+my $dbname     = $config->{db_name};
+my $host       = $config->{host};
 
-# Connection strings
-my $conn_a = "host=$host port=$node_ports->[0] dbname=$dbname";
-my $conn_b = "host=$host port=$node_ports->[1] dbname=$dbname";
+my $conn_n1 = "host=$host port=$node_ports->[0] dbname=$dbname";
+my $conn_n2 = "host=$host port=$node_ports->[1] dbname=$dbname";
 
 # =============================================================================
 # TEST: Forward Origin Advance
@@ -64,116 +73,212 @@ psql_or_bail(2, "SELECT spock.repset_add_table('cascade_set', 'test_origin')");
 psql_or_bail(3, "SELECT spock.repset_add_table('cascade_set', 'test_origin')");
 pass('Added table to replication sets');
 
-# Create cascade: A -> B -> C
-# B subscribes to A with forward_origins='all'
-psql_or_bail(2, "SELECT spock.sub_create('sub_a_to_b', '$conn_a', ARRAY['cascade_set'], false, false, ARRAY['all'])");
-pass('Created subscription B->A with forward_origins=all');
+# n1 subscribes to n2, an ordinary subscription. n2's own commits carry no
+# origin (InvalidRepOriginId, since n2 has no upstream peer of its own in
+# this test) and are never filtered by forward_origins regardless of its
+# setting, so this leg does not need it.
+psql_or_bail(1, "SELECT spock.sub_create('sub_n1_n2', '$conn_n2', ARRAY['cascade_set'], false, false)");
+pass('Created subscription n1->n2');
 
-# C subscribes to B with forward_origins='all'
-psql_or_bail(3, "SELECT spock.sub_create('sub_b_to_c', '$conn_b', ARRAY['cascade_set'], false, false, ARRAY['all'])");
-pass('Created subscription C->B with forward_origins=all');
+# n3 subscribes to n1 (the source) for catchup.  forward_origins='all' here
+# is what tells n1's output plugin to also include transactions n1 itself
+# received from n2 (tagged with n2's origin), rather than only n1's own.
+psql_or_bail(3, "SELECT spock.sub_create('sub_n3_n1', '$conn_n1', ARRAY['cascade_set'], false, false, ARRAY['all'])");
+pass('Created subscription n3->n1 with forward_origins=all');
 
-# Wait for subscriptions to be ready
-system_or_bail 'sleep', '5';
+# Pre-create a disabled subscription on n3 to peer n2 before catchup begins.
+# sub_create(enabled=false) creates a named replication origin on n3 at LSN 0/0
+# without starting an apply worker.  track_forward_peer_origin()/
+# maybe_advance_forwarded_origin() advance it as forwarded n2 transactions
+# arrive, so that sub_enable('sub_n3_n2') starts from the correct LSN.
+psql_or_bail(3, "SELECT spock.sub_create(
+    subscription_name := 'sub_n3_n2',
+    provider_dsn      := '$conn_n2',
+    replication_sets  := ARRAY['cascade_set'],
+    synchronize_structure := false,
+    synchronize_data  := false,
+    enabled           := false
+)");
+pass('Pre-created disabled subscription n3->n2');
 
-# Verify subscriptions are replicating
-my $sub_b = scalar_query(2, "SELECT 1 FROM spock.sub_show_status() WHERE subscription_name = 'sub_a_to_b' AND status = 'replicating'");
-is($sub_b, '1', 'Subscription A->B is replicating');
+# sub_create(enabled=false) creates the catalog entry and replication origin
+# but not a slot on the provider.  In the real join flow, spock_create_subscriber
+# handles slot creation.  Create it directly here so sub_enable() can start the
+# apply worker.
+my $sub_n3_n2_slot = scalar_query(3,
+    "SELECT spock.spock_gen_slot_name(current_database()::name, 'n2'::name, 'sub_n3_n2'::name)");
+psql_or_bail(2, "SELECT pg_create_logical_replication_slot('$sub_n3_n2_slot', 'spock_output')");
 
-my $sub_c = scalar_query(3, "SELECT 1 FROM spock.sub_show_status() WHERE subscription_name = 'sub_b_to_c' AND status = 'replicating'");
-is($sub_c, '1', 'Subscription B->C is replicating');
+ok(wait_for_sub_status(1, 'sub_n1_n2', 'replicating', 30),
+   'Subscription n1->n2 is replicating');
+ok(wait_for_sub_status(3, 'sub_n3_n1', 'replicating', 30),
+   'Subscription n3->n1 is replicating');
 
-# Insert data on A - this will be forwarded through B to C
-psql_or_bail(1, "INSERT INTO test_origin (val) VALUES ('from_node_a')");
-system_or_bail 'sleep', '5';
+my $sub_disabled = scalar_query(3, "SELECT 1 FROM spock.sub_show_status() WHERE subscription_name = 'sub_n3_n2' AND status = 'disabled'");
+is($sub_disabled, '1', 'Subscription sub_n3_n2 is disabled on n3');
 
-# Verify data reached C
-my $count_c = scalar_query(3, "SELECT COUNT(*) FROM test_origin WHERE val = 'from_node_a'");
-is($count_c, '1', 'Data from A reached C via B');
+# Insert data on n2 — will be forwarded through n1 to n3
+psql_or_bail(2, "INSERT INTO test_origin (val) VALUES ('from_n2')");
+
+my $count_n3 = 0;
+for my $attempt (1..30) {
+    $count_n3 = scalar_query(3, "SELECT COUNT(*) FROM test_origin WHERE val = 'from_n2'");
+    last if defined $count_n3 && $count_n3 >= 1;
+    sleep 1;
+}
+is($count_n3, '1', 'Data from n2 reached n3 via n1');
 
 # =============================================================================
-# KEY TEST: Check if C has created a replication origin for node A
+# KEY TEST: Check that n3's pre-created origin for n2 has been advanced
 # =============================================================================
-# On main branch: This origin will NOT exist (test fails)
-# On fix branch: This origin WILL exist (test passes)
-#
-# The origin uses slot name format: spk_<db>_<provider>_<subscription>
-# e.g., "spk_regression_n1_sub_b_to_c" for forwarded transactions from n1 via sub_b_to_c
+# sub_create(enabled=false) created the origin at 0/0.
+# As forwarded n2 transactions arrive on n3, maybe_advance_forwarded_origin()
+# looks up sub_n3_n2 by n2's node OID and advances its named origin.
+# When sub_enable('sub_n3_n2') fires, the apply worker reads this origin
+# and starts replication from the already-advanced position.
 
-my $expected_origin = scalar_query(3, "SELECT spock.spock_gen_slot_name(current_database()::name, 'n1'::name, 'sub_b_to_c'::name)");
-diag("Expected forwarded origin name on C: $expected_origin");
+my $expected_origin = scalar_query(3,
+    "SELECT spock.spock_gen_slot_name(current_database()::name, 'n2'::name, 'sub_n3_n2'::name)");
+diag("Expected forwarded origin name on n3: $expected_origin");
 
-my $origin_exists = scalar_query(3, "SELECT COUNT(*) FROM pg_replication_origin WHERE roname = '$expected_origin'");
-diag("Origin '$expected_origin' exists on C: $origin_exists");
-is($origin_exists, '1', "C has replication origin for forwarded source ($expected_origin)");
+my $origin_exists = scalar_query(3,
+    "SELECT COUNT(*) FROM pg_replication_origin WHERE roname = '$expected_origin'");
+diag("Origin '$expected_origin' exists on n3: $origin_exists");
+is($origin_exists, '1', "n3 has replication origin for forwarded n2 ($expected_origin)");
 
-# Also verify the origin has a valid LSN (not 0/0)
-my $origin_lsn = scalar_query(3, "SELECT COALESCE(s.remote_lsn::text, 'NULL') FROM pg_replication_origin o LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id WHERE o.roname = '$expected_origin'");
-diag("Origin '$expected_origin' LSN on C: $origin_lsn");
-ok($origin_lsn ne '0/0' && $origin_lsn ne 'NULL' && $origin_lsn ne '', "Origin $expected_origin has been advanced (LSN is valid)");
+my $origin_lsn = scalar_query(3,
+    "SELECT COALESCE(s.remote_lsn::text, 'NULL')
+     FROM pg_replication_origin o
+     LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id
+     WHERE o.roname = '$expected_origin'");
+diag("Origin '$expected_origin' LSN on n3: $origin_lsn");
+ok($origin_lsn ne '0/0' && $origin_lsn ne 'NULL' && $origin_lsn ne '',
+    "Origin $expected_origin has been advanced (LSN is valid)");
 
 # =============================================================================
 # GAP DETECTION TEST: Demonstrate origin tracking enables gap detection
 # =============================================================================
-# This test demonstrates that forwarded origin tracking enables detection of
-# unreplicated data during cascade switchover scenarios.
-#
-# With the fix (forwarded origin tracking):
-#   - We can query C's position relative to A via the forwarded origin LSN
-#   - We can query A's current position: pg_current_wal_lsn()
-#   - If A's LSN > C's tracked LSN, there's unreplicated data (a "gap")
-#   - This enables tooling to make informed switchover decisions
-#
-# Without the fix (main branch):
-#   - C has no forwarded origin, so we cannot detect gaps
-#   - Switchover is "blind" - we don't know what C has received from A
 
 diag("=== GAP DETECTION TEST: Origin tracking enables gap detection ===");
 
-# Insert more data and let it propagate
-psql_or_bail(1, "INSERT INTO test_origin (val) VALUES ('batch2_row1')");
-psql_or_bail(1, "INSERT INTO test_origin (val) VALUES ('batch2_row2')");
-system_or_bail 'sleep', '3';
+psql_or_bail(2, "INSERT INTO test_origin (val) VALUES ('batch2_row1')");
+psql_or_bail(2, "INSERT INTO test_origin (val) VALUES ('batch2_row2')");
 
-# Verify data reached C
-my $count_after_batch2 = scalar_query(3, "SELECT COUNT(*) FROM test_origin");
-diag("Row count on C after batch 2: $count_after_batch2");
-is($count_after_batch2, '3', 'C has 3 rows after batch 2');
+my $count_after_batch2 = 0;
+for my $attempt (1..30) {
+    $count_after_batch2 = scalar_query(3, "SELECT COUNT(*) FROM test_origin");
+    last if defined $count_after_batch2 && $count_after_batch2 >= 3;
+    sleep 1;
+}
+diag("Row count on n3 after batch 2: $count_after_batch2");
+is($count_after_batch2, '3', 'n3 has 3 rows after batch 2');
 
-# KEY TEST: Query C's tracked position for forwarded origin (only works with fix)
-my $c_origin_lsn = scalar_query(3, "SELECT COALESCE(s.remote_lsn::text, 'not_tracked') FROM pg_replication_origin o LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id WHERE o.roname = '$expected_origin'");
-diag("C's tracked LSN for A (origin '$expected_origin'): $c_origin_lsn");
+my $c_origin_lsn = scalar_query(3,
+    "SELECT COALESCE(s.remote_lsn::text, 'not_tracked')
+     FROM pg_replication_origin o
+     LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id
+     WHERE o.roname = '$expected_origin'");
+diag("n3's tracked LSN for n2 (origin '$expected_origin'): $c_origin_lsn");
 
-# Query A's current WAL position
-my $a_wal_lsn = scalar_query(1, "SELECT pg_current_wal_lsn()::text");
-diag("A's current WAL LSN: $a_wal_lsn");
-
-# On fix branch: c_origin_lsn should be a valid LSN (not 'not_tracked')
-# On main branch: c_origin_lsn would be 'not_tracked' (query returns nothing)
 ok($c_origin_lsn ne 'not_tracked' && $c_origin_lsn ne '',
-   'C can track its position relative to A (gap detection enabled)');
+   'n3 can track its position relative to n2 (gap detection enabled)');
 
-# Simulate gap: disable B->A, insert on A, check that we can detect the gap
-diag("Creating gap: disabling B->A subscription...");
-psql_or_bail(2, "SELECT spock.sub_disable('sub_a_to_b')");
-system_or_bail 'sleep', '2';
+# Simulate gap: disable n1->n2, insert on n2, check origin does not advance
+diag("Creating gap: disabling n1->n2 subscription...");
+psql_or_bail(1, "SELECT spock.sub_disable('sub_n1_n2')");
+ok(wait_for_sub_status(1, 'sub_n1_n2', 'disabled', 30),
+   'Subscription n1->n2 disabled to create gap');
 
-# Insert data on A that creates a gap (can't reach C)
-psql_or_bail(1, "INSERT INTO test_origin (val) VALUES ('gap_data')");
-my $a_wal_after_gap = scalar_query(1, "SELECT pg_current_wal_lsn()::text");
-diag("A's WAL LSN after gap data: $a_wal_after_gap");
+# This is a negative check (proving gap_data does NOT reach n3): there is no
+# status transition or count change to poll for, so a bounded sleep is the
+# right tool -- it gives propagation every chance to happen before we assert
+# that it didn't.
+psql_or_bail(2, "INSERT INTO test_origin (val) VALUES ('gap_data')");
+system_or_bail 'sleep', '5';
 
-# C's origin LSN should still be at the old position (gap exists)
-my $c_origin_after_gap = scalar_query(3, "SELECT COALESCE(s.remote_lsn::text, 'not_tracked') FROM pg_replication_origin o LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id WHERE o.roname = '$expected_origin'");
-diag("C's origin LSN (unchanged, gap detected): $c_origin_after_gap");
+my $c_origin_after_gap = scalar_query(3,
+    "SELECT COALESCE(s.remote_lsn::text, 'not_tracked')
+     FROM pg_replication_origin o
+     LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id
+     WHERE o.roname = '$expected_origin'");
+diag("n3's origin LSN (unchanged, gap detected): $c_origin_after_gap");
 
-# Verify the LSNs show a gap (A advanced, C's tracking hasn't)
-# This is the key insight: with origin tracking, we KNOW there's unreplicated data
-is($c_origin_after_gap, $c_origin_lsn, 'Gap detected: C origin unchanged while A advanced');
+is($c_origin_after_gap, $c_origin_lsn, 'Gap detected: n3 origin unchanged while n2 advanced');
 
-# Clean test: verify C still has 3 rows (gap data didn't arrive)
 my $count_with_gap = scalar_query(3, "SELECT COUNT(*) FROM test_origin");
-is($count_with_gap, '3', 'C still has 3 rows (gap data not received)');
+is($count_with_gap, '3', 'n3 still has 3 rows (gap data not received)');
+
+# =============================================================================
+# GAP RECOVERY TEST: Re-enable n1->n2 and verify gap data arrives on n3
+# =============================================================================
+
+psql_or_bail(1, "SELECT spock.sub_enable('sub_n1_n2')");
+ok(wait_for_sub_status(1, 'sub_n1_n2', 'replicating', 30),
+   'Subscription n1->n2 re-enabled');
+
+my $count_after_reenable = 0;
+for my $attempt (1..30) {
+    $count_after_reenable = scalar_query(3, "SELECT COUNT(*) FROM test_origin");
+    last if defined $count_after_reenable && $count_after_reenable >= 4;
+    sleep 1;
+}
+is($count_after_reenable, '4', 'n3 received gap_data after n1->n2 re-enabled');
+
+my $c_origin_after_reenable = scalar_query(3,
+    "SELECT COALESCE(s.remote_lsn::text, 'not_tracked')
+     FROM pg_replication_origin o
+     LEFT JOIN pg_replication_origin_status s ON o.roident = s.local_id
+     WHERE o.roname = '$expected_origin'");
+diag("n3's origin LSN after re-enable: $c_origin_after_reenable");
+ok($c_origin_after_reenable ne $c_origin_lsn,
+   'n3 forwarded origin LSN advanced after gap closed');
+
+# =============================================================================
+# SUB_ENABLE TEST: Verify no duplicates when sub_n3_n2 is enabled
+# =============================================================================
+# The forwarded origin on n3 for n2 has been advanced during cascade catchup.
+# When sub_enable('sub_n3_n2') fires, the apply worker calls
+# replorigin_session_get_progress() on the pre-created origin and receives
+# the forwarded LSN — so it starts replication from that position, skipping
+# rows n3 already received via the n1 cascade.  This is the end-to-end proof
+# that maybe_advance_forwarded_origin() prevents duplicates.
+
+# Disable the cascade leg so that new rows on n2 can only reach n3 via the
+# direct subscription we are about to enable.  Without this, data arriving
+# via sub_n3_n1 would mask whether sub_n3_n2 is actually running.
+psql_or_bail(3, "SELECT spock.sub_disable('sub_n3_n1')");
+ok(wait_for_sub_status(3, 'sub_n3_n1', 'disabled', 30),
+   'Cascade leg sub_n3_n1 fully disabled before enabling direct subscription');
+
+psql_or_bail(3, "SELECT spock.sub_enable('sub_n3_n2')");
+ok(wait_for_sub_status(3, 'sub_n3_n2', 'replicating', 30),
+   'Enabled direct subscription sub_n3_n2 on n3');
+
+# No-duplicates check: if the apply worker started from 0/0 instead of the
+# forwarded LSN, it would re-send all 4 rows already on n3, making the count
+# jump to 8.  A stable count of 4 proves the correct start position was used.
+my $count_no_dup = scalar_query(3, "SELECT COUNT(*) FROM test_origin");
+is($count_no_dup, '4', 'No duplicates: existing rows not re-sent after sub_enable');
+
+# Insert a new row on n2 and poll for it to arrive on n3.  With sub_n3_n1
+# disabled, the only path is sub_n3_n2, so arrival proves that subscription
+# is live and replicating.
+psql_or_bail(2, "INSERT INTO test_origin (val) VALUES ('via_direct_sub')");
+my $direct_arrived = 0;
+for my $attempt (1..60) {
+    my $cnt = scalar_query(3,
+        "SELECT COUNT(*) FROM test_origin WHERE val = 'via_direct_sub'");
+    if (defined $cnt && $cnt >= 1) { $direct_arrived = 1; last; }
+    sleep 1;
+}
+ok($direct_arrived, 'sub_n3_n2 is replicating directly from n2 (cascade disabled)');
+
+my $count_after_direct = scalar_query(3, "SELECT COUNT(*) FROM test_origin");
+is($count_after_direct, '5', 'n3 has exactly 5 rows via direct sub_n3_n2');
+
+my $direct_row = scalar_query(3,
+    "SELECT COUNT(*) FROM test_origin WHERE val = 'via_direct_sub'");
+is($direct_row, '1', 'Direct row arrived exactly once on n3');
 
 # =============================================================================
 # CLEANUP


### PR DESCRIPTION
    Any node that subscribes with forward_origins='all' receives transactions
    originally sourced from other peer nodes, forwarded through its immediate
    provider. Each forwarded transaction's ORIGIN wire message carries the
    original peer's Spock node OID, not the immediate provider's. A peer's
    transactions can reach this node forwarded this way well before -- or
    without -- a direct subscription to that peer ever being created here. If
    one has been (or later is) created, tracking the forwarded progress on its
    origin lets it start from the right position whenever it is enabled,
    instead of a full resync. A replication origin only exists where a
    subscription entry does, so this requires resolving the peer's node id to
    the local subscription (if any) that names it as provider.

    handle_origin() resolves the peer node ID to a matching local subscription,
    excluding invalid origins and the direct provider, and stores the result in
    forwarded_local_origin_id for the duration of the transaction. This is
    resolved fresh for every ORIGIN message rather than cached across
    transactions: a cached RepOriginId can be silently reassigned to an
    unrelated origin once its owning subscription is dropped (RepOriginId is a
    small, actively recycled space -- replorigin_create() always reuses the
    lowest free id, and replorigin_advance() does no catalog validation against
    it), and Spock's resolution has no cheap way to revalidate a stale value
    later the way a simple name lookup would. Resolving within the same
    transaction that uses it bounds that exposure to a single transaction's
    replay. Multiple matching subscriptions are rejected as ambiguous.

    At commit, maybe_advance_forwarded_origin() advances the resolved origin using
    XactLastCommitEnd as this node's local position, rather than the provider's
    end_lsn from a different WAL space. The WAL-logged origin becomes the durable
    resume position. Because the advance is logged separately after the data
    commit, a crash may replay the latest transaction, preserving at-least-once
    semantics; delta-apply idempotency remains a separate follow-up.