### PR TITLE
Refresh attoptions patch for heap_update() change in PG17.11/18.5/19

### DIFF
--- a/patches/17/pg17-015-attoptions.diff
+++ b/patches/17/pg17-015-attoptions.diff
@@ -121,7 +121,7 @@ index 1bacea4360e..20f60178c72 100644
 +										   logged_old_attrs,
  										   &old_key_copied);
  
- 	/* NO EREPORT(ERROR) from here till changes are logged */
+ 	clear_all_visible = PageIsAllVisible(page);
 @@ -4171,6 +4182,7 @@ l2:
  	bms_free(key_attrs);
  	bms_free(id_attrs);

--- a/patches/18/pg18-015-attoptions.diff
+++ b/patches/18/pg18-015-attoptions.diff
@@ -122,7 +122,7 @@ index 0dcd6ee817e..dcf26167cae 100644
 +										   logged_old_attrs,
  										   &old_key_copied);
  
- 	/* NO EREPORT(ERROR) from here till changes are logged */
+ 	clear_all_visible = PageIsAllVisible(page);
 @@ -4207,6 +4219,7 @@ l2:
  	bms_free(key_attrs);
  	bms_free(id_attrs);

--- a/patches/19/pg19-015-attoptions.diff
+++ b/patches/19/pg19-015-attoptions.diff
@@ -122,7 +122,7 @@ index 0dcd6ee817e..dcf26167cae 100644
 +										   logged_old_attrs,
  										   &old_key_copied);
  
- 	/* NO EREPORT(ERROR) from here till changes are logged */
+ 	clear_all_visible = PageIsAllVisible(page);
 @@ -4207,6 +4219,7 @@ l2:
  	bms_free(key_attrs);
  	bms_free(id_attrs);


### PR DESCRIPTION
PG 17.11/18.5/19beta3 moved the visibility-map code in heap_update() above START_CRIT_SECTION(), so the trailing context of hunk #8 in pgNN-015-attoptions.diff no longer matched and the hunk was rejected under --fuzz=0.

Refreshed that context line to clear_all_visible = PageIsAllVisible(page); in the PG17, PG18 and PG19 copies — context-only change, the logged_old_attrs argument it adds is untouched.