### PR TITLE
Fix INJECTION_POINT() macro arity mismatch on PG17

### DIFF
--- a/.github/workflows/spockbench.yml
+++ b/.github/workflows/spockbench.yml
@@ -50,9 +50,12 @@ jobs:
       - name: Build docker container
         run: |
           cd ${GITHUB_WORKSPACE}/
-          # Build docker image once for specific version, needed for this test
+          # --enable-injection-points is on here (and SPOCK_RANDOM_DELAYS is
+          # left unset) purely so spock_injection.h's USE_INJECTION_POINTS
+          # branch gets compiled and checked.
           docker build \
             --build-arg PGVER=${{ matrix.pgver }} \
+            --build-arg ENABLE_INJECTION_POINTS=1 \
             -t spock -f tests/docker/Dockerfile-step-1.el9 .
 
       - name: Start docker cluster

--- a/include/spock_injection.h
+++ b/include/spock_injection.h
@@ -28,7 +28,12 @@ extern void spock_random_delay(void);
 #elif defined(USE_INJECTION_POINTS)
 
 #include "utils/injection_point.h"
+
+#if PG_VERSION_NUM >= 180000
 #define SPOCK_WORKER_DELAY()	INJECTION_POINT("spock-worker-delay", NULL)
+#else
+#define SPOCK_WORKER_DELAY()	INJECTION_POINT("spock-worker-delay")
+#endif
 
 #else
 

--- a/tests/docker/Dockerfile-step-1.el9
+++ b/tests/docker/Dockerfile-step-1.el9
@@ -59,6 +59,10 @@ ARG PG_REF=
 # injecting random 1-100 ms delays at every transaction begin, worker start,
 # and worker finish.  Used by the random-delays-regress workflow.
 ARG SPOCK_RANDOM_DELAYS=
+# When set to any non-empty value, PostgreSQL is configured with
+# --enable-injection-points, so spock_injection.h's USE_INJECTION_POINTS
+# branch is compiled.  Must be combined with an empty SPOCK_RANDOM_DELAYS.
+ARG ENABLE_INJECTION_POINTS=
 
 # Export as environment variables for build-time and runtime
 ENV PGVER=${PGVER} \
@@ -196,6 +200,7 @@ RUN set -eux && \
 	--enable-dtrace \
 	--enable-cassert \
 	--enable-tap-tests \
+	${ENABLE_INJECTION_POINTS:+--enable-injection-points} \
 	PYTHON=/usr/bin/python3 \
 	CFLAGS="-g -O0" \
 	BITCODE_CFLAGS="-gdwarf-5 -O0 -fforce-dwarf-frame" && \


### PR DESCRIPTION
spock_injection.h always called INJECTION_POINT() with two arguments (name, arg), the PG18+ signature. PG17 defines it with a single argument, so building spock with USE_INJECTION_POINTS against a PG17 core failed to compile. Gate the call on PG_VERSION_NUM so each core gets the arity it actually expects.

Also compile spockbench.yml's per-PR Docker build with --enable-injection-points (new ENABLE_INJECTION_POINTS Dockerfile build-arg) so this path is exercised on every PR instead of relying on SPOCK_RANDOM_DELAYS, which takes precedence in the same header and had been masking it.