### PR TITLE
Pull in v5.0.11 changes

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -365,6 +365,32 @@ given LSN before logical replication is allowed to proceed. The default
 spock.standby_slots_min_confirmed = -1
 ```
 
+### `spock.failover_slots_naptime`
+
+How long the `spock_failover_slots` worker sleeps between slot-synchronization
+passes, in milliseconds. A smaller value keeps the standby's synchronized slots
+closer to the primary — narrowing the window in which a promotion can find a
+stale slot — at the cost of more frequent sync passes. Default: `1000` (1s).
+Range: `1`–`3600000`. Settable at runtime with `SIGHUP` (reload).
+
+```ini
+spock.failover_slots_naptime = 1000
+```
+
+Used on PostgreSQL 15, 16, and 17 (when `sync_replication_slots` is not
+enabled) — the versions on which the built-in worker performs the sync.
+
+### `spock.failover_slots_feedback_naptime`
+
+Shorter retry interval, in milliseconds, used instead of
+`spock.failover_slots_naptime` while the standby has not yet received or fed
+back the WAL a slot needs. Default: `10000` (10s). Range: `1`–`3600000`.
+Settable at runtime with `SIGHUP` (reload).
+
+```ini
+spock.failover_slots_feedback_naptime = 10000
+```
+
 ### `spock.include_ddl_repset`
 
 `spock.include_ddl_repset` enables spock to automatically add tables to

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -192,8 +192,8 @@ steps below run after the 6.0.0 binaries are installed.
 ALTER EXTENSION spock UPDATE TO '6.0.0';
 ```
 
-PostgreSQL walks the version chain (5.0.8 to 5.0.9 to 5.0.10 to 6.0.0) and runs
-each step in order. The 5.0.10 to 6.0.0 step calls
+PostgreSQL walks the version chain (5.0.8 to 5.0.9 to 5.0.10 to 5.0.11 to
+6.0.0) and runs each step in order. The 5.0.11 to 6.0.0 step calls
 `spock.slot_enable_failover()` for you.
 
 `spock.slot_enable_failover()` behaves as follows:

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -86,6 +86,8 @@ addition to the base settings.
 | `spock.primary_dsn` | standby | `''` | Connection to the primary. Falls back to `primary_conninfo` when empty. |
 | `spock.pg_standby_slot_names` | primary | `''` | Physical slots that must confirm an LSN before logical replication advances. Optional. |
 | `spock.standby_slots_min_confirmed` | primary | `-1` | How many of those slots must confirm. `-1` means all. |
+| `spock.failover_slots_naptime` | standby | `1000` | Worker sleep between slot-sync passes, in ms (SIGHUP; range 1–3600000). |
+| `spock.failover_slots_feedback_naptime` | standby | `10000` | Shorter retry, in ms, while waiting for standby WAL feedback (SIGHUP; range 1–3600000). |
 
 `hot_standby_feedback = on` plus a physical slot named by `primary_slot_name` is
 the important pair. Without both, the primary can remove catalog rows a slot
@@ -161,6 +163,8 @@ on the standby and periodically copies slot state from the primary.
 | `spock.primary_dsn` | `''` | DSN to connect to primary (falls back to `primary_conninfo`) |
 | `spock.pg_standby_slot_names` | `''` | Physical slots that must confirm LSN before logical replication advances |
 | `spock.standby_slots_min_confirmed` | `-1` | How many slots from `pg_standby_slot_names` must confirm (`-1` = all) |
+| `spock.failover_slots_naptime` | `1000` | Worker sleep between slot-sync passes, in ms (SIGHUP; range 1–3600000) |
+| `spock.failover_slots_feedback_naptime` | `10000` | Shorter retry, in ms, while waiting for standby WAL feedback (SIGHUP; range 1–3600000) |
 
 ### Example (`postgresql.conf` on standby)
 

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -423,7 +423,7 @@ AutoDDL has been refactored and hardened:
 
 ### Bug fixes carried forward from the 5.0.x line
 
-These shipped in 5.0.6 – 5.0.10 and are included in 6.0.0:
+These shipped in 5.0.6 – 5.0.11 and are included in 6.0.0:
 
 * Handle upstream connection loss cleanly without replication-origin
   advance leak.  Previously a stale libpq socket fd produced an
@@ -458,7 +458,7 @@ These shipped in 5.0.6 – 5.0.10 and are included in 6.0.0:
 
 ### Upgrading
 
-The upgrade from 5.0.10 to 6.0.0 is a single `ALTER EXTENSION spock UPDATE`
+The upgrade from 5.0.11 to 6.0.0 is a single `ALTER EXTENSION spock UPDATE`
 once the binaries are swapped.  The upgrade:
 
 * drops the legacy `spock.progress` table and recreates it as a view,
@@ -473,6 +473,36 @@ once the binaries are swapped.  The upgrade:
   and it skips slots that are in use at the time. See
   [Logical Slot Failover](logical_slot_failover.md) for how to handle any
   skipped slots.
+
+## Spock 5.0.11
+
+### New Features
+* Add `spock.use_native_failover_slots` (default off, PGC_POSTMASTER). When
+  enabled, spock marks logical slots with the FAILOVER flag on PG17+, yields to
+  PostgreSQL's native slotsync worker on PG17 when `sync_replication_slots=on`,
+  and does not register spock's own failover-slot worker on PG18+. Off preserves
+  the existing worker-based behavior. Read on the subscriber node that creates
+  the logical replication slot; changing it requires a server restart. See
+  [Logical Slot Failover](logical_slot_failover.md) for setup steps and the
+  required post-promotion `synchronized_standby_slots` runbook.
+
+* Sync failover slots to the standby every 1s by default instead of a
+  hard-coded 60s, shrinking the window in which a promotion can find a stale
+  slot. The interval is now tunable via `spock.failover_slots_naptime` (and the
+  feedback-wait retry via `spock.failover_slots_feedback_naptime`), both
+  SIGHUP-settable in milliseconds
+
+* Never copy the `pgedge_ace` schema to a node joining via `add_node`. ACE
+  state is node-local, so its objects are now excluded from both the schema
+  copy and the data sync, even when an ACE table belongs to a replication set.
+
+### Bug Fixes
+
+* Fixed a bug where a transient provider connection loss could incorrectly
+  disable a subscription under SUB_DISABLE exception handling. A transaction
+  retransmitted after a reconnect is no longer misclassified as an apply
+  failure, so replication resumes normally instead of stopping.
+
 
 ## Spock 5.0.10
 

--- a/sql/spock--5.0.10--5.0.11.sql
+++ b/sql/spock--5.0.10--5.0.11.sql
@@ -1,0 +1,6 @@
+/* spock--5.0.10--5.0.11.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION spock UPDATE TO '5.0.11'" to load this file. \quit
+
+-- No schema changes in 5.0.11.

--- a/sql/spock--5.0.11--6.0.0.sql
+++ b/sql/spock--5.0.11--6.0.0.sql
@@ -1,4 +1,4 @@
-/* spock--5.0.10--6.0.0.sql */
+/* spock--5.0.11--6.0.0.sql */
 
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION spock UPDATE TO '6.0.0'" to load this file. \quit

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -60,8 +60,9 @@
 #include "libpq/auth.h"
 #include "libpq/libpq.h"
 
-#define WORKER_NAP_TIME 60000L
-#define WORKER_WAIT_FEEDBACK 10000L
+/* Defaults (milliseconds) for the tunable worker intervals below. */
+#define WORKER_NAP_TIME_DEFAULT 1000
+#define WORKER_WAIT_FEEDBACK_DEFAULT 10000
 
 /*
  * PostgreSQL 19 replaced ReplicationSlot.active_pid (an int pid, 0 when the
@@ -111,6 +112,16 @@ static char *spock_failover_slot_names;
 static char *spock_failover_slot_names_str = NULL;
 static List *spock_failover_slot_names_list = NIL;
 static bool spock_failover_slots_drop = true;
+
+/*
+ * How long the worker sleeps between slot-sync passes, and the shorter retry
+ * used while it is still waiting for the standby to receive/feedback WAL.
+ * Both are in milliseconds and settable at runtime (SIGHUP).  A smaller
+ * naptime narrows the window in which the standby's synced slots lag the
+ * primary, at the cost of more frequent sync passes.
+ */
+static int	spock_failover_slots_naptime = WORKER_NAP_TIME_DEFAULT;
+static int	spock_failover_slots_feedback_naptime = WORKER_WAIT_FEEDBACK_DEFAULT;
 
 void		spock_init_failover_slot(void);
 
@@ -1180,7 +1191,7 @@ synchronize_failover_slots(long sleep_time)
 							"cannot synchronize replication slot positions yet because feedback was not sent yet")));
 			was_lsn_safe = false;
 			PQfinish(conn);
-			return Min(sleep_time, WORKER_WAIT_FEEDBACK);
+			return Min(sleep_time, spock_failover_slots_feedback_naptime);
 		}
 		else if (WalRcv->latestWalEnd < lsn)
 		{
@@ -1193,7 +1204,7 @@ synchronize_failover_slots(long sleep_time)
 							(uint32) (WalRcv->latestWalEnd))));
 			was_lsn_safe = false;
 			PQfinish(conn);
-			return Min(sleep_time, WORKER_WAIT_FEEDBACK);
+			return Min(sleep_time, spock_failover_slots_feedback_naptime);
 		}
 
 		foreach(lc, slots)
@@ -1290,7 +1301,7 @@ spock_failover_slots_main(Datum main_arg)
 	while (true)
 	{
 		int			rc;
-		long		sleep_time = WORKER_NAP_TIME;
+		long		sleep_time = spock_failover_slots_naptime;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -1309,9 +1320,9 @@ spock_failover_slots_main(Datum main_arg)
 			&& !sync_replication_slots
 #endif
 			)
-			sleep_time = synchronize_failover_slots(WORKER_NAP_TIME);
+			sleep_time = synchronize_failover_slots(spock_failover_slots_naptime);
 		else
-			sleep_time = WORKER_NAP_TIME * 10;
+			sleep_time = (long) spock_failover_slots_naptime * 10;
 
 		rc =
 			WaitLatch(MyLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH,
@@ -1825,6 +1836,24 @@ spock_init_failover_slot(void)
 							   "if empty, uses the defaults to primary_conninfo",
 							   &spock_failover_slots_dsn, "", PGC_SIGHUP, GUC_SUPERUSER_ONLY, NULL, NULL,
 							   NULL);
+
+	DefineCustomIntVariable(
+		"spock.failover_slots_naptime",
+		"time the failover slot worker sleeps between slot synchronization passes",
+		"A smaller value keeps the standby's synchronized slots closer to the "
+		"primary, at the cost of more frequent sync passes.",
+		&spock_failover_slots_naptime, WORKER_NAP_TIME_DEFAULT,
+		1000, 3600000,
+		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
+
+	DefineCustomIntVariable(
+		"spock.failover_slots_feedback_naptime",
+		"shorter retry interval used while waiting for standby WAL feedback",
+		"The worker retries this often (instead of failover_slots_naptime) while "
+		"the standby has not yet received or fed back the WAL a slot needs.",
+		&spock_failover_slots_feedback_naptime, WORKER_WAIT_FEEDBACK_DEFAULT,
+		1000, 3600000,
+		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 
 	if (IsBinaryUpgrade)

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -1618,7 +1618,7 @@ attach_to_walsender(Port *port, int status)
 /*
  * spock_slot_enable_failover
  *
- * SQL-callable maintenance helper used by the 5.0.10 -> 6.0.0 upgrade.
+ * SQL-callable maintenance helper used by the 5.0.11 -> 6.0.0 upgrade.
  *
  * PostgreSQL 17+ can synchronize a logical replication slot to a physical
  * standby (natively on 18 via sync_replication_slots, and on 17 when that GUC

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -1843,7 +1843,7 @@ spock_init_failover_slot(void)
 		"A smaller value keeps the standby's synchronized slots closer to the "
 		"primary, at the cost of more frequent sync passes.",
 		&spock_failover_slots_naptime, WORKER_NAP_TIME_DEFAULT,
-		1000, 3600000,
+		1, 3600000,
 		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
@@ -1852,7 +1852,7 @@ spock_init_failover_slot(void)
 		"The worker retries this often (instead of failover_slots_naptime) while "
 		"the standby has not yet received or fed back the WAL a slot needs.",
 		&spock_failover_slots_feedback_naptime, WORKER_WAIT_FEEDBACK_DEFAULT,
-		1000, 3600000,
+		1, 3600000,
 		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -1838,22 +1838,22 @@ spock_init_failover_slot(void)
 							   NULL);
 
 	DefineCustomIntVariable(
-		"spock.failover_slots_naptime",
-		"time the failover slot worker sleeps between slot synchronization passes",
-		"A smaller value keeps the standby's synchronized slots closer to the "
-		"primary, at the cost of more frequent sync passes.",
-		&spock_failover_slots_naptime, WORKER_NAP_TIME_DEFAULT,
-		1, 3600000,
-		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
+							"spock.failover_slots_naptime",
+							"time the failover slot worker sleeps between slot synchronization passes",
+							"A smaller value keeps the standby's synchronized slots closer to the "
+							"primary, at the cost of more frequent sync passes.",
+							&spock_failover_slots_naptime, WORKER_NAP_TIME_DEFAULT,
+							1, 3600000,
+							PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 	DefineCustomIntVariable(
-		"spock.failover_slots_feedback_naptime",
-		"shorter retry interval used while waiting for standby WAL feedback",
-		"The worker retries this often (instead of failover_slots_naptime) while "
-		"the standby has not yet received or fed back the WAL a slot needs.",
-		&spock_failover_slots_feedback_naptime, WORKER_WAIT_FEEDBACK_DEFAULT,
-		1, 3600000,
-		PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
+							"spock.failover_slots_feedback_naptime",
+							"shorter retry interval used while waiting for standby WAL feedback",
+							"The worker retries this often (instead of failover_slots_naptime) while "
+							"the standby has not yet received or fed back the WAL a slot needs.",
+							&spock_failover_slots_feedback_naptime, WORKER_WAIT_FEEDBACK_DEFAULT,
+							1, 3600000,
+							PGC_SIGHUP, GUC_UNIT_MS, NULL, NULL, NULL);
 
 
 	if (IsBinaryUpgrade)

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -49,6 +49,7 @@ test: 022_apply_mem_context
 test: 024_node_id_collision
 test: 025_tiebreaker_equal_warning
 test: 027_reserved_object
+test: 028_failover_slots_naptime_guc
 test: 030_autoddl_repset_stickiness
 test: 032_lolor_largeobject_repset
 test: 033_zodan_lolor_add_node

--- a/tests/tap/t/009_zodan_add_remove_nodes.pl
+++ b/tests/tap/t/009_zodan_add_remove_nodes.pl
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 40;  # Fixed test count to match actual tests
+use Test::More tests => 43;  # Fixed test count to match actual tests
 use lib '.';
 use lib 't';
 use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe);
@@ -88,6 +88,22 @@ if ($data_on_n2 eq '3') {
 } else {
     fail("Data replication failed: expected 3 rows, got $data_on_n2");
 }
+
+# Step 2b: Create a pgedge_ace schema with a table on n1.
+#
+# spock excludes the pgedge_ace schema from the schema-sync pg_dump when a new
+# node joins: pgedge_ace is a built-in row in the spock.reserved_object catalog
+# with exclude_from_dump = true (see build_exclude_schema_string() in
+# src/spock_sync.c). Create the schema and table here, BEFORE n3 exists or
+# subscribes, so the only path by which n3 could acquire it is the add_node
+# schema copy. This isolates the exclusion logic from DDL replication.
+system_or_bail "$pg_bin/psql", '-p', $node_ports->[0], '-d', $dbname, '-c', "
+    CREATE SCHEMA pgedge_ace;
+    CREATE TABLE pgedge_ace.ace_meta (id INTEGER PRIMARY KEY, note TEXT);
+    INSERT INTO pgedge_ace.ace_meta VALUES (1, 'alpha'), (2, 'beta');
+";
+
+pass('Created pgedge_ace schema and table on n1');
 
 # Step 3: Create n3 database instance
 pass('Creating n3 database instance');
@@ -310,6 +326,27 @@ if ($table_exists_n3 eq 't') {
     }
 } else {
     fail('Test table does not exist on n3');
+}
+
+# Verify the pgedge_ace schema was NOT copied to n3 by add_node.
+# spock's schema-sync pg_dump excludes every reserved schema marked
+# exclude_from_dump (pgedge_ace among them), so neither the schema nor its
+# tables should exist on the joining node.
+my $ace_schema_on_n3 = `$pg_bin/psql -p $n3_port -d $dbname -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'pgedge_ace')"`;
+chomp($ace_schema_on_n3);
+$ace_schema_on_n3 =~ s/\s+//g;
+if ($ace_schema_on_n3 eq 'f') {
+    pass('pgedge_ace schema was not copied to n3 (excluded from add_node sync)');
+} else {
+    fail('pgedge_ace schema exists on n3 but should have been excluded from add_node sync');
+}
+
+# Explicit control: the public-schema table copied to n3 while pgedge_ace did
+# not. This confirms the exclusion is targeted, not a wholesale sync failure.
+if ($table_exists_n3 eq 't' && $ace_schema_on_n3 eq 'f') {
+    pass('Exclusion is targeted: public test table copied, pgedge_ace did not');
+} else {
+    fail("Unexpected sync result on n3: test_zodan_table exists=$table_exists_n3, pgedge_ace exists=$ace_schema_on_n3");
 }
 
 # Verify n3 has subscriptions that reference the default replication sets

--- a/tests/tap/t/026_failover_slots_naptime_guc.pl
+++ b/tests/tap/t/026_failover_slots_naptime_guc.pl
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query
+);
+
+# =============================================================================
+# Test: 026_failover_slots_naptime_guc.pl
+#
+# Verifies the tunable failover-slot worker interval GUCs:
+#   spock.failover_slots_naptime
+#   spock.failover_slots_feedback_naptime
+#
+# These control how often the spock_failover_slots worker syncs slot state to
+# a physical standby.  A smaller naptime narrows the window in which the
+# standby's synchronized slots lag the primary.
+#
+# The test checks defaults, unit, bounds, reloadability, that a new value
+# takes effect on reload, and that out-of-range values are rejected.
+# =============================================================================
+
+create_cluster(1);
+
+my $cfg  = get_test_config();
+my $bin  = $cfg->{pg_bin};
+my $host = $cfg->{host};
+my $port = $cfg->{node_ports}[0];
+my $db   = $cfg->{db_name};
+my $user = $cfg->{db_user};
+
+# Run SQL and return (exit_code, combined_output).  ON_ERROR_STOP makes psql
+# exit non-zero when the server rejects the statement.
+sub psql_try {
+    my ($sql) = @_;
+    my $out = `$bin/psql -X -h $host -p $port -d $db -U $user -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    return ($? >> 8, $out);
+}
+
+sub setting_of {
+    my ($name) = @_;
+    return scalar_query(1,
+        "SELECT setting FROM pg_settings WHERE name = '$name'");
+}
+
+# --------------------------------------------------------------------------
+# Defaults (pg_settings reports the value in the base unit, ms)
+# --------------------------------------------------------------------------
+is(setting_of('spock.failover_slots_naptime'), '1000',
+   'failover_slots_naptime default is 1000 ms');
+is(setting_of('spock.failover_slots_feedback_naptime'), '10000',
+   'failover_slots_feedback_naptime default is 10000 ms');
+
+# --------------------------------------------------------------------------
+# Unit, bounds, and context
+# --------------------------------------------------------------------------
+is(scalar_query(1, "SELECT unit FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   'ms', 'naptime unit is ms');
+is(scalar_query(1, "SELECT min_val||'/'||max_val FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   '1000/3600000', 'naptime bounds are 1000..3600000 ms');
+is(scalar_query(1, "SELECT context FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
+   'sighup', 'naptime is reloadable (sighup), no restart needed');
+
+# --------------------------------------------------------------------------
+# A new value takes effect on reload
+# --------------------------------------------------------------------------
+my ($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '5s'");
+is($rc, 0, "ALTER SYSTEM accepts '5s'") or diag($out);
+psql_try("SELECT pg_reload_conf()");
+
+# Reload is asynchronous; poll briefly for the change to land.
+my $val = '';
+for (1 .. 20) {
+    $val = setting_of('spock.failover_slots_naptime');
+    last if $val eq '5000';
+    select(undef, undef, undef, 0.25);
+}
+is($val, '5000', "naptime becomes 5000 ms after reload");
+
+# --------------------------------------------------------------------------
+# Out-of-range values are rejected
+# --------------------------------------------------------------------------
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '10ms'");
+isnt($rc, 0, "ALTER SYSTEM rejects 10ms (below the 1s minimum)");
+like($out, qr/outside the valid range|invalid value/i,
+     "rejection message mentions the valid range");
+
+# Restore the default so the node is clean for teardown.
+psql_try("ALTER SYSTEM RESET spock.failover_slots_naptime");
+psql_try("SELECT pg_reload_conf()");
+
+destroy_cluster();
+done_testing();

--- a/tests/tap/t/028_failover_slots_naptime_guc.pl
+++ b/tests/tap/t/028_failover_slots_naptime_guc.pl
@@ -65,6 +65,16 @@ is(scalar_query(1, "SELECT min_val||'/'||max_val FROM pg_settings WHERE name='sp
 is(scalar_query(1, "SELECT context FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
    'sighup', 'naptime is reloadable (sighup), no restart needed');
 
+# The two GUCs are defined by near-identical DefineCustomIntVariable() calls,
+# so assert the second one's properties independently rather than assuming it
+# inherited the first's.  This also pins the feedback GUC's 1 ms floor.
+is(scalar_query(1, "SELECT unit FROM pg_settings WHERE name='spock.failover_slots_feedback_naptime'"),
+   'ms', 'feedback_naptime unit is ms');
+is(scalar_query(1, "SELECT min_val||'/'||max_val FROM pg_settings WHERE name='spock.failover_slots_feedback_naptime'"),
+   '1/3600000', 'feedback_naptime bounds are 1..3600000 ms');
+is(scalar_query(1, "SELECT context FROM pg_settings WHERE name='spock.failover_slots_feedback_naptime'"),
+   'sighup', 'feedback_naptime is reloadable (sighup), no restart needed');
+
 # --------------------------------------------------------------------------
 # A new value takes effect on reload
 # --------------------------------------------------------------------------
@@ -94,6 +104,15 @@ is($rc, 0, "ALTER SYSTEM accepts a subsecond value ('500ms')") or diag($out);
 isnt($rc, 0, "ALTER SYSTEM rejects '2h' (above the 3600000 ms maximum)");
 like($out, qr/outside the valid range|invalid value/i,
      "rejection message mentions the valid range");
+
+# Lower bound: the floor is 1 ms, so 0 must still be rejected.  This is the
+# boundary the subsecond change moved (it was 1000 ms), so pin it explicitly
+# -- 0 would otherwise read as a plausible "disable the nap" value.
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '0ms'");
+isnt($rc, 0, "ALTER SYSTEM rejects '0ms' (below the 1 ms minimum)");
+
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_feedback_naptime = '0ms'");
+isnt($rc, 0, "ALTER SYSTEM rejects '0ms' for feedback_naptime (below the 1 ms minimum)");
 
 # Restore the default so the node is clean for teardown.
 psql_try("ALTER SYSTEM RESET spock.failover_slots_naptime");

--- a/tests/tap/t/028_failover_slots_naptime_guc.pl
+++ b/tests/tap/t/028_failover_slots_naptime_guc.pl
@@ -9,7 +9,7 @@ use SpockTest qw(
 );
 
 # =============================================================================
-# Test: 026_failover_slots_naptime_guc.pl
+# Test: 028_failover_slots_naptime_guc.pl
 #
 # Verifies the tunable failover-slot worker interval GUCs:
 #   spock.failover_slots_naptime
@@ -17,10 +17,11 @@ use SpockTest qw(
 #
 # These control how often the spock_failover_slots worker syncs slot state to
 # a physical standby.  A smaller naptime narrows the window in which the
-# standby's synchronized slots lag the primary.
+# standby's synchronized slots lag the primary; subsecond values are allowed.
 #
 # The test checks defaults, unit, bounds, reloadability, that a new value
-# takes effect on reload, and that out-of-range values are rejected.
+# takes effect on reload, that subsecond values are accepted, and that
+# out-of-range values are rejected.
 # =============================================================================
 
 create_cluster(1);
@@ -60,7 +61,7 @@ is(setting_of('spock.failover_slots_feedback_naptime'), '10000',
 is(scalar_query(1, "SELECT unit FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
    'ms', 'naptime unit is ms');
 is(scalar_query(1, "SELECT min_val||'/'||max_val FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
-   '1000/3600000', 'naptime bounds are 1000..3600000 ms');
+   '1/3600000', 'naptime bounds are 1..3600000 ms');
 is(scalar_query(1, "SELECT context FROM pg_settings WHERE name='spock.failover_slots_naptime'"),
    'sighup', 'naptime is reloadable (sighup), no restart needed');
 
@@ -81,10 +82,16 @@ for (1 .. 20) {
 is($val, '5000', "naptime becomes 5000 ms after reload");
 
 # --------------------------------------------------------------------------
+# Subsecond values are accepted (the minimum is 1 ms, not 1 s)
+# --------------------------------------------------------------------------
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '500ms'");
+is($rc, 0, "ALTER SYSTEM accepts a subsecond value ('500ms')") or diag($out);
+
+# --------------------------------------------------------------------------
 # Out-of-range values are rejected
 # --------------------------------------------------------------------------
-($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '10ms'");
-isnt($rc, 0, "ALTER SYSTEM rejects 10ms (below the 1s minimum)");
+($rc, $out) = psql_try("ALTER SYSTEM SET spock.failover_slots_naptime = '2h'");
+isnt($rc, 0, "ALTER SYSTEM rejects '2h' (above the 3600000 ms maximum)");
 like($out, qr/outside the valid range|invalid value/i,
      "rejection message mentions the valid range");
 


### PR DESCRIPTION
Branch v5_STABLE has 5.0.11, but main's migration assumed nodes upgrade
from 5.0.10. This fixes the upgrade path and pulls in the 5.0.11 changes
that are still applicable to 6.0.

### Upgrade path

- Rename `sql/spock--5.0.10--6.0.0.sql` → `sql/spock--5.0.11--6.0.0.sql`.
  5.0.11 had no schema changes, so the migration body is unchanged.
- Add the no-op `sql/spock--5.0.10--5.0.11.sql` stub (from v5_STABLE) so a
  node still on 5.0.10 walks 5.0.10 → 5.0.11 → 6.0.0.
- Add the 5.0.11 release-notes section; update version-chain references in
  `logical_slot_failover.md` and the `slot_enable_failover()` comment.

The Makefile globs `sql/*--*.sql`, so no build changes are needed.

### Ported from v5_STABLE

- **`failover_slots_naptime` / `failover_slots_feedback_naptime` GUCs**
  (cherry-picks of 550adf4 + e6e8e53, with `-x` provenance). Replaces the
  hardcoded 60s worker nap; default 1s, range 1–3600000 ms, SIGHUP. These
  tune the `spock_failover_slots` worker, which main registers on PG15/16/17
  (on 17 only while native `sync_replication_slots` is off) — so this still
  matters on main. Follow-up commit adapts them: test renumbered 026 → 028
  (026 is taken), assertions matched to main's 1 ms floor, test scheduled,
  GUC docs added.
- **pgedge_ace `add_node` exclusion test** (from 9857942). The code half is
  already in main via the `reserved_object` catalog; only coverage was
  missing.

### Evaluated, not ported

| Change | Why |
|---|---|
| SUB_DISABLE reconnect fix (f16a004) | Already in main, code + test 105 |
| pgedge_ace exclusion code (9857942) | Already covered by `reserved_object` |
| `use_native_failover_slots` GUC (54d2a5f) | 5.x-only opt-in; main already defaults to native on PG17+/18+ |