### PR TITLE
Document logical slot failover under Patroni on PostgreSQL 17+

### DIFF
--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -8,8 +8,8 @@ standby so that replication can resume without data loss after a failover.
 
 When a primary server fails and a physical standby is promoted, any active
 logical subscribers must be able to continue replicating from the new primary.
-This requires the logical replication slots — which track each subscriber's
-replication position — to be present and up to date on the standby before the
+This requires the logical replication slots, which track each subscriber's
+replication position, to be present and up to date on the standby before the
 failover occurs.
 
 Without slot synchronization, a failover would require manual slot recreation
@@ -23,11 +23,11 @@ Starting with Spock 5, PostgreSQL's native slot-failover path (PG17+) is
 every PostgreSQL version: its own `spock_failover_slots` worker runs and no
 slot carries the `FAILOVER` flag.
 
-This GUC is `PGC_POSTMASTER` — it can only be set in `postgresql.conf` (or
+This GUC is `PGC_POSTMASTER`. It can only be set in `postgresql.conf` (or
 `ALTER SYSTEM`) and requires a **server restart** to take effect; it cannot
 be changed with `SET` or reloaded with `SIGHUP`.
 
-The flag is read on the **subscriber** — the node that issues
+The flag is read on the **subscriber**, the node that issues
 `CREATE_REPLICATION_SLOT` against the provider to create its logical slot.
 Set it there, not on the provider.
 
@@ -121,7 +121,7 @@ string to point to the new primary. Replication resumes from the last
 synchronized LSN with no data loss and no slot recreation required.
 
 **Important:** if `synchronized_standby_slots` was configured (step 3 above),
-you must adjust it on the promoted node before replication will resume — see
+you must adjust it on the promoted node before replication will resume. See
 [Runbook: clear `synchronized_standby_slots` after promotion](#runbook-clear-synchronized_standby_slots-after-promotion)
 below.
 
@@ -130,7 +130,7 @@ below.
 When `synchronized_standby_slots` is configured (Setup step 3 above), the
 provider's walsenders hold back logical decoding until every physical slot
 named in that list has confirmed flush of the relevant LSN. This is what
-keeps a physical standby from falling behind a logical subscriber — but it
+keeps a physical standby from falling behind a logical subscriber, but it
 has a sharp edge on failover.
 
 When a standby is promoted, `synchronized_standby_slots` on the **promoted**
@@ -154,7 +154,7 @@ SELECT pg_drop_replication_slot('spock_standby_slot');
 
 If the new topology has its own physical standby(s), set
 `synchronized_standby_slots` to the physical slot(s) for *that* standby
-instead of clearing it to `''` — the point is to remove references to
+instead of clearing it to `''`. The point is to remove references to
 orphaned slots, not to leave the setting pointing at slots nothing will ever
 consume.
 
@@ -162,6 +162,147 @@ Add this step to your failover runbook alongside the subscriber DSN update
 described above; skipping it is the most common cause of "failover
 succeeded but replication stopped" reports when native failover slots are
 in use.
+
+## Running Under Patroni (PostgreSQL 17+)
+
+Patroni manages the physical replication slots for its members itself. When
+`postgresql.use_slots: true` (the default), Patroni creates a slot per member
+and drops or recreates those slots as the topology changes, including on a
+graceful switchover. That behaviour is fine for the physical stream, but it
+is also what makes Spock's built-in `spock_failover_slots` worker unreliable
+under Patroni: when Patroni recreates a slot on switchover it resets the
+`catalog_xmin` that `hot_standby_feedback` had pinned, and a busy primary
+running vacuum can then remove catalog rows the promoted node's copied slot
+still needs. The slot comes back invalidated (`invalidation_reason =
+rows_removed`) and the subscriber has to re-sync from scratch.
+
+The fix is to stop copying logical slots by hand and let PostgreSQL do it.
+On PG17+ use the native failover-slots path (`spock.use_native_failover_slots
+= on` plus `sync_replication_slots = on`) so the slot carries the `FAILOVER`
+flag and PostgreSQL's own slotsync worker keeps it current on every member.
+This is the same mechanism described under
+[Setup: PostgreSQL 17 and 18+](#setup-postgresql-17-and-18-native-requires-spockuse_native_failover_slots--on);
+the rest of this section is only about where those settings go in a Patroni
+configuration and the one sharp edge switchover introduces.
+
+Use Patroni 4.x, the line these instructions are written and tested against.
+
+### Required settings
+
+| Setting | Value | Where | Restart? | Why |
+|---|---|---|---|---|
+| `spock.use_native_failover_slots` | `on` | dynamic config, **every member** | **Yes** (`PGC_POSTMASTER`) | Creates each logical slot with the `FAILOVER` flag |
+| `sync_replication_slots` | `on` | dynamic config | No (reload) | PostgreSQL slotsync worker copies flagged slots to standbys |
+| `hot_standby_feedback` | `on` | dynamic config | No (reload) | Pins `catalog_xmin` so vacuum can't remove rows a slot needs |
+| `wal_level` | `logical` | dynamic config | Yes | Required for logical decoding |
+| `postgresql.use_slots` | `true` | Patroni config | n/a | Patroni manages the physical member slots (leave on) |
+| `max_replication_slots` / `max_wal_senders` | sized to cluster | dynamic config | Yes | Enough slots/senders for members plus Spock logical slots |
+| `synchronized_standby_slots` | standby member slot name(s) | dynamic config | No (reload) | Optional but recommended; holds the leader back until the standby confirms. See the [sharp edge](#the-switchover-sharp-edge-synchronized_standby_slots) below |
+
+"Dynamic config" means Patroni's DCS-backed configuration:
+`bootstrap.dcs.postgresql.parameters` when you first bootstrap the cluster,
+and `patronictl edit-config` for a running one. The next subsection shows the
+full bootstrap block.
+
+### Where the settings go (bootstrap)
+
+Cluster-wide PostgreSQL parameters belong in Patroni's dynamic configuration
+(`bootstrap.dcs.postgresql.parameters` at bootstrap, `patronictl edit-config`
+afterwards) so every member, current and future leader, agrees on them.
+Set them there, not in a per-node `postgresql.conf`.
+
+```yaml
+bootstrap:
+  dcs:
+    postgresql:
+      use_slots: true
+      parameters:
+        wal_level: logical
+        hot_standby_feedback: "on"          # required; pins catalog_xmin
+        spock.use_native_failover_slots: "on"   # PGC_POSTMASTER, see restart note
+        sync_replication_slots: "on"        # PG slotsync worker copies FAILOVER slots
+        max_replication_slots: 10
+        max_wal_senders: 10
+```
+
+`spock.use_native_failover_slots` is `PGC_POSTMASTER`. Patroni cannot reload
+it into a running server; after adding it, Patroni flags every member as
+**pending restart**, and you must restart them (`patronictl restart <scope>`)
+before any slot is created with the `FAILOVER` flag. Set it uniformly across
+the whole cluster. A mixed setting means slots created on one leader behave
+differently after a switchover to another.
+
+Do **not** also declare the Spock logical slots as Patroni *permanent logical
+slots* (the `slots:` block in dynamic config). Permanent logical slots are
+copied by Patroni's own mechanism, which is exactly the hand-copying the
+native path replaces; declaring them there reintroduces the invalidation
+race. Let Patroni manage only the physical member slots and leave the logical
+slots to PostgreSQL's slotsync worker.
+
+### The switchover sharp edge: `synchronized_standby_slots`
+
+`synchronized_standby_slots` (Setup step 3) must name the physical slot(s) of
+the standby member(s) so the leader's walsenders hold back until the standby
+has confirmed the LSN. Under Patroni the member slots are named after the
+members, so on a two-member cluster with leader `n2` and standby `r1` the
+leader needs:
+
+```
+synchronized_standby_slots = 'r1'
+```
+
+The edge is that this value is *role-specific* but Patroni's dynamic config is
+*cluster-wide*. If you hardcode `'r1'` and then switch over so `r1` becomes
+leader, the new leader is left pointing at a slot for itself that nothing
+consumes, so its walsenders block forever and logical replication freezes. This
+is the same failure the
+[post-promotion runbook](#runbook-clear-synchronized_standby_slots-after-promotion)
+describes, and under Patroni it will recur on every switchover unless you
+handle it.
+
+Two ways to handle it:
+
+- **Automate it with an `on_role_change` callback.** Point
+  `synchronized_standby_slots` at the current standby member(s) whenever a
+  node's role changes. This keeps the guarantee intact across switchovers
+  without manual steps and is the recommended approach for anything beyond a
+  test cluster.
+
+  ```yaml
+  postgresql:
+    callbacks:
+      on_role_change: /etc/patroni/set_synchronized_standby_slots.sh
+  ```
+
+  The script receives `on_role_change <role> <scope>`; on becoming leader it
+  should `ALTER SYSTEM SET synchronized_standby_slots` to the other members'
+  slot names and reload, and on becoming a replica it should clear it.
+
+- **Leave it unset and accept the trade-off.** Without
+  `synchronized_standby_slots`, nothing freezes on switchover, but the leader
+  no longer waits for the standby to confirm before letting logical
+  subscribers advance. A subscriber can then get slightly ahead of the
+  physical standby, so immediately after a promotion the new leader may be
+  marginally behind a subscriber. For many deployments that small window is
+  acceptable; for zero-data-loss requirements, use the callback instead.
+
+### Verify
+
+After bootstrap and restart, confirm every member carries the flagged,
+synchronized slots:
+
+```sql
+-- on each standby member
+SELECT slot_name, synced, failover, invalidation_reason
+FROM pg_replication_slots
+WHERE plugin = 'spock_output' AND NOT temporary;
+```
+
+`synced` and `failover` should both be `true` and `invalidation_reason`
+`NULL`. If `failover` is `false`, the slot was created before
+`spock.use_native_failover_slots` took effect (check that the restart
+actually happened). Drop and recreate the subscription so the slot is
+recreated with the flag.
 
 ## Setup: PostgreSQL 15 and 16 (Spock Worker)
 
@@ -234,8 +375,8 @@ WHERE application_name = 'spock_failover_slots worker';
 **Q: Do I need to do anything after a failover?**
 
 On PG17+ with `spock.use_native_failover_slots = on`: update the
-subscriber's `host=` in their DSN, and — if `synchronized_standby_slots` was
-configured — clear/adjust it on the promoted node as described in the
+subscriber's `host=` in their DSN, and, if `synchronized_standby_slots` was
+configured, clear/adjust it on the promoted node as described in the
 [runbook above](#runbook-clear-synchronized_standby_slots-after-promotion).
 No slot recreation is needed.
 
@@ -249,7 +390,7 @@ With `spock.use_native_failover_slots = on`, Spock's worker is not
 registered on PG18+. If `sync_replication_slots = on` is not also set,
 logical slots will **not** be synchronized to standbys, and a failover will
 require manual slot recreation and table re-sync. (With the GUC left `off`,
-this does not apply — Spock's worker is registered and runs as usual.)
+this does not apply, since Spock's worker is registered and runs as usual.)
 
 **Q: Can I use both mechanisms on PG17?**
 
@@ -262,6 +403,6 @@ Spock's slots since they are never marked with `FAILOVER`.
 
 **Q: Do I need to restart the server to enable this?**
 
-Yes. `spock.use_native_failover_slots` is `PGC_POSTMASTER` — it can only be
+Yes. `spock.use_native_failover_slots` is `PGC_POSTMASTER`; it can only be
 set at server start (via `postgresql.conf` or `ALTER SYSTEM` followed by a
 restart), not with `SET` or a `SIGHUP` reload.

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -276,7 +276,10 @@ Two ways to handle it:
 
   The script receives `on_role_change <role> <scope>`; on becoming leader it
   should `ALTER SYSTEM SET synchronized_standby_slots` to the other members'
-  slot names and reload, and on becoming a replica it should clear it.
+  slot names and reload, and on becoming a replica it should clear it. A
+  ready-to-adapt reference implementation ships with Spock at
+  [`samples/set_synchronized_standby_slots.sh`](../samples/set_synchronized_standby_slots.sh);
+  review and tailor it to your environment before production use.
 
 - **Leave it unset and accept the trade-off.** Without
   `synchronized_standby_slots`, nothing freezes on switchover, but the leader

--- a/samples/README.md
+++ b/samples/README.md
@@ -3,3 +3,8 @@
 The `samples` directory includes unmaintained helper tutorials, functions, and procedures for the Spock extension.  Sample programs in this directory should be considered illustrative only, and should be well tested before being used in a production environment.
 
 The content of this directory is subject to change or removal at any time.  To contribute a sample to this directory, open a Pull Request and attach the content; a developer will review the content for inclusion.
+
+### Contents
+
+- `set_synchronized_standby_slots.sh` — Patroni `on_role_change` callback that keeps `synchronized_standby_slots` pointed at the current standby member(s) across switchovers. Reference only; see [`docs/logical_slot_failover.md`](../docs/logical_slot_failover.md) for the rationale.
+- `Z0DAN/` — Zero Downtime Add/Remove Node sample scripts.

--- a/samples/set_synchronized_standby_slots.sh
+++ b/samples/set_synchronized_standby_slots.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# set_synchronized_standby_slots.sh - Patroni on_role_change callback for Spock
+#
+# SAMPLE / REFERENCE ONLY. Read it, understand it, and adapt it to your
+# environment before wiring it into a production cluster.
+#
+# Purpose
+# -------
+# Keeps PostgreSQL's `synchronized_standby_slots` pointed at the physical
+# replication slot(s) of the *current* standby member(s) whenever a node's
+# role changes. This holds the leader's walsenders back until the standby has
+# confirmed the LSN, so a logical subscriber can never advance ahead of the
+# physical standby that may later be promoted.
+#
+# The value is role-specific but Patroni's dynamic config is cluster-wide, so a
+# hardcoded value points the new leader at a slot for itself after a switchover
+# and freezes logical replication. Setting it from a callback avoids that. See
+# docs/logical_slot_failover.md, "The switchover sharp edge", for the full
+# rationale and the manual runbook this script automates.
+#
+# Installation
+# ------------
+# Place this script on every member and reference it from patroni.yml:
+#
+#   postgresql:
+#     callbacks:
+#       on_role_change: /etc/patroni/set_synchronized_standby_slots.sh
+#
+# Patroni invokes callbacks as:  <script> <action> <role> <scope>
+#   $1 = action  (on_role_change)
+#   $2 = role    (primary | master | replica | standby_leader)
+#   $3 = scope   (cluster name)
+
+set -euo pipefail
+
+ACTION="${1:-}"
+ROLE="${2:-}"
+SCOPE="${3:-}"
+
+# --- adapt these to your deployment -----------------------------------------
+# Command + config used to enumerate the cluster's members.
+PATRONICTL="${PATRONICTL:-patronictl}"
+PATRONI_CONFIG="${PATRONI_CONFIG:-/etc/patroni/patroni.yml}"
+# Local superuser psql connection used to run ALTER SYSTEM / pg_reload_conf().
+# e.g. PGCONN="-h /var/run/postgresql -U postgres -d postgres"
+PSQL="${PSQL:-psql}"
+PGCONN="${PGCONN:-}"
+# ----------------------------------------------------------------------------
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') set_synchronized_standby_slots: $*"; }
+
+run_sql() {
+	# shellcheck disable=SC2086
+	$PSQL $PGCONN -X -q -v ON_ERROR_STOP=1 -c "$1"
+}
+
+# Patroni names a member's physical slot after the member, lowercased with any
+# character outside [a-z0-9_] replaced by '_'. Mirror that transform here.
+slot_name_from_member() {
+	echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_]/_/g'
+}
+
+# Comma-separated, quoted slot names of every member that is NOT this node.
+other_member_slots() {
+	local self="$1" name role slots=""
+	while IFS='|' read -r name role; do
+		[ -z "$name" ] && continue
+		[ "$name" = "$self" ] && continue
+		local slot
+		slot="$(slot_name_from_member "$name")"
+		if [ -z "$slots" ]; then
+			slots="'$slot'"
+		else
+			slots="$slots, '$slot'"
+		fi
+	done < <("$PATRONICTL" -c "$PATRONI_CONFIG" list -f tsv "$SCOPE" \
+		| awk -F'\t' 'NR>1 {print $2 "|" $4}')
+	echo "$slots"
+}
+
+case "$ROLE" in
+	primary|master)
+		# This node is (becoming) the leader: hold its walsenders back for the
+		# other members' physical slots.
+		self="$(hostname)"
+		slots="$(other_member_slots "$self")"
+		if [ -z "$slots" ]; then
+			log "no other members found; clearing synchronized_standby_slots"
+			run_sql "ALTER SYSTEM SET synchronized_standby_slots = ''"
+		else
+			log "leader $self -> synchronized_standby_slots = $slots"
+			run_sql "ALTER SYSTEM SET synchronized_standby_slots = '$(echo "$slots" | sed "s/'//g;s/, /,/g")'"
+		fi
+		run_sql "SELECT pg_reload_conf()"
+		;;
+	replica|standby_leader)
+		# This node is (becoming) a standby: it must not hold anything back, or
+		# it would point at a slot for itself and freeze on the next promotion.
+		log "role $ROLE -> clearing synchronized_standby_slots"
+		run_sql "ALTER SYSTEM SET synchronized_standby_slots = ''"
+		run_sql "SELECT pg_reload_conf()"
+		;;
+	*)
+		log "unhandled role '$ROLE' for action '$ACTION'; nothing to do"
+		;;
+esac


### PR DESCRIPTION
Add a Patroni section covering the required GUCs, the bootstrap DCS parameters, and the synchronized_standby_slots switchover handling.