### PR TITLE
Register the custom rmgr before the IsBinaryUpgrade return

### DIFF
--- a/src/spock.c
+++ b/src/spock.c
@@ -1340,11 +1340,27 @@ _PG_init(void)
 							NULL,
 							NULL);
 
+	/*
+	 * Spock resource manager.
+	 *
+	 * This must happen even under binary upgrade, and therefore before the
+	 * IsBinaryUpgrade early return below. From PG17 on, pg_upgrade proves
+	 * every logical slot is drained by calling
+	 * binary_upgrade_logical_slot_has_caught_up(), which decodes the WAL from
+	 * the slot's confirmed_flush to the end of WAL. Logical decoding looks up
+	 * the resource manager of every record it walks past -- whether or not
+	 * that rmgr has a decode callback -- so an unregistered SPOCK_RMGR_ID
+	 * makes GetRmgr() raise "resource manager with ID 144 not registered" and
+	 * pg_upgrade fails at the consistency-check stage.
+	 *
+	 * RegisterCustomRmgr() only installs redo/desc/identify callbacks; it
+	 * starts no worker and touches no shared state, so it does not
+	 * reintroduce any of the activity the early return exists to prevent.
+	 */
+	spock_rmgr_init();
+
 	if (IsBinaryUpgrade)
 		return;
-
-	/* Spock resource manager */
-	spock_rmgr_init();
 
 	/* Init shared memory for all subsystems needed it */
 	spock_shmem_init();

--- a/src/spock_rmgr.c
+++ b/src/spock_rmgr.c
@@ -38,6 +38,15 @@
 #include "spock_rmgr.h"
 #include "spock_worker.h"
 
+/*
+ * rm_decode is deliberately NULL. These records are forensic only: they
+ * carry no replicated data, so there is nothing for logical decoding to turn
+ * into an output-plugin callback. Logical decoding then takes its "no decode
+ * callback" branch, which processes the record's xid and nothing else -- the
+ * behaviour we want. Note that this branch is reached for every one of our
+ * records that a decoder walks past, which is why the rmgr must be
+ * registered even during a binary upgrade (see _PG_init in spock.c).
+ */
 static RmgrData spock_custom_rmgr = {
 	.rm_name = SPOCK_RMGR_NAME,
 	.rm_redo = spock_rmgr_redo,
@@ -45,6 +54,8 @@ static RmgrData spock_custom_rmgr = {
 	.rm_identify = spock_rmgr_identify,
 	.rm_startup = NULL,
 	.rm_cleanup = NULL,
+	.rm_mask = NULL,
+	.rm_decode = NULL,
 };
 
 void


### PR DESCRIPTION
From PG17 on, pg_upgrade proves every logical slot is drained by calling binary_upgrade_logical_slot_has_caught_up(), which decodes the WAL from the slot's confirmed_flush to the end of WAL.  Logical decoding resolves the resource manager of every record it walks past, whether or not that rmgr has a decode callback.

_PG_init() called spock_rmgr_init() below the IsBinaryUpgrade early return, so in the throwaway servers pg_upgrade starts, rmgr 144 was not registered.  The supervisor's before_shmem_exit hook emits its SPOCK_DUMP_SHUTDOWN records past the slot's last confirmed_flush, so every active node has such a record inside the decoded range, and GetRmgr() raised

    ERROR:  resource manager with ID 144 not registered

Move spock_rmgr_init() above the early return.  RegisterCustomRmgr() only installs redo/desc/identify callbacks; it starts no worker and touches no shared state, so it does not reintroduce the activity the early return exists to prevent.  Also record why rm_decode is NULL: the records are forensic and carry no replicated data, so the decoder's "no decode callback" branch is the wanted behaviour -- but it is that branch which makes registration mandatory during a binary upgrade.