### PR TITLE
Add spock plugin to output_plugin_libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,26 @@ _regress=$(patsubst %/,%,$(srcdir))/tests/regress
 REGRESS_OPTS += --dbname=regression \
 				--bindir=$(shell $(PG_CONFIG) --bindir) \
 				--inputdir=$(abspath $(_regress))
+
+# Servers carrying the output_plugin_libraries security fix (commit 2a29b607dbb)
+# refuse to let a slot name spock_output as its output plugin until the GUC
+# lists it, so the setting is layered in from a separate file.
+#
+# The fix shipped in minor releases of every supported major as well as in
+# PG19, so the major version says nothing about whether the GUC is there;
+# ask the server binary instead.  --describe-config needs no data directory.
+# An empty answer (probe failed, or server predates the fix) leaves the
+# setting out, which is required -- an unrecognised parameter would stop the
+# postmaster from starting.  pg_regress appends each --temp-config in order.
+#
+# Deferred (=, not :=) on purpose: the probe then runs only when regresscheck
+# expands it.  An immediate assignment forks pg_config and postgres during
+# Makefile parse, on every invocation -- make, make install, make clean, and
+# each recursive one -- to compute something only this one recipe reads.
+_regress_output_plugin_config = $(shell \
+	"$$($(PG_CONFIG) --bindir)/postgres" --describe-config 2>/dev/null \
+	| grep -q '^output_plugin_libraries' \
+	&& echo --temp-config $(_regress)/regress-output-plugin.conf)
 pg_regress_clean_files = $(_regress)/results $(_regress)/regression_output \
 			$(_regress)/regression.diffs $(_regress)/regression.out $(_regress)/tmp_check/ \
 			$(_regress)/tmp_check_iso/ $(_regress)/log/ $(_regress)/output_iso/
@@ -118,6 +138,7 @@ regresscheck:
 	$(MKDIR_P) $(_regress)/regression_output
 	$(pg_regress_check) $(REGRESS_OPTS) \
 	    --temp-config $(_regress)/regress-postgresql.conf \
+	    $(_regress_output_plugin_config) \
 	    --temp-instance=$(_regress)/tmp_check \
 	    --outputdir=$(_regress)/regression_output \
 	    --create-role=logical \

--- a/patches/18/pg18-015-attoptions.diff
+++ b/patches/18/pg18-015-attoptions.diff
@@ -1,5 +1,5 @@
 diff --git a/src/backend/access/common/reloptions.c b/src/backend/access/common/reloptions.c
-index 50747c16396..6cdbbe1d0dd 100644
+index 50747c1..6cdbbe1 100644
 --- a/src/backend/access/common/reloptions.c
 +++ b/src/backend/access/common/reloptions.c
 @@ -166,6 +166,15 @@ static relopt_bool boolRelOpts[] =
@@ -50,7 +50,7 @@ index 50747c16396..6cdbbe1d0dd 100644
  
  	return (bytea *) build_reloptions(reloptions, validate,
 diff --git a/src/backend/access/heap/heapam.c b/src/backend/access/heap/heapam.c
-index 0dcd6ee817e..dcf26167cae 100644
+index d72b41e..1633c07 100644
 --- a/src/backend/access/heap/heapam.c
 +++ b/src/backend/access/heap/heapam.c
 @@ -48,6 +48,7 @@
@@ -61,7 +61,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  #include "utils/datum.h"
  #include "utils/injection_point.h"
  #include "utils/inval.h"
-@@ -67,6 +68,7 @@ static void check_lock_if_inplace_updateable_rel(Relation relation,
+@@ -68,6 +69,7 @@ static void check_lock_if_inplace_updateable_rel(Relation relation,
  												 HeapTuple newtup);
  static void check_inplace_rel_lock(HeapTuple oldtup);
  #endif
@@ -69,7 +69,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  static Bitmapset *HeapDetermineColumnsInfo(Relation relation,
  										   Bitmapset *interesting_cols,
  										   Bitmapset *external_cols,
-@@ -104,6 +106,7 @@ static void index_delete_sort(TM_IndexDeleteOp *delstate);
+@@ -108,6 +110,7 @@ static void index_delete_sort(TM_IndexDeleteOp *delstate);
  static int	bottomup_sort_and_shrink(TM_IndexDeleteOp *delstate);
  static XLogRecPtr log_heap_new_cid(Relation relation, HeapTuple tup);
  static HeapTuple ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
@@ -77,7 +77,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  										bool *copy);
  
  
-@@ -3016,7 +3019,7 @@ l1:
+@@ -3075,7 +3078,7 @@ l1:
  	 * Compute replica identity tuple before entering the critical section so
  	 * we don't PANIC upon a memory allocation failure.
  	 */
@@ -86,7 +86,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  
  	/*
  	 * If this is the first possibly-multixact-able operation in the current
-@@ -3249,6 +3252,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
+@@ -3331,6 +3334,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
  	Bitmapset  *id_attrs;
  	Bitmapset  *interesting_attrs;
  	Bitmapset  *modified_attrs;
@@ -94,7 +94,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	ItemId		lp;
  	HeapTupleData oldtup;
  	HeapTuple	heaptup;
-@@ -3419,6 +3423,12 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
+@@ -3506,6 +3510,12 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
  											  id_attrs, &oldtup,
  											  newtup, &id_has_external);
  
@@ -107,7 +107,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	/*
  	 * If we're not updating any "key" column, we can grab a weaker lock type.
  	 * This allows for more concurrency when we are running simultaneously
-@@ -3692,6 +3702,7 @@ l2:
+@@ -3779,6 +3789,7 @@ l2:
  		bms_free(key_attrs);
  		bms_free(id_attrs);
  		bms_free(modified_attrs);
@@ -115,15 +115,15 @@ index 0dcd6ee817e..dcf26167cae 100644
  		bms_free(interesting_attrs);
  		return result;
  	}
-@@ -4041,6 +4052,7 @@ l2:
+@@ -4151,6 +4162,7 @@ l2:
  	old_key_tuple = ExtractReplicaIdentity(relation, &oldtup,
  										   bms_overlap(modified_attrs, id_attrs) ||
  										   id_has_external,
 +										   logged_old_attrs,
  										   &old_key_copied);
  
- 	/* NO EREPORT(ERROR) from here till changes are logged */
-@@ -4207,6 +4219,7 @@ l2:
+ 	clear_all_visible = PageIsAllVisible(page);
+@@ -4412,6 +4424,7 @@ l2:
  	bms_free(key_attrs);
  	bms_free(id_attrs);
  	bms_free(modified_attrs);
@@ -131,7 +131,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	bms_free(interesting_attrs);
  
  	return TM_Ok;
-@@ -4379,6 +4392,26 @@ heap_attr_equals(TupleDesc tupdesc, int attrnum, Datum value1, Datum value2,
+@@ -4584,6 +4597,26 @@ heap_attr_equals(TupleDesc tupdesc, int attrnum, Datum value1, Datum value2,
  	}
  }
  
@@ -158,7 +158,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  /*
   * Check which columns are being updated.
   *
-@@ -9132,6 +9165,7 @@ log_heap_new_cid(Relation relation, HeapTuple tup)
+@@ -9420,6 +9453,7 @@ log_heap_new_cid(Relation relation, HeapTuple tup)
   */
  static HeapTuple
  ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
@@ -166,7 +166,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  					   bool *copy)
  {
  	TupleDesc	desc = RelationGetDescr(relation);
-@@ -9164,13 +9198,16 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
+@@ -9452,13 +9486,16 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
  	}
  
  	/* if the key isn't required and we're only logging the key, we're done */
@@ -185,7 +185,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	 * If there's no defined replica identity columns, treat as !key_required.
  	 * (This case should not be reachable from heap_update, since that should
 diff --git a/src/include/utils/attoptcache.h b/src/include/utils/attoptcache.h
-index f684a772af5..6c965fede13 100644
+index f684a77..6c965fe 100644
 --- a/src/include/utils/attoptcache.h
 +++ b/src/include/utils/attoptcache.h
 @@ -21,6 +21,8 @@ typedef struct AttributeOpts

--- a/patches/19/pg19-015-attoptions.diff
+++ b/patches/19/pg19-015-attoptions.diff
@@ -1,8 +1,8 @@
 diff --git a/src/backend/access/common/reloptions.c b/src/backend/access/common/reloptions.c
-index 50747c16396..6cdbbe1d0dd 100644
+index 3e832c3..dcb534d 100644
 --- a/src/backend/access/common/reloptions.c
 +++ b/src/backend/access/common/reloptions.c
-@@ -166,6 +166,15 @@ static relopt_bool boolRelOpts[] =
+@@ -162,6 +162,15 @@ static relopt_bool boolRelOpts[] =
  		},
  		true
  	},
@@ -18,7 +18,7 @@ index 50747c16396..6cdbbe1d0dd 100644
  	/* list terminator */
  	{{NULL}}
  };
-@@ -557,6 +566,19 @@ static relopt_enum enumRelOpts[] =
+@@ -589,6 +598,19 @@ static relopt_enum enumRelOpts[] =
  
  static relopt_string stringRelOpts[] =
  {
@@ -38,7 +38,7 @@ index 50747c16396..6cdbbe1d0dd 100644
  	/* list terminator */
  	{{NULL}}
  };
-@@ -2106,7 +2128,9 @@ attribute_reloptions(Datum reloptions, bool validate)
+@@ -2215,7 +2237,9 @@ attribute_reloptions(Datum reloptions, bool validate)
  {
  	static const relopt_parse_elt tab[] = {
  		{"n_distinct", RELOPT_TYPE_REAL, offsetof(AttributeOpts, n_distinct)},
@@ -50,16 +50,18 @@ index 50747c16396..6cdbbe1d0dd 100644
  
  	return (bytea *) build_reloptions(reloptions, validate,
 diff --git a/src/backend/access/heap/heapam.c b/src/backend/access/heap/heapam.c
-index 0dcd6ee817e..dcf26167cae 100644
+index 182740c..a176a15 100644
 --- a/src/backend/access/heap/heapam.c
 +++ b/src/backend/access/heap/heapam.c
-@@ -52,4 +52,5 @@
+@@ -50,6 +50,7 @@
+ #include "storage/predicate.h"
+ #include "storage/proc.h"
  #include "storage/procarray.h"
 +#include "utils/attoptcache.h"
  #include "utils/datum.h"
  #include "utils/injection_point.h"
  #include "utils/inval.h"
-@@ -67,6 +68,7 @@ static void check_lock_if_inplace_updateable_rel(Relation relation,
+@@ -71,6 +72,7 @@ static void check_lock_if_inplace_updateable_rel(Relation relation,
  												 HeapTuple newtup);
  static void check_inplace_rel_lock(HeapTuple oldtup);
  #endif
@@ -67,7 +69,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  static Bitmapset *HeapDetermineColumnsInfo(Relation relation,
  										   Bitmapset *interesting_cols,
  										   Bitmapset *external_cols,
-@@ -104,6 +106,7 @@ static void index_delete_sort(TM_IndexDeleteOp *delstate);
+@@ -111,6 +113,7 @@ static void index_delete_sort(TM_IndexDeleteOp *delstate);
  static int	bottomup_sort_and_shrink(TM_IndexDeleteOp *delstate);
  static XLogRecPtr log_heap_new_cid(Relation relation, HeapTuple tup);
  static HeapTuple ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
@@ -75,18 +77,16 @@ index 0dcd6ee817e..dcf26167cae 100644
  										bool *copy);
  
  
-@@ -3016,8 +3019,8 @@ l1:
- 	 * Compute replica identity tuple before entering the critical section so
+@@ -3009,7 +3012,7 @@ l1:
  	 * we don't PANIC upon a memory allocation failure.
  	 */
--	old_key_tuple = walLogical ?
+ 	old_key_tuple = walLogical ?
 -		ExtractReplicaIdentity(relation, &tp, true, &old_key_copied) : NULL;
-+	old_key_tuple = walLogical ?
 +		ExtractReplicaIdentity(relation, &tp, true, NULL, &old_key_copied) : NULL;
  
  	/*
  	 * If this is the first possibly-multixact-able operation in the current
-@@ -3249,6 +3252,7 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
+@@ -3277,6 +3280,7 @@ heap_update(Relation relation, const ItemPointerData *otid, HeapTuple newtup,
  	Bitmapset  *id_attrs;
  	Bitmapset  *interesting_attrs;
  	Bitmapset  *modified_attrs;
@@ -94,7 +94,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	ItemId		lp;
  	HeapTupleData oldtup;
  	HeapTuple	heaptup;
-@@ -3419,6 +3423,12 @@ heap_update(Relation relation, ItemPointer otid, HeapTuple newtup,
+@@ -3453,6 +3457,12 @@ heap_update(Relation relation, const ItemPointerData *otid, HeapTuple newtup,
  											  id_attrs, &oldtup,
  											  newtup, &id_has_external);
  
@@ -107,7 +107,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	/*
  	 * If we're not updating any "key" column, we can grab a weaker lock type.
  	 * This allows for more concurrency when we are running simultaneously
-@@ -3692,6 +3702,7 @@ l2:
+@@ -3726,6 +3736,7 @@ l2:
  		bms_free(key_attrs);
  		bms_free(id_attrs);
  		bms_free(modified_attrs);
@@ -115,15 +115,15 @@ index 0dcd6ee817e..dcf26167cae 100644
  		bms_free(interesting_attrs);
  		return result;
  	}
-@@ -4041,6 +4052,7 @@ l2:
+@@ -4098,6 +4109,7 @@ l2:
  	old_key_tuple = ExtractReplicaIdentity(relation, &oldtup,
  										   bms_overlap(modified_attrs, id_attrs) ||
  										   id_has_external,
 +										   logged_old_attrs,
  										   &old_key_copied);
  
- 	/* NO EREPORT(ERROR) from here till changes are logged */
-@@ -4207,6 +4219,7 @@ l2:
+ 	clear_all_visible = PageIsAllVisible(page);
+@@ -4363,6 +4375,7 @@ l2:
  	bms_free(key_attrs);
  	bms_free(id_attrs);
  	bms_free(modified_attrs);
@@ -131,7 +131,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	bms_free(interesting_attrs);
  
  	return TM_Ok;
-@@ -4379,6 +4392,26 @@ heap_attr_equals(TupleDesc tupdesc, int attrnum, Datum value1, Datum value2,
+@@ -4535,6 +4548,26 @@ heap_attr_equals(TupleDesc tupdesc, int attrnum, Datum value1, Datum value2,
  	}
  }
  
@@ -158,7 +158,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  /*
   * Check which columns are being updated.
   *
-@@ -9132,6 +9165,7 @@ log_heap_new_cid(Relation relation, HeapTuple tup)
+@@ -9335,6 +9368,7 @@ log_heap_new_cid(Relation relation, HeapTuple tup)
   */
  static HeapTuple
  ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
@@ -166,7 +166,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  					   bool *copy)
  {
  	TupleDesc	desc = RelationGetDescr(relation);
-@@ -9164,13 +9198,16 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
+@@ -9367,13 +9401,16 @@ ExtractReplicaIdentity(Relation relation, HeapTuple tp, bool key_required,
  	}
  
  	/* if the key isn't required and we're only logging the key, we're done */
@@ -185,7 +185,7 @@ index 0dcd6ee817e..dcf26167cae 100644
  	 * If there's no defined replica identity columns, treat as !key_required.
  	 * (This case should not be reachable from heap_update, since that should
 diff --git a/src/include/utils/attoptcache.h b/src/include/utils/attoptcache.h
-index f684a772af5..6c965fede13 100644
+index 172055f..a896f60 100644
 --- a/src/include/utils/attoptcache.h
 +++ b/src/include/utils/attoptcache.h
 @@ -21,6 +21,8 @@ typedef struct AttributeOpts

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -1573,7 +1573,7 @@ spock_sync_subscription(SpockSubscription *sub)
 			savecxt = MemoryContextSwitchTo(myctx);
 			edata = CopyErrorData();
 
-			FlushErrorState();
+			/* Do NOT call FlushErrorState() here. */
 			elog(LOG, "SPOCK cswp error sub=%s slot=%s: %s",
 				 sub->name, sub->slot_name,
 				 edata->message ? edata->message : "");

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -84,7 +84,11 @@ EOF
 		echo "ERROR: could not run postgres --describe-config"
 		exit 1
 	fi
-	if printf '%s\n' "${described}" | grep -q '^output_plugin_libraries'; then
+	# Here-string rather than `printf ... | grep -q`: grep -q exits at the
+	# first match, printf takes EPIPE on the rest of the listing, and under
+	# `set -o pipefail` the pipeline then fails -- reporting "GUC absent"
+	# exactly when it is present.
+	if grep -q '^output_plugin_libraries' <<<"${described}"; then
 		cat >> "${PGDATA}/postgresql.conf" <<EOF
 output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
 EOF

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -77,6 +77,19 @@ spock.conflict_resolution = 'last_update_wins'
 spock.save_resolutions = 'on'
 EOF
 
+	# Adjust spock settings to satisfy security fix (commit 2a29b607dbb).
+	# A probe that cannot run is a broken image, not an old server; failing
+	# here beats a slot creation error once the cluster is being wired up.
+	if ! described="$(postgres --describe-config 2>/dev/null)"; then
+		echo "ERROR: could not run postgres --describe-config"
+		exit 1
+	fi
+	if printf '%s\n' "${described}" | grep -q '^output_plugin_libraries'; then
+		cat >> "${PGDATA}/postgresql.conf" <<EOF
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+EOF
+	fi
+
 	# Configure client authentication for Docker network
 	cat >> "${PGDATA}/pg_hba.conf" <<EOF
 # Allow connections from Docker network (all containers)

--- a/tests/regress/regress-output-plugin.conf
+++ b/tests/regress/regress-output-plugin.conf
@@ -1,0 +1,14 @@
+# Configuration layered on top of regress-postgresql.conf, used only when the
+# server understands output_plugin_libraries.  Kept in a separate file because
+# on servers predating that GUC an unrecognised parameter in postgresql.conf
+# stops the postmaster from starting at all.
+
+# The security fix in commit 2a29b607dbb (shipped in the 2026 minor releases
+# and in PG19) stops a replication slot naming a library as its output plugin
+# unless output_plugin_libraries lists that library.  The default is
+# 'pgoutput, test_decoding', which excludes spock_output, so without this every
+# slot creation fails with
+#   ERROR: library "spock_output" may not be used as an output plugin
+# and no subscription ever syncs.  The core defaults are kept alongside
+# spock_output so nothing relying on them changes behaviour.
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'

--- a/tests/run-single-pg18-installcheck.sh
+++ b/tests/run-single-pg18-installcheck.sh
@@ -424,6 +424,21 @@ init_node() {
 		spock.allow_ddl_from_functions = on
 	EOF
 
+	# Commit 2a29b607dbb requires Spock to be in the output_plugin_libraries.
+	# Absent on servers predating that fix, where writing an unrecognised
+	# parameter would stop the postmaster starting -- so probe rather than
+	# test the major version.  A probe that cannot run is a broken install,
+	# not an old server: fail here rather than let it become a slot creation
+	# failure once the mesh is being wired up.
+	local described
+	described="$("${PREFIX}/bin/postgres" --describe-config 2>/dev/null)" \
+		|| fail "pg${PG_VER}: could not run postgres --describe-config" 5
+	if printf '%s\n' "${described}" | grep -q '^output_plugin_libraries'; then
+		cat >>"${data}/postgresql.conf" <<-EOF
+			output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+		EOF
+	fi
+
 	# Trust on the shared Unix socket; no TCP listener so this is local-only.
 	cat >>"${data}/pg_hba.conf" <<-EOF
 		local all all trust

--- a/tests/run-single-pg18-installcheck.sh
+++ b/tests/run-single-pg18-installcheck.sh
@@ -130,7 +130,24 @@ run_phase() {
 	local logf="${LOG_DIR}/${label}-${phase}.log"
 	log "${label}: [${phase}] start  -> ${logf}"
 	local rc=0
-	"$@" >"${logf}" 2>&1 || rc=$?
+
+	# Run the phase in a standalone subshell that re-arms errexit rather than
+	# as `"$@" || rc=$?`.  A command that is part of an AND-OR list has
+	# errexit suppressed for its whole body, so a multi-command phase carried
+	# on past a failure and reported the status of its *last* command as the
+	# phase result: _do_patch_pg ran every remaining `git apply` after one had
+	# failed and still returned 0, because its last command is a `touch`.
+	# That turned a rejected patch into a "pg-patch ok" line and surfaced two
+	# minutes later as a compile error about a missing struct member.
+	#
+	# `( set -e; "$@" )` alone does not help -- the suppression propagates
+	# into a subshell that is itself part of an AND-OR list -- so errexit is
+	# disabled around a subshell that is not.
+	set +e
+	( set -e; "$@" ) >"${logf}" 2>&1
+	rc=$?
+	set -e
+
 	if [ "${rc}" -ne 0 ]; then
 		log "${label}: [${phase}] FAILED rc=${rc}  (see ${logf})"
 		say "${label}: ${phase} FAILED rc=${rc}  (see ${logf})"
@@ -304,7 +321,14 @@ _do_patch_pg() {
 		[ -f "${p}" ] || continue
 		any=1
 		echo "----- applying $(basename "${p}") -----"
-		( cd "${SRC}" && git apply --whitespace=nowarn -p1 "${p}" )
+		# Checked explicitly rather than left to errexit: a rejected patch
+		# must stop the phase here, with the culprit named, and must leave
+		# the marker below unwritten -- otherwise a cached source tree is
+		# treated as patched on every later run and only --force recovers.
+		if ! ( cd "${SRC}" && git apply --whitespace=nowarn -p1 "${p}" ); then
+			echo "----- FAILED to apply $(basename "${p}") -----"
+			return 1
+		fi
 	done
 	if [ "${any}" -eq 0 ]; then
 		echo "no .diff/.patch files in ${patch_dir}"
@@ -433,7 +457,13 @@ init_node() {
 	local described
 	described="$("${PREFIX}/bin/postgres" --describe-config 2>/dev/null)" \
 		|| fail "pg${PG_VER}: could not run postgres --describe-config" 5
-	if printf '%s\n' "${described}" | grep -q '^output_plugin_libraries'; then
+	# Matched with a here-string, not `printf ... | grep -q`: grep -q exits at
+	# the first match, so printf takes EPIPE on the rest of the ~60kB listing,
+	# and under `set -o pipefail` that makes the whole pipeline fail.  The
+	# probe then reported "GUC absent" precisely when the GUC was present --
+	# only on servers whose listing exceeds the pipe buffer, which is why it
+	# passed locally and failed in CI against an --enable-cassert build.
+	if grep -q '^output_plugin_libraries' <<<"${described}"; then
 		cat >>"${data}/postgresql.conf" <<-EOF
 			output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
 		EOF

--- a/tests/tap/t/009_zodan_add_remove_nodes.pl
+++ b/tests/tap/t/009_zodan_add_remove_nodes.pl
@@ -3,7 +3,7 @@ use warnings;
 use Test::More tests => 43;  # Fixed test count to match actual tests
 use lib '.';
 use lib 't';
-use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe);
+use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe output_plugin_libraries_conf);
 
 # =============================================================================
 # Test: 009_zodan_add_remove_nodes.pl - Test Zodan Node Addition and Removal
@@ -127,6 +127,7 @@ if (-f 'regress-pg_hba.conf') {
 open(my $conf, '>>', "$n3_datadir/postgresql.conf") or die "Cannot open config file: $!";
 print $conf "shared_buffers=1GB\n";
 print $conf "shared_preload_libraries='spock'\n";
+print $conf output_plugin_libraries_conf();
 print $conf "wal_level=logical\n";
 print $conf "spock.enable_ddl_replication=on\n";
 print $conf "spock.include_ddl_repset=on\n";

--- a/tests/tap/t/010_zodan_add_remove_python.pl
+++ b/tests/tap/t/010_zodan_add_remove_python.pl
@@ -3,7 +3,7 @@ use warnings;
 use Test::More tests => 35;  # Fixed test count to match actual tests
 use lib '.';
 use lib 't';
-use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe);
+use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe output_plugin_libraries_conf);
 
 # ==============================================================================================
 # Test: 010_zodan_add_remove_python.pl - Test Zodan Node Addition and Removal for python version
@@ -109,6 +109,7 @@ if (-f 'regress-pg_hba.conf') {
 open(my $conf, '>>', "$n3_datadir/postgresql.conf") or die "Cannot open config file: $!";
 print $conf "shared_buffers=1GB\n";
 print $conf "shared_preload_libraries='spock'\n";
+print $conf output_plugin_libraries_conf();
 print $conf "wal_level=logical\n";
 print $conf "spock.enable_ddl_replication=on\n";
 print $conf "spock.include_ddl_repset=on\n";

--- a/tests/tap/t/018_upgrade_schema_match.pl
+++ b/tests/tap/t/018_upgrade_schema_match.pl
@@ -6,7 +6,7 @@ use Cwd qw(getcwd);
 
 use lib '.';
 use lib 't';
-use SpockTest qw(system_or_bail system_maybe wait_for_pg_ready psql_or_bail scalar_query);
+use SpockTest qw(system_or_bail system_maybe wait_for_pg_ready psql_or_bail scalar_query output_plugin_libraries_conf);
 
 # =============================================================================
 # Test: 018_upgrade_schema_match.pl
@@ -268,6 +268,19 @@ sub init_and_start_node {
         shared_preload_libraries => "'spock'",
         log_min_messages         => 'warning',
     );
+
+    # A server carrying the output_plugin_libraries security fix will not let a
+    # slot name spock_output until the GUC lists it; see
+    # SpockTest::output_plugin_libraries_conf.  Each Spock version under test
+    # has its own PostgreSQL install, and PG_TAG defaults to a release that
+    # predates the fix, so probe this install's binaries -- not whichever
+    # happens to be first on PATH -- and expect '' to be a normal answer.
+    my $opl = output_plugin_libraries_conf($pg_bin);
+    if ($opl ne '') {
+        open my $fh, '>>', "$datadir/postgresql.conf" or die $!;
+        print $fh $opl;
+        close $fh;
+    }
 
     _start_postgres($pg_bin, $datadir);
     return wait_for_pg_ready($HOST, $port, $PG_BIN, 30);

--- a/tests/tap/t/SpockTest.pm
+++ b/tests/tap/t/SpockTest.pm
@@ -24,6 +24,7 @@ our @EXPORT_OK = qw(
     wait_for_exception_log
     wait_for_pg_ready
     ensure_lolor
+    output_plugin_libraries_conf
 );
 
 # Test configuration
@@ -168,6 +169,41 @@ sub ensure_lolor {
     return ($sharedir && -f "$sharedir/extension/lolor.control") ? 1 : 0;
 }
 
+# Return the output_plugin_libraries line a node needs, or '' if the server
+# does not have that GUC (to satisfy security fix 2a29b607dbb).
+#
+# The GUC is absent from servers predating the fix, and an unrecognised
+# parameter in postgresql.conf stops the postmaster from starting at all.
+# A bindir is taken as an argument because the upgrade tests run against more
+# than one installation.
+#
+# A probe that cannot run at all is a broken install, not an old server, and
+# must not be mistaken for one: returning '' there would omit the setting and
+# turn the failure into a slot creation error thirty seconds later, in another
+# test file.  Die instead.  The answer is per-bindir invariant, so cache it --
+# create_postgresql_conf() runs once per node.
+my %output_plugin_libraries_cache;
+
+sub output_plugin_libraries_conf {
+    my ($pg_bin) = @_;
+    $pg_bin = $PG_BIN unless defined $pg_bin && length $pg_bin;
+
+    return $output_plugin_libraries_cache{$pg_bin}
+        if exists $output_plugin_libraries_cache{$pg_bin};
+
+    my $described = `"$pg_bin/postgres" --describe-config 2>/dev/null`;
+    die "could not run $pg_bin/postgres --describe-config (wait status $?)\n"
+        if $? != 0;
+
+    # Core's defaults are kept alongside spock_output so nothing relying on
+    # them changes behaviour.
+    my $line = $described =~ /^output_plugin_libraries\b/m
+        ? "output_plugin_libraries='pgoutput, test_decoding, spock_output'\n"
+        : '';
+
+    return $output_plugin_libraries_cache{$pg_bin} = $line;
+}
+
 # Create PostgreSQL configuration file
 sub create_postgresql_conf {
     my ($datadir, $port) = @_;
@@ -175,6 +211,7 @@ sub create_postgresql_conf {
     open(my $conf, '>>', "$datadir/postgresql.conf") or die "Cannot open config file: $!";
     print $conf "shared_buffers=1GB\n";
     print $conf "shared_preload_libraries='spock'\n";
+    print $conf output_plugin_libraries_conf($PG_BIN);
     print $conf "wal_level=logical\n";
     print $conf "spock.enable_ddl_replication=on\n";
     print $conf "spock.include_ddl_repset=on\n";


### PR DESCRIPTION
According to the security fix (commit 2a29b607dbb) it is mandatory for replication plugins that are intended to create replication slots to be in this list.

Also, quick fix:
Do not flush the error state before re-throwing in the sync worker

The PG_CATCH around spock_create_slot_and_read_progress() called FlushErrorState() and then PG_RE_THROW().  Flushing resets errordata_stack_depth to -1, so the re-thrown error arrived at the outer handler with an empty stack and CHECK_STACK_DEPTH() replaced it with the internal "errstart was not called".