### PR TITLE
Cherry-pick PG19-adaptation commits and fixes from v5_STABLE

### DIFF
--- a/src/compat/15/spock_compat.h
+++ b/src/compat/15/spock_compat.h
@@ -110,5 +110,25 @@
 							restart_seqs, run_as_table_owner) \
 		ExecuteTruncateGuts(explicit_rels, relids, relids_logged, behavior, \
 							restart_seqs)
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
 
 #endif

--- a/src/compat/16/spock_compat.h
+++ b/src/compat/16/spock_compat.h
@@ -135,5 +135,25 @@
 /* Must use this interface for access HeapTuple in ReorderBufferChange */
 #define ReorderBufferChangeHeapTuple(change, tuple_type) \
 	&change->data.tp.tuple_type->tuple
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
 
 #endif

--- a/src/compat/17/spock_compat.h
+++ b/src/compat/17/spock_compat.h
@@ -117,5 +117,25 @@
 /* Must use this interface for access HeapTuple in ReorderBufferChange */
 #define ReorderBufferChangeHeapTuple(change, tuple_type) \
 	change->data.tp.tuple_type
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
 
 #endif

--- a/src/compat/18/spock_compat.h
+++ b/src/compat/18/spock_compat.h
@@ -128,5 +128,25 @@
 
 #include "parser/parse_node.h"
 extern bool check_simple_rowfilter_expr(Node *node, ParseState *pstate);
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
 
 #endif

--- a/src/compat/19/spock_compat.h
+++ b/src/compat/19/spock_compat.h
@@ -175,5 +175,12 @@
 #include "catalog/dependency.h"
 #define isQueryUsingTempRelation(query) \
 	query_uses_temp_object((query), &(ObjectAddress){0})
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ * Requires miscadmin.h for MyBackendType.
+ */
+#include "miscadmin.h"
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages[MyBackendType])
 
 #endif

--- a/src/spock.c
+++ b/src/spock.c
@@ -69,6 +69,8 @@
 #include "spock_shmem.h"
 #include "spock.h"
 
+#include "spock_compat.h"
+
 #if PG_VERSION_NUM >= 180000
 PG_MODULE_MAGIC_EXT(
 	.name = "spock",
@@ -988,10 +990,17 @@ log_message_filter(ErrorData *edata)
 
 		if (lower_output_level)
 		{
-			/* Reconsider decision on exposing the message */
-			if (log_min_messages < edata->elevel)
+			/*
+			 * Reconsider the decision on exposing the message.  errstart()
+			 * made it for the original elevel, which was LOG and therefore
+			 * loud enough to pass both thresholds; now that the level is
+			 * DEBUG1 the message must be held back wherever DEBUG1 is below
+			 * the threshold.  The test is the same one is_log_level_output()
+			 * applies for a non-LOG elevel: emit when elevel >= the minimum.
+			 */
+			if (edata->elevel < SPOCK_LOG_MIN_MESSAGES)
 				edata->output_to_server = false;
-			if (client_min_messages < edata->elevel)
+			if (edata->elevel < client_min_messages)
 				edata->output_to_client = false;
 		}
 	}

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -640,8 +640,6 @@ handle_begin(StringInfo s)
 	XLogRecPtr	commit_lsn;
 	TimestampTz commit_time;
 	bool		slot_found = false;
-	int			sub_name_len = strlen(MySubscription->name);
-	char	   *slot_name;
 
 	SPOCK_WORKER_DELAY();
 
@@ -703,9 +701,9 @@ handle_begin(StringInfo s)
 		for (int i = 0; i < SpockCtx->total_workers; i++)
 		{
 			exception_log = &exception_log_ptr[i];
-			slot_name = NameStr(exception_log->slot_name);
 
-			if (strncmp(slot_name, MySubscription->name, sub_name_len) == 0)
+			if (namestrcmp(&exception_log->slot_name,
+						   MySubscription->name) == 0)
 			{
 				/* We found our slot in shared memory. */
 				slot_found = true;
@@ -741,9 +739,9 @@ handle_begin(StringInfo s)
 			for (int i = 0; i < SpockCtx->total_workers; i++)
 			{
 				exception_log = &exception_log_ptr[i];
-				slot_name = NameStr(exception_log->slot_name);
 
-				if (strncmp(slot_name, MySubscription->name, sub_name_len) == 0)
+				if (namestrcmp(&exception_log->slot_name,
+							   MySubscription->name) == 0)
 				{
 					/* We found our slot in shared memory. */
 					slot_found = true;
@@ -756,7 +754,8 @@ handle_begin(StringInfo s)
 					break;
 				}
 
-				if (free_slot_index < 0 && strlen(slot_name) == 0)
+				if (free_slot_index < 0 &&
+					NameStr(exception_log->slot_name)[0] == '\0')
 				{
 					free_slot_index = i;
 				}

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -708,8 +708,8 @@ handle_begin(StringInfo s)
 	 * the entries. We need to create a slot here as well.
 	 *
 	 * 3. The error log is not empty and we found our entry, but the commit
-	 * lsn does not match. We simply update the commit lsn and move on. This
-	 * case happens when we have not errored out previously.
+	 * lsn does not match. The recorded failure is not this transaction, so we
+	 * clear the entry, leave exception handling off and apply normally.
 	 *
 	 * 4. The error log is not empty, we found our entry and the commit lsn.
 	 * This would mean that we previously errored and restarted. We set the
@@ -840,6 +840,33 @@ handle_begin(StringInfo s)
 			 * handling, don't go into a fast error loop.
 			 */
 			MySpockWorker->restart_delay = restart_delay_default;
+		}
+		else
+		{
+			/*
+			 * The recorded failure is not this transaction, so this one has not
+			 * been attempted yet and must be applied normally.
+			 *
+			 * use_try_block lives in the worker's shared memory slot and is not
+			 * per-transaction state, so it can still be set from an earlier
+			 * failure.  The case that matters is an error raised between remote
+			 * transactions: apply_work() switches to replay mode even though
+			 * nothing was queued for this cycle, and the flag then belongs to
+			 * whichever transaction the provider sends next.  Leaving it set
+			 * would replay that transaction read-only and, under TRANSDISCARD
+			 * or SUB_DISABLE, discard it -- a transaction that never failed,
+			 * reported as if the exception policy had fired.
+			 *
+			 * Drop the recorded root cause along with the flag.  Nothing will
+			 * be attributed to it now, and leaving it behind would make the
+			 * next genuine exception surface a stale "Initial error".
+			 *
+			 * We only get here on the first BEGIN of an apply cycle, which is
+			 * also the first BEGIN after an exception: apply_work() sets
+			 * first_begin_at_startup back to true when it catches one.
+			 */
+			MyApplyWorker->use_try_block = false;
+			clear_exception_log_entry(exception_log);
 		}
 	}
 
@@ -1217,8 +1244,11 @@ handle_commit(StringInfo s)
 	apply_replay_queue_reset();
 
 	/*
-	 * This is the only place we can reset the use_try_block = false without
-	 * any risk of going into the error deathloop
+	 * Clearing use_try_block here cannot start an error deathloop: the
+	 * transaction has committed, so there is nothing left to retry.  The only
+	 * other places that may clear it are the ones which have established that
+	 * the incoming transaction is not the failure recorded in the exception log
+	 * (see handle_begin).
 	 */
 	MyApplyWorker->use_try_block = false;
 
@@ -4040,6 +4070,15 @@ stream_replay:
 		apply_replay_queue_start_replay();
 
 		in_remote_transaction = false;
+
+		/*
+		 * Re-arm the exception log lookup in handle_begin().  The next BEGIN
+		 * has to compare the recorded commit_lsn against the incoming one:
+		 * that is where exception handling is entered for the transaction that
+		 * failed, and where the recorded failure is dropped if the provider
+		 * sends a different transaction instead.  Without this the stale entry
+		 * would be left to govern transactions it knows nothing about.
+		 */
 		first_begin_at_startup = true;
 		remote_origin_lsn = InvalidXLogRecPtr;
 		remote_origin_id = InvalidRepOriginId;

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -367,7 +367,32 @@ should_log_exception(bool failed)
 }
 
 /*
- * Forget the in-flight transaction marker after a transient failure on the
+ * Reset one exception log entry to the "no failure recorded" state.
+ *
+ * Only the apply worker of the subscription named in slot_name ever writes its
+ * own entry, so no lock is taken here.  The caller must have established that
+ * the recorded failure is not the transaction about to be applied; wiping the
+ * entry of a failure that is still pending would lose the root cause we report
+ * for it.
+ *
+ * local_tuple is included deliberately.  It is a HeapTuple copied into
+ * ApplyOperationContext by the conflict handling code, and every path that
+ * reaches here has already reset that context, so the pointer parked in shared
+ * memory is dangling.
+ */
+static void
+clear_exception_log_entry(SpockExceptionLog *entry)
+{
+	Assert(entry != NULL);
+
+	entry->commit_lsn = InvalidXLogRecPtr;
+	entry->local_tuple = NULL;
+	entry->initial_error_message[0] = '\0';
+	entry->failed_action = 0;
+}
+
+/*
+ * Forget the in-flight transaction marker after a transport failure on the
  * normal apply path.
  *
  * handle_begin() records commit_lsn in shared memory before any changes are
@@ -400,10 +425,7 @@ clear_transient_exception_state(const char *reason)
 		return;
 
 	exception_log = &exception_log_ptr[my_exception_log_index];
-	exception_log->commit_lsn = InvalidXLogRecPtr;
-	exception_log->local_tuple = NULL;
-	exception_log->initial_error_message[0] = '\0';
-	exception_log->failed_action = 0;
+	clear_exception_log_entry(exception_log);
 
 	elog(DEBUG1, "SPOCK %s: cleared transient exception state after %s",
 		 MySubscription->name, reason);

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -90,6 +90,8 @@
 #include "spock.h"
 #include "spock_injection.h"
 
+#include "spock_compat.h"
+
 
 PGDLLEXPORT void spock_apply_main(Datum main_arg);
 
@@ -2854,7 +2856,7 @@ handle_queued_message(HeapTuple msgtup, bool tx_just_started)
 	{
 		case QUEUE_COMMAND_TYPE_DDL:
 			in_spock_queue_ddl_command = true;
-			/* fallthrough */
+			pg_fallthrough;
 		case QUEUE_COMMAND_TYPE_SQL:
 			errcallback_arg.action_name = "QUEUED_SQL";
 			handle_sql_or_exception(queued_message, tx_just_started);

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -700,7 +700,7 @@ handle_begin(StringInfo s)
 	{
 		first_begin_at_startup = false;
 
-		for (int i = 0; i <= SpockCtx->total_workers; i++)
+		for (int i = 0; i < SpockCtx->total_workers; i++)
 		{
 			exception_log = &exception_log_ptr[i];
 			slot_name = NameStr(exception_log->slot_name);
@@ -738,7 +738,7 @@ handle_begin(StringInfo s)
 			 */
 			LWLockAcquire(SpockCtx->lock, LW_EXCLUSIVE);
 
-			for (int i = 0; i <= SpockCtx->total_workers; i++)
+			for (int i = 0; i < SpockCtx->total_workers; i++)
 			{
 				exception_log = &exception_log_ptr[i];
 				slot_name = NameStr(exception_log->slot_name);

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -437,10 +437,16 @@ get_database_oid(const char *dbname)
  * This is slightly complicated because we default to primary_conninfo if
  * user didn't explicitly set anything and we might need to request explicit
  * database name override, that's why we need dedicated function for this.
+ *
+ * Returns false if no connection string is available yet, which only happens
+ * on the primary_conninfo path; connstr is left untouched in that case and the
+ * caller must not try to connect.  See the comment on that path below.
  */
-static void
+static bool
 make_sync_failover_slots_dsn(StringInfo connstr, char *db_name)
 {
+	char		conninfo[MAXCONNINFO];
+
 	if (spock_failover_slots_dsn && strlen(spock_failover_slots_dsn) > 0)
 	{
 		if (db_name)
@@ -448,13 +454,31 @@ make_sync_failover_slots_dsn(StringInfo connstr, char *db_name)
 							 db_name);
 		else
 			appendStringInfoString(connstr, spock_failover_slots_dsn);
+
+		return true;
 	}
-	else
-	{
-		Assert(WalRcv);
-		appendStringInfo(connstr, "%s dbname=%s", WalRcv->conninfo,
-						 db_name ? db_name : "postgres");
-	}
+
+	/*
+	 * Fall back to the walreceiver's connection string.
+	 * The field might be legitimately empty for as long as a connection
+	 * attempt is in flight.  WalReceiverMain() clears conninfo before calling
+	 * walrcv_connect() and only fills it in once the connection is fully
+	 * established, so this happens on every walreceiver start and restart --
+	 * not merely in a narrow window while the standby comes up.
+	 */
+	Assert(WalRcv);
+
+	SpinLockAcquire(&WalRcv->mutex);
+	strlcpy(conninfo, (char *) WalRcv->conninfo, sizeof(conninfo));
+	SpinLockRelease(&WalRcv->mutex);
+
+	if (conninfo[0] == '\0')
+		return false;
+
+	appendStringInfo(connstr, "%s dbname=%s", conninfo,
+					 db_name ? db_name : "postgres");
+
+	return true;
 }
 
 /*
@@ -553,7 +577,19 @@ wait_for_primary_slot_catchup(ReplicationSlot *slot, RemoteSlot *remote_slot)
 	 * postgres here because plugin callback below might want to invoke
 	 * extension functions.  Keep connstr alive for reconnect attempts.
 	 */
-	make_sync_failover_slots_dsn(&connstr, remote_slot->database);
+	if (!make_sync_failover_slots_dsn(&connstr, remote_slot->database))
+	{
+		/*
+		 * The walreceiver dropped its connection string while we were getting
+		 * here, so it is reconnecting to the primary.  Give up on this slot for
+		 * now; the caller's next cycle starts over.
+		 */
+		elog(DEBUG1,
+			 "no connection string for the primary yet, not waiting for slot %s",
+			 remote_slot->name);
+		pfree(connstr.data);
+		return false;
+	}
 
 	conn = remote_connect(connstr.data, "spock_failover_slots");
 
@@ -1066,7 +1102,15 @@ synchronize_failover_slots(long sleep_time)
 	elog(DEBUG1, "starting replication slot synchronization from primary");
 
 	initStringInfo(&connstr);
-	make_sync_failover_slots_dsn(&connstr, NULL /* Use default db name */ );
+	if (!make_sync_failover_slots_dsn(&connstr, NULL /* Use default db name */ ))
+	{
+		/* Nothing to connect with yet.  Nap and retry later. */
+		elog(DEBUG1, "no connection string for the primary yet, "
+			 "deferring replication slot synchronization");
+		pfree(connstr.data);
+		return sleep_time;
+	}
+
 	conn = remote_connect(connstr.data, "spock_failover_slots");
 
 	/*

--- a/src/spock_group.c
+++ b/src/spock_group.c
@@ -165,8 +165,8 @@ spock_group_shmem_startup(bool found)
 		spock_group_resource_load();
 
 		elog(DEBUG1,
-			 "spock_group_shmem_startup: hash initialized with %lu entries from resource file",
-			 hash_get_num_entries(SpockGroupHash));
+			 "spock_group_shmem_startup: hash initialized with " INT64_FORMAT " entries from resource file",
+			 (int64) hash_get_num_entries(SpockGroupHash));
 	}
 }
 

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -988,7 +988,7 @@ get_node_interface_by_name(Oid nodeid, const char *name, bool missing_ok)
  * INTERNAL dependency type.
  */
 static inline Oid
-generate_subscription_id()
+generate_subscription_id(void)
 {
 	RangeVar   *rv;
 	Relation	rel;


### PR DESCRIPTION
### Fixes

- **Exception replay mode leaked onto healthy transactions.** `use_try_block` lives in the worker's shmem slot, not per-transaction state. An error raised *between* remote transactions never reaches the commit that clears it, and `apply_work()` enters replay mode anyway — so the flag landed on the next transaction from the stream. `handle_begin()` only reasoned about the flag when `commit_lsn` matched the recorded failure, so a non-matching transaction inherited it, was replayed read-only, and under `TRANSDISCARD`/`SUB_DISABLE` was discarded. A transaction that never failed, lost, and blamed on an unrelated error. Now the flag is derived from the comparison, and the recorded root cause is dropped with it.

- **Off-by-one scan of the exception log array.** Both search loops ran to `i <= SpockCtx->total_workers`, one past the end. `[total_workers]` is outside the region startup zeroes, and an empty-looking name there would be taken as the free slot, so `namestrcpy()` wrote past the array. It landed in slack only because `worker_shmem_size()` over-allocates.

- **Slot name matched by prefix instead of exactly.** `strncmp()` bounded by `strlen(MySubscription->name)` made `test_subscription` share a slot with `test_subscription_parallel` — and sharing the slot means sharing `commit_lsn`, so one subscription's failure could push the other into exception handling for a transaction that never failed. Now `namestrcmp()`.

- **Failover-slots worker died while the walreceiver reconnected.** `WalRcv->conninfo` is empty for as long as a connection attempt is in flight, which is every walreceiver start and restart, not just standby startup — the worker died in that window for 60s at a time. `make_sync_failover_slots_dsn()` now reports whether a DSN is available instead of building an unusable one; both callers wait for the next cycle. The field is also copied under `WalRcv->mutex`, matching core's `pg_stat_get_wal_receiver()`; it was read unlocked while the walreceiver rewrote it under that spinlock.

- **Log-level re-check was inverted.** `spock_error_callback()` downgrades two serialization-failure retry messages to `DEBUG1`, then re-tests whether they should still be emitted — backwards in both comparisons. `DEBUG1` is 14 and the default `log_min_messages` is `WARNING` = 19, so `19 < 14` never fired and the messages went to the server log regardless of the threshold, which is what this code exists to prevent. Now compares in the direction `is_log_level_output()` uses, as `spock_dependency.c` already does.

- **Four PG19 compiler warnings.** `log_min_messages` became an array indexed by backend type (pointer-vs-int comparison, the bug above); `pg_fallthrough` is new in PG19's `c.h` and clang won't accept a comment as the annotation; `hash_get_num_entries()` now returns `int64`, no longer matching `%lu`; `generate_subscription_id()` had an empty parameter list. New compat macros for the 15–18 headers.

### Refactor

- `clear_exception_log_entry()` collects the four assignments that reset a shared exception log entry. Two call sites need the same set, and `local_tuple` is easy to overlook — it's the only non-scalar, and it dangles by the time either caller runs. No functional change.