### PR TITLE
docs: document output_plugin_libraries requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,6 @@ Modify the `postgresql.conf` file, adding:
 
 PostgreSQL 15.19, 16.15, 17.11, 18.6, and 19 (and their later minor releases) require every logical decoding output plugin to be named in the `output_plugin_libraries` parameter before it can be used. Spock decodes with the `spock_output` plugin, so `spock_output` must appear in this list on every node, or slot creation fails with `library "spock_output" may not be used as an output plugin`.
 
-The value must be *additive*: the built-in default is `'pgoutput, test_decoding'`, so keep those entries alongside `spock_output`. Setting the parameter to `spock_output` alone disables the built-in plugins.
-
 You'll also want to enable automatic ddl replication on each node; add these GUCs to the `postgresql.conf` file as well:
 
     spock.enable_ddl_replication=on

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ Modify the `postgresql.conf` file, adding:
     max_wal_senders = 10        # one per node needed on provider node
     shared_preload_libraries = 'spock'
     track_commit_timestamp = on # needed for conflict resolution
+    output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+                                # required on newer Postgres versions; must be additive
+
+PostgreSQL 15.19, 16.15, 17.11, 18.6, and 19 (and their later minor releases) require every logical decoding output plugin to be named in the `output_plugin_libraries` parameter before it can be used. Spock decodes with the `spock_output` plugin, so `spock_output` must appear in this list on every node, or slot creation fails with `library "spock_output" may not be used as an output plugin`.
+
+The value must be *additive*: the built-in default is `'pgoutput, test_decoding'`, so keep those entries alongside `spock_output`. Setting the parameter to `spock_output` alone disables the built-in plugins.
 
 You'll also want to enable automatic ddl replication on each node; add these GUCs to the `postgresql.conf` file as well:
 


### PR DESCRIPTION
PostgreSQL 15.19, 16.15, 17.11, 18.6, and 19 require logical decoding output plugins to be named in the new output_plugin_libraries parameter before they can be used. Slot creation with Spock's spock_output plugin fails with 'library "spock_output" may not be used as an output plugin' unless it is added to that list.

Add the setting to the postgresql.conf example block and explain that the value must be additive, since replacing the built-in default of 'pgoutput, test_decoding' disables the built-in plugins.