### PR TITLE
Introduce patchsets

### DIFF
--- a/include/spock.h
+++ b/include/spock.h
@@ -27,6 +27,20 @@
 #define SPOCK_VERSION "6.0.0"
 #define SPOCK_VERSION_NUM 60000
 
+/*
+ * Core patch-set generation this Spock build is designed for. Bump in lockstep
+ * with the pgNN-000-spock-patchset.diff patches. 0 is reserved to mean the
+ * server's patch set predates generation tracking (baseline).
+ *
+ * NOT enforced yet: _PG_init() currently only detects and logs the server's
+ * generation. A future release may compare against this to gate or limit
+ * patch-dependent features.
+ */
+#define SPOCK_CORE_PATCHSET_TARGET 1
+
+/* Detected core patch-set generation; 0 = baseline/untracked. Set in _PG_init(). */
+extern int spock_detected_patchset;
+
 #define EXTENSION_NAME "spock"
 
 #define REPLICATION_ORIGIN_ALL	"all"

--- a/include/spock.h
+++ b/include/spock.h
@@ -16,6 +16,7 @@
 #include "postmaster/bgworker.h"
 #include "utils/array.h"
 #include "access/xlogdefs.h"
+#include "datatype/timestamp.h"
 #include "parser/analyze.h"
 #include "executor/executor.h"
 
@@ -40,6 +41,35 @@
 
 /* Detected core patch-set generation; 0 = baseline/untracked. Set in _PG_init(). */
 extern int spock_detected_patchset;
+
+/*
+ * spock-lite groundwork. These point at patch-provided core symbols, resolved
+ * by name via dlsym() at _PG_init() so that spock.so can LOAD even on unpatched
+ * PostgreSQL (a hard link-time reference to a missing symbol would make the
+ * library fail to dlopen before any spock code runs). They are NULL when the
+ * server is unpatched.
+ *
+ *   spock_remote_ts_ptr - &remoteTransactionStopTimestamp (logical commit clock)
+ *   spock_subxact_setts - SubTransactionIdSetCommitTsData (delta apply)
+ *   spock_hlc_available - true when the logical commit clock support is present
+ */
+extern bool spock_hlc_available;
+extern TimestampTz *spock_remote_ts_ptr;
+
+/*
+ * RepOriginId was renamed to ReplOriginId in PG19 (access/xlogdefs.h); use the
+ * name that exists for the target version so this header compiles everywhere.
+ */
+#if PG_VERSION_NUM >= 190000
+typedef void (*SubTransactionSetCommitTs_fn) (TransactionId xid,
+											  TimestampTz ts,
+											  ReplOriginId nodeid);
+#else
+typedef void (*SubTransactionSetCommitTs_fn) (TransactionId xid,
+											  TimestampTz ts,
+											  RepOriginId nodeid);
+#endif
+extern SubTransactionSetCommitTs_fn spock_subxact_setts;
 
 #define EXTENSION_NAME "spock"
 

--- a/patches/15/pg15-000-spock-patchset.diff
+++ b/patches/15/pg15-000-spock-patchset.diff
@@ -1,0 +1,14 @@
+diff --git a/src/backend/utils/init/globals.c b/src/backend/utils/init/globals.c
+index cc61937eef7..3ddb5be6e48 100644
+--- a/src/backend/utils/init/globals.c
++++ b/src/backend/utils/init/globals.c
+@@ -42,6 +42,9 @@ volatile uint32 InterruptHoldoffCount = 0;
+ volatile uint32 QueryCancelHoldoffCount = 0;
+ volatile uint32 CritSectionCount = 0;
+ 
++/* Spock core patch-set generation. Bumped when the patch set changes. */
++int			SpockCorePatchsetVersion = 1;
++
+ int			MyProcPid;
+ pg_time_t	MyStartTime;
+ TimestampTz MyStartTimestamp;

--- a/patches/16/pg16-000-spock-patchset.diff
+++ b/patches/16/pg16-000-spock-patchset.diff
@@ -1,0 +1,14 @@
+diff --git a/src/backend/utils/init/globals.c b/src/backend/utils/init/globals.c
+index cc61937eef7..3ddb5be6e48 100644
+--- a/src/backend/utils/init/globals.c
++++ b/src/backend/utils/init/globals.c
+@@ -42,6 +42,9 @@ volatile uint32 InterruptHoldoffCount = 0;
+ volatile uint32 QueryCancelHoldoffCount = 0;
+ volatile uint32 CritSectionCount = 0;
+ 
++/* Spock core patch-set generation. Bumped when the patch set changes. */
++int			SpockCorePatchsetVersion = 1;
++
+ int			MyProcPid;
+ pg_time_t	MyStartTime;
+ TimestampTz MyStartTimestamp;

--- a/patches/17/pg17-000-spock-patchset.diff
+++ b/patches/17/pg17-000-spock-patchset.diff
@@ -1,0 +1,14 @@
+diff --git a/src/backend/utils/init/globals.c b/src/backend/utils/init/globals.c
+index cc61937eef7..3ddb5be6e48 100644
+--- a/src/backend/utils/init/globals.c
++++ b/src/backend/utils/init/globals.c
+@@ -42,6 +42,9 @@ volatile uint32 InterruptHoldoffCount = 0;
+ volatile uint32 QueryCancelHoldoffCount = 0;
+ volatile uint32 CritSectionCount = 0;
+ 
++/* Spock core patch-set generation. Bumped when the patch set changes. */
++int			SpockCorePatchsetVersion = 1;
++
+ int			MyProcPid;
+ pg_time_t	MyStartTime;
+ TimestampTz MyStartTimestamp;

--- a/patches/18/pg18-000-spock-patchset.diff
+++ b/patches/18/pg18-000-spock-patchset.diff
@@ -1,0 +1,14 @@
+diff --git a/src/backend/utils/init/globals.c b/src/backend/utils/init/globals.c
+index d31cb45a058..4f8c9fd5083 100644
+--- a/src/backend/utils/init/globals.c
++++ b/src/backend/utils/init/globals.c
+@@ -44,6 +44,9 @@ volatile uint32 InterruptHoldoffCount = 0;
+ volatile uint32 QueryCancelHoldoffCount = 0;
+ volatile uint32 CritSectionCount = 0;
+ 
++/* Spock core patch-set generation. Bumped when the patch set changes. */
++int			SpockCorePatchsetVersion = 1;
++
+ int			MyProcPid;
+ pg_time_t	MyStartTime;
+ TimestampTz MyStartTimestamp;

--- a/patches/19/pg19-000-spock-patchset.diff
+++ b/patches/19/pg19-000-spock-patchset.diff
@@ -1,0 +1,14 @@
+diff --git a/src/backend/utils/init/globals.c b/src/backend/utils/init/globals.c
+index cc61937eef7..3ddb5be6e48 100644
+--- a/src/backend/utils/init/globals.c
++++ b/src/backend/utils/init/globals.c
+@@ -42,6 +42,9 @@ volatile uint32 InterruptHoldoffCount = 0;
+ volatile uint32 QueryCancelHoldoffCount = 0;
+ volatile uint32 CritSectionCount = 0;
+ 
++/* Spock core patch-set generation. Bumped when the patch set changes. */
++int			SpockCorePatchsetVersion = 1;
++
+ int			MyProcPid;
+ pg_time_t	MyStartTime;
+ TimestampTz MyStartTimestamp;

--- a/sql/spock--5.0.11--6.0.0.sql
+++ b/sql/spock--5.0.11--6.0.0.sql
@@ -324,6 +324,10 @@ RETURNS boolean
 AS 'MODULE_PATHNAME', 'spock_alter_subscription_options'
 LANGUAGE C STRICT VOLATILE;
 
+CREATE FUNCTION spock.core_patchset() RETURNS integer
+AS 'MODULE_PATHNAME', 'spock_core_patchset'
+LANGUAGE c;
+
 -- ----
 -- Enable the "failover" flag on spock's existing logical replication slots.
 --

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -636,6 +636,10 @@ LANGUAGE c AS 'MODULE_PATHNAME';
 CREATE FUNCTION spock_version_num() RETURNS integer
 LANGUAGE c AS 'MODULE_PATHNAME';
 
+CREATE FUNCTION spock.core_patchset() RETURNS integer
+AS 'MODULE_PATHNAME', 'spock_core_patchset'
+LANGUAGE c;
+
 CREATE FUNCTION spock_max_proto_version() RETURNS integer
 LANGUAGE c AS 'MODULE_PATHNAME';
 

--- a/src/spock.c
+++ b/src/spock.c
@@ -52,6 +52,8 @@
 
 #include "pgstat.h"
 
+#include <dlfcn.h>
+
 #include "spock_apply.h"
 #if PG_VERSION_NUM >= 180000
 #include "spock_conflict_stat.h"
@@ -77,6 +79,8 @@ PG_MODULE_MAGIC_EXT(
 #else
 PG_MODULE_MAGIC;
 #endif
+
+int			spock_detected_patchset = 0;	/* detected; 0 = unpatched/absent */
 
 static const struct config_enum_entry SpockConflictResolvers[] = {
 	/*
@@ -1007,6 +1011,29 @@ _PG_init(void)
 
 	if (!process_shared_preload_libraries_in_progress)
 		elog(ERROR, "spock is not in shared_preload_libraries");
+
+	/*
+	 * Detect the core patch set. The patched server exports
+	 * SpockCorePatchsetVersion; we read it by name so a server whose patch set
+	 * predates this marker (or is otherwise absent) does not prevent spock.so
+	 * from loading. For now this is informational only: we record and log the
+	 * detected generation and continue. A future release may use it to gate or
+	 * limit patch-dependent features (HLC, delta apply).
+	 */
+	{
+		int		   *core_patchset = (int *) dlsym(RTLD_DEFAULT,
+												  "SpockCorePatchsetVersion");
+
+		if (core_patchset != NULL)
+			spock_detected_patchset = *core_patchset;
+
+		if (spock_detected_patchset > 0)
+			elog(LOG, "spock: PostgreSQL core patch set generation %d detected",
+				 spock_detected_patchset);
+		else
+			elog(LOG, "spock: PostgreSQL core patch set predates generation "
+				 "tracking; treating as baseline (generation 0)");
+	}
 
 	DefineCustomEnumVariable("spock.conflict_resolution",
 							 gettext_noop("Sets method used for conflict resolution for resolvable conflicts."),

--- a/src/spock.c
+++ b/src/spock.c
@@ -82,6 +82,11 @@ PG_MODULE_MAGIC;
 
 int			spock_detected_patchset = 0;	/* detected; 0 = unpatched/absent */
 
+/* Unpatched Postgres groundwork: resolved via dlsym() in _PG_init(). See spock.h. */
+bool		spock_hlc_available = false;
+TimestampTz *spock_remote_ts_ptr = NULL;
+SubTransactionSetCommitTs_fn spock_subxact_setts = NULL;
+
 static const struct config_enum_entry SpockConflictResolvers[] = {
 	/*
 	 * Disabled until we can clearly define their desired behavior. Jan Wieck
@@ -1033,6 +1038,47 @@ _PG_init(void)
 		else
 			elog(LOG, "spock: PostgreSQL core patch set predates generation "
 				 "tracking; treating as baseline (generation 0)");
+	}
+
+	/*
+	 * Resolve the patch-provided core symbols by name. Because these lookups
+	 * are the only way spock references the symbols (the by-name uses in the
+	 * apply path were removed), spock.so has no unresolved link-time reference
+	 * to them and therefore loads even on unpatched PostgreSQL.
+	 *
+	 * For now spock does not actually run in a degraded unpatched mode. If the
+	 * logical commit clock (HLC) support is absent, we refuse to start with a
+	 * clear message instead of the cryptic dynamic-linker "undefined symbol"
+	 * error the old hard references produced. Running on unpatched PostgreSQL
+	 * with reduced functionality is future work.
+	 */
+	spock_remote_ts_ptr = (TimestampTz *)
+		dlsym(RTLD_DEFAULT, "remoteTransactionStopTimestamp");
+	spock_subxact_setts = (SubTransactionSetCommitTs_fn)
+		dlsym(RTLD_DEFAULT, "SubTransactionIdSetCommitTsData");
+	spock_hlc_available = (spock_remote_ts_ptr != NULL);
+
+	/*
+	 * Both symbols come from the Spock core patch set and must be present
+	 * together. A partially patched server (e.g. the logical commit clock but
+	 * not the delta-apply commit-timestamp support) would otherwise pass init
+	 * and later let delta apply silently skip its per-subtransaction
+	 * commit-timestamp override, corrupting conflict-resolution metadata.
+	 * Refuse startup if either required symbol is missing.
+	 */
+	if (spock_remote_ts_ptr == NULL || spock_subxact_setts == NULL)
+	{
+		const char *missing = (spock_remote_ts_ptr == NULL)
+			? "remoteTransactionStopTimestamp (logical commit clock)"
+			: "SubTransactionIdSetCommitTsData (delta apply commit timestamp)";
+
+		ereport(FATAL,
+				(errmsg("spock cannot currently run against unpatched PostgreSQL"),
+				 errdetail("Required Spock core patch-set symbol \"%s\" is not present.",
+						   missing),
+				 errhint("Use a PostgreSQL server built with the complete Spock "
+						 "patch set. Running on unpatched PostgreSQL is not yet "
+						 "supported.")));
 	}
 
 	DefineCustomEnumVariable("spock.conflict_resolution",

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -976,15 +976,22 @@ handle_commit(StringInfo s)
 			Assert(XactReadOnly);
 		}
 
-		/* Have the commit code adjust our logical clock if needed */
-		remoteTransactionStopTimestamp = commit_time;
+		/*
+		 * Have the commit code adjust our logical clock if needed. Written
+		 * through the dlsym-resolved pointer so spock.so has no hard link-time
+		 * reference to the patch-provided symbol (see spock.h). NULL only on
+		 * unpatched PostgreSQL, where _PG_init() has already refused to start.
+		 */
+		if (spock_remote_ts_ptr != NULL)
+			*spock_remote_ts_ptr = commit_time;
 
 		CommitTransactionCommand();
 
 		if (WalSndCtl->sync_standbys_status & SYNC_STANDBY_DEFINED)
 			append_feedback_position(XactLastCommitEnd, end_lsn);
 
-		remoteTransactionStopTimestamp = 0;
+		if (spock_remote_ts_ptr != NULL)
+			*spock_remote_ts_ptr = 0;
 
 		MemoryContextSwitchTo(TopMemoryContext);
 

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -773,8 +773,15 @@ spock_handle_conflict_and_apply(SpockRelation *rel, EState *estate,
 		if (is_delta_apply)
 		{
 			CurrentResourceOwner = save_resowner;
-			SubTransactionIdSetCommitTsData(GetCurrentTransactionId(),
-											local_ts, local_origin);
+			/*
+			 * Called through the dlsym-resolved pointer so spock.so has no hard
+			 * link-time reference to the patch-provided symbol (see spock.h).
+			 * _PG_init() refuses to start unless this symbol resolved, so the
+			 * pointer is non-NULL by invariant here.
+			 */
+			Assert(spock_subxact_setts != NULL);
+			spock_subxact_setts(GetCurrentTransactionId(),
+								local_ts, local_origin);
 			ReleaseCurrentSubTransaction();
 		}
 

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -169,6 +169,7 @@ PG_FUNCTION_INFO_V1(spock_table_data_filtered);
 /* Information */
 PG_FUNCTION_INFO_V1(spock_version);
 PG_FUNCTION_INFO_V1(spock_version_num);
+PG_FUNCTION_INFO_V1(spock_core_patchset);
 PG_FUNCTION_INFO_V1(spock_min_proto_version);
 PG_FUNCTION_INFO_V1(spock_max_proto_version);
 
@@ -3408,6 +3409,12 @@ Datum
 spock_version_num(PG_FUNCTION_ARGS)
 {
 	PG_RETURN_INT32(SPOCK_VERSION_NUM);
+}
+
+Datum
+spock_core_patchset(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_INT32(spock_detected_patchset);
 }
 
 Datum

--- a/tests/tap/t/106_core_patchset.pl
+++ b/tests/tap/t/106_core_patchset.pl
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster scalar_query);
+
+# =============================================================================
+# Test: 106_core_patchset.pl - Core patch-set generation handshake
+# =============================================================================
+# Verifies that a patched PostgreSQL server exposes a patch-set generation and
+# that spock detects and reports it via spock.core_patchset(). This is the
+# positive path: a correctly patched build starts and reports a non-zero
+# generation matching what this spock build requires.
+# =============================================================================
+
+create_cluster(1, 'Create 1-node cluster for core patch-set handshake test');
+
+# The recorded generation must be non-zero (server is patched and spock
+# detected the symbol). Update the expected value when the generation bumps.
+my $patchset = scalar_query(1, "SELECT spock.core_patchset()");
+ok($patchset > 0, "core patch set generation is detected (non-zero), got $patchset");
+is($patchset, 1, "core patch set generation matches SPOCK_CORE_PATCHSET_TARGET (1)");
+
+destroy_cluster();
+
+done_testing();


### PR DESCRIPTION
Introduce patchset version numbers. Over time we can start enforcing this in the extension as appropriate. For now avoid forcing users to update Postgres.

In addition, we lay the groundwork for spock lite mode.

By checking for the existence of symbols, Spock can determine what the situation with the Postgres it is using is:

1. It contains a patchset version number.

2. It does not contain a patchset version number, but from checking symbols we can see it is (pre-patchset numbered) pgedge-patched Postgres

3. It is unpatched Postgres. Instead of failing at library load time, now fail at startup with a more descriptive message. In the future, we can instead output a message and operate in a mode with degraded functionality.

Original idea came from this PR: https://github.com/pgEdge/spock/pull/421

