### PR TITLE
Adapt the test suites to output_plugin_libraries, and document it (v5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,26 @@ _regress=$(patsubst %/,%,$(srcdir))/tests/regress
 REGRESS_OPTS += --dbname=regression \
 				--bindir=$(shell $(PG_CONFIG) --bindir) \
 				--inputdir=$(abspath $(_regress))
+
+# Servers carrying the output_plugin_libraries security fix (commit 2a29b607dbb)
+# refuse to let a slot name spock_output as its output plugin until the GUC
+# lists it, so the setting is layered in from a separate file.
+#
+# The fix shipped in minor releases of every supported major as well as in
+# PG19, so the major version says nothing about whether the GUC is there;
+# ask the server binary instead.  --describe-config needs no data directory.
+# An empty answer (probe failed, or server predates the fix) leaves the
+# setting out, which is required -- an unrecognised parameter would stop the
+# postmaster from starting.  pg_regress appends each --temp-config in order.
+#
+# Deferred (=, not :=) on purpose: the probe then runs only when regresscheck
+# expands it.  An immediate assignment forks pg_config and postgres during
+# Makefile parse, on every invocation -- make, make install, make clean, and
+# each recursive one -- to compute something only this one recipe reads.
+_regress_output_plugin_config = $(shell \
+	"$$($(PG_CONFIG) --bindir)/postgres" --describe-config 2>/dev/null \
+	| grep -q '^output_plugin_libraries' \
+	&& echo --temp-config $(_regress)/regress-output-plugin.conf)
 pg_regress_clean_files = $(_regress)/results $(_regress)/regression_output \
 			$(_regress)/regression.diffs $(_regress)/regression.out $(_regress)/tmp_check/ \
 			$(_regress)/tmp_check_iso/ $(_regress)/log/ $(_regress)/output_iso/
@@ -94,6 +114,7 @@ regresscheck:
 	$(MKDIR_P) $(_regress)/regression_output
 	$(pg_regress_check) $(REGRESS_OPTS) \
 	    --temp-config $(_regress)/regress-postgresql.conf \
+	    $(_regress_output_plugin_config) \
 	    --temp-instance=$(_regress)/tmp_check \
 	    --outputdir=$(_regress)/regression_output \
 	    --create-role=logical \

--- a/README.md
+++ b/README.md
@@ -132,7 +132,17 @@ You will need to build the Spock extension on a patched PostgreSQL source tree t
    ```bash
    shared_preload_libraries = 'spock'
    track_commit_timestamp = on # needed for conflict resolution
+   output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
    ```
+
+   Set `output_plugin_libraries` only if your server has that parameter: it was
+   added by a 2026 security fix (CVE-2026-6471), and unless `spock_output` is
+   listed there logical decoding fails with `library "spock_output" may not be
+   used as an output plugin` — on established clusters as well as new ones,
+   because the check runs every time decoding starts. On a release predating
+   the fix the parameter does not exist and setting it stops the server from
+   starting; check with
+   `SELECT current_setting('output_plugin_libraries', true)`.
 
 8. Then, connect to the server and use the `CREATE EXTENSION` command to create the spock extension on each node in the database you wish to replicate:
 
@@ -191,6 +201,14 @@ Modify the `postgresql.conf` file, adding:
     max_wal_senders = 10        # one per node needed on provider node
     shared_preload_libraries = 'spock'
     track_commit_timestamp = on # needed for conflict resolution
+    output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+
+Add `output_plugin_libraries` only on a server that has that parameter (see step
+7 of the build instructions above): it was added by a 2026 security fix, and
+unless `spock_output` is listed there logical decoding fails with `library
+"spock_output" may not be used as an output plugin`. Set it on every node,
+physical standbys included — see
+[Configuring Spock](docs/configuring.md).
 
 You'll also want to enable automatic ddl replication on each node; add these GUCs to the `postgresql.conf` file as well:
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -11,7 +11,42 @@ max_replication_slots = 10  # one per node needed on provider node
 max_wal_senders = 10        # one per node needed on provider node
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+                            # only on servers that have this parameter; see below
 ```
+
+!!! warning "`output_plugin_libraries`"
+
+    A 2026 PostgreSQL security fix (CVE-2026-6471, back-patched to every
+    supported major) added the `output_plugin_libraries` parameter, and a
+    library may no longer be used as an output plugin unless it is listed
+    there. Its default, `'pgoutput, test_decoding'`, does not include
+    `spock_output`, so on such a server logical decoding fails with:
+
+    ```
+    ERROR:  library "spock_output" may not be used as an output plugin
+    ```
+
+    The check runs every time decoding starts, not only when the slot is
+    created, so an established cluster stops replicating after a minor-version
+    upgrade too. Add `spock_output` to the list, keeping the core defaults, as
+    shown above, on every node — including standbys, which need it once
+    promoted.
+
+    Only set the parameter if your server has it. On a PostgreSQL release
+    predating the fix an unrecognised parameter in `postgresql.conf` stops the
+    server from starting at all. To check, run against a server that is up:
+
+    ```sql
+    SELECT current_setting('output_plugin_libraries', true);
+    ```
+
+    A NULL result means the parameter does not exist and must not be set. You
+    can also ask the binary, with no server running:
+
+    ```bash
+    postgres --describe-config | grep '^output_plugin_libraries'
+    ```
 
 After modifying the parameters and restarting the Postgres server with your
 OS-specific restart command, connect with psql and create the Spock

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -179,7 +179,19 @@ max_wal_senders = 10        # one per node on provider
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 listen_addresses = '*'
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
 ```
+
+!!! note
+
+    Set `output_plugin_libraries` only if your server has that parameter — it
+    was added by a 2026 security fix and, without `spock_output` listed there,
+    logical decoding fails with `library "spock_output" may not be used as an
+    output plugin`. The check runs every time decoding starts, so it stops
+    established clusters after a minor-version upgrade too, and it applies to
+    every node. On older releases the parameter does not exist and setting it
+    stops the server from starting. See
+    [Configuring Spock](configuring.md) for how to check.
 
 !!! note
 

--- a/docs/install_spock.md
+++ b/docs/install_spock.md
@@ -122,7 +122,16 @@ max_replication_slots = 10
 max_wal_senders = 10
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
 ```
+
+Set `output_plugin_libraries` only if your server has that parameter — it was
+added by a 2026 security fix and, without `spock_output` listed there, logical
+decoding fails with `library "spock_output" may not be used as an output
+plugin`. The check runs every time decoding starts, so it stops established
+clusters after a minor-version upgrade too, and it applies to every node. On
+older releases the parameter does not exist and setting it stops the server
+from starting. See [Configuring Spock](configuring.md) for how to check.
 
 Note on replication origin states:
 

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -195,6 +195,7 @@ Use Patroni 4.x, the line these instructions are written and tested against.
 | `sync_replication_slots` | `on` | dynamic config | No (reload) | PostgreSQL slotsync worker copies flagged slots to standbys |
 | `hot_standby_feedback` | `on` | dynamic config | No (reload) | Pins `catalog_xmin` so vacuum can't remove rows a slot needs |
 | `wal_level` | `logical` | dynamic config | Yes | Required for logical decoding |
+| `output_plugin_libraries` | include `spock_output` | dynamic config, **every member** | No (reload) | Only on servers that have the parameter (see note below). A synchronized slot keeps `spock_output` as its plugin, so a member missing this setting fails to serve replication once promoted |
 | `postgresql.use_slots` | `true` | Patroni config | n/a | Patroni manages the physical member slots (leave on) |
 | `max_replication_slots` / `max_wal_senders` | sized to cluster | dynamic config | Yes | Enough slots/senders for members plus Spock logical slots |
 | `synchronized_standby_slots` | standby member slot name(s) | dynamic config | No (reload) | Optional but recommended; holds the leader back until the standby confirms. See the [sharp edge](#the-switchover-sharp-edge-synchronized_standby_slots) below |
@@ -223,7 +224,24 @@ bootstrap:
         sync_replication_slots: "on"        # PG slotsync worker copies FAILOVER slots
         max_replication_slots: 10
         max_wal_senders: 10
+        # Only on servers that have this parameter -- see the note below
+        output_plugin_libraries: "pgoutput, test_decoding, spock_output"
 ```
+
+`output_plugin_libraries` arrived with PostgreSQL's 2026 security fix
+(CVE-2026-6471, back-patched to every supported major): a library may not be
+used as an output plugin unless it is listed there, and the default excludes
+`spock_output`. A synchronized slot keeps `spock_output` as its plugin, so a
+member without this setting looks healthy while it is a replica and then fails
+to serve replication the moment it is promoted — the failure surfaces during a
+switchover, which is the worst time to find it. It is `PGC_SUSET`, so Patroni
+reloads it without a restart.
+
+Do not set it on a release that predates the fix: an unrecognised parameter
+stops the server from starting, and pushing one through the DCS stops *every*
+member. Check first, on each member, with
+`SELECT current_setting('output_plugin_libraries', true)` — a NULL result means
+the parameter does not exist.
 
 `spock.use_native_failover_slots` is `PGC_POSTMASTER`. Patroni cannot reload
 it into a running server; after adding it, Patroni flags every member as

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Upgrade Notes
+* PostgreSQL's 2026 security fix for CVE-2026-6471 (back-patched to every
+  supported major) added the `output_plugin_libraries` parameter, and a library
+  may no longer be used as an output plugin unless it is listed there. Its
+  default excludes `spock_output`, so on a server carrying the fix logical
+  decoding fails with `library "spock_output" may not be used as an output
+  plugin`. The check runs whenever decoding starts, not only at slot creation,
+  so this stops an established cluster after a minor-version upgrade — not just
+  new subscriptions. Set
+  `output_plugin_libraries = 'pgoutput, test_decoding, spock_output'` on every
+  node, physical standbys included, and only on servers that have the parameter
+  — on older releases an unrecognised parameter stops the server from starting.
+  See [Configuring Spock](configuring.md).
+
 ### New Features
 * **PostgreSQL 19 support** — new `compat/19` layer and version-specific API
   adaptations (`CLUSTER` folded into `REPACK`, the recovery-conflict

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,6 +194,52 @@ After modifying `postgresql.conf`, restart PostgreSQL with this command:
 sudo systemctl restart postgresql-18
 ```
 
+### Decoding Fails on `spock_output`
+
+Replication stops — either a new subscription never leaves the initializing
+state, or an established subscription stops applying after a minor-version
+upgrade — and the provider's log records:
+
+```
+ERROR:  library "spock_output" may not be used as an output plugin
+HINT:   If it is safe for all REPLICATION users to use this library as an
+        output plugin, add it to "output_plugin_libraries" and reload the
+        server configuration.
+```
+
+A 2026 PostgreSQL security fix (CVE-2026-6471, back-patched to every supported
+major) added the `output_plugin_libraries` parameter, and a library may no
+longer be used as an output plugin unless it is listed there. The default,
+`'pgoutput, test_decoding'`, excludes `spock_output`.
+
+The check runs whenever logical decoding starts, not only when the slot is
+created, so this is not limited to new subscriptions: a cluster that has been
+replicating for months will stop the first time a walsender starts decoding
+after the upgrade. Add the library on **every** node a subscription may connect
+to — which, in a mesh, is all of them — keeping the core defaults:
+
+```sql
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+```
+
+Include physical standbys and Patroni replicas that hold synchronized failover
+slots: a copied slot keeps `spock_output` as its plugin, so a standby missing
+this setting serves replication only until it is promoted, and then fails.
+
+The parameter is `PGC_SUSET`, so `SELECT pg_reload_conf();` is enough — no
+restart needed. Re-enable the subscription afterwards if the failure had
+already disabled it.
+
+Only set the parameter if your server has it; on a release predating the fix,
+an unrecognised parameter in `postgresql.conf` stops the server from starting.
+Check with:
+
+```sql
+SELECT current_setting('output_plugin_libraries', true);
+```
+
+A NULL result means the parameter does not exist and must not be set.
+
 ### Conflict Resolution Issues
 
 If conflicts are causing replication to stop, check the conflict

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -26,6 +26,41 @@ sudo python3 setup.py install
 cd ~/pgedge
 sed -i '/log_min_messages/s/^#//g' data/pg$PGVER/postgresql.conf
 sed -i -e '/log_min_messages =/ s/= .*/= debug1/' data/pg$PGVER/postgresql.conf
+
+# Adjust spock settings to satisfy security fix (commit 2a29b607dbb): a server
+# carrying it refuses to let a slot name spock_output as its output plugin
+# until output_plugin_libraries lists the library, so every sub-create below
+# would fail with
+#   ERROR: library "spock_output" may not be used as an output plugin
+#
+# The fix shipped in minor releases of every supported major, so $PGVER says
+# nothing about whether the GUC is there; ask the server binary instead.  On a
+# server predating the fix the setting must stay out -- an unrecognised
+# parameter would stop the postmaster from starting.  A probe that cannot run
+# is a broken image, not an old server; failing here beats a slot creation
+# error once the cluster is being wired up.
+#
+# Matched with a here-string rather than `printf ... | grep -q`: grep -q exits
+# at the first match, printf takes EPIPE on the rest of the listing, and under
+# `set -o pipefail` the pipeline would then fail -- reporting "GUC absent"
+# exactly when it is present.
+if ! described="$(postgres --describe-config 2>/dev/null)"; then
+  echo "ERROR: could not run postgres --describe-config"
+  exit 1
+fi
+#
+# Appended only once: unlike the sed edits above this is not idempotent, and
+# the entrypoint runs again on every container start against a data directory
+# that persists.
+if grep -q '^output_plugin_libraries' <<<"${described}" &&
+	! grep -q '^output_plugin_libraries' data/pg$PGVER/postgresql.conf; then
+  # The core defaults are kept alongside spock_output so nothing relying on
+  # them changes behaviour.
+  cat >> data/pg$PGVER/postgresql.conf <<EOF
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'
+EOF
+fi
+
 ./pgedge restart
 
 wait_for_pg

--- a/tests/regress/regress-output-plugin.conf
+++ b/tests/regress/regress-output-plugin.conf
@@ -1,0 +1,14 @@
+# Configuration layered on top of regress-postgresql.conf, used only when the
+# server understands output_plugin_libraries.  Kept in a separate file because
+# on servers predating that GUC an unrecognised parameter in postgresql.conf
+# stops the postmaster from starting at all.
+
+# The security fix in commit 2a29b607dbb (shipped in the 2026 minor releases
+# and in PG19) stops a replication slot naming a library as its output plugin
+# unless output_plugin_libraries lists that library.  The default is
+# 'pgoutput, test_decoding', which excludes spock_output, so without this every
+# slot creation fails with
+#   ERROR: library "spock_output" may not be used as an output plugin
+# and no subscription ever syncs.  The core defaults are kept alongside
+# spock_output so nothing relying on them changes behaviour.
+output_plugin_libraries = 'pgoutput, test_decoding, spock_output'

--- a/tests/tap/t/009_zodan_add_remove_nodes.pl
+++ b/tests/tap/t/009_zodan_add_remove_nodes.pl
@@ -3,7 +3,7 @@ use warnings;
 use Test::More tests => 43;  # Fixed test count to match actual tests
 use lib '.';
 use lib 't';
-use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe);
+use SpockTest qw(create_cluster destroy_cluster system_or_bail command_ok get_test_config cross_wire system_maybe output_plugin_libraries_conf);
 
 # =============================================================================
 # Test: 009_zodan_add_remove_nodes.pl - Test Zodan Node Addition and Removal
@@ -126,6 +126,7 @@ if (-f 'regress-pg_hba.conf') {
 open(my $conf, '>>', "$n3_datadir/postgresql.conf") or die "Cannot open config file: $!";
 print $conf "shared_buffers=1GB\n";
 print $conf "shared_preload_libraries='spock'\n";
+print $conf output_plugin_libraries_conf();
 print $conf "wal_level=logical\n";
 print $conf "spock.enable_ddl_replication=on\n";
 print $conf "spock.include_ddl_repset=on\n";

--- a/tests/tap/t/016_sub_disable_missing_relation.pl
+++ b/tests/tap/t/016_sub_disable_missing_relation.pl
@@ -9,6 +9,24 @@ use SpockTest qw(
     wait_for_sub_status wait_for_exception_log wait_for_pg_ready
 );
 
+# Poll $check once a second for up to $timeout seconds, returning true as soon
+# as it succeeds.  Used in place of sleep() wherever the wait is on an apply
+# worker respawn: sub_enable() SIGTERMs the running worker and the manager only
+# re-registers it spock.restart_delay_default (5s) later, so no fixed sleep is
+# reliably longer than the wait -- one of exactly 5s races the respawn and can
+# lose by a millisecond.
+sub wait_for
+{
+	my ($timeout, $check) = @_;
+
+	for (my $i = 0; $i < $timeout; $i++)
+	{
+		return 1 if $check->();
+		sleep(1);
+	}
+	return 0;
+}
+
 # =============================================================================
 # Test 016: SUB_DISABLE on missing relation + skip_lsn recovery
 #           + regression: dangling local_tuple after conflict
@@ -106,14 +124,25 @@ ok(wait_for_sub_status(2, 'sub_n1_n2', 'replicating', 30),
     'P1: sub_n1_n2 returns to replicating state after recovery');
 
 psql_or_bail(1, "INSERT INTO test_missing_rel (val) VALUES ('post_recovery_row')");
-sleep(5);
-my $post_count = scalar_query(2, "SELECT count(*) FROM test_missing_rel");
-cmp_ok($post_count, '>=', '1', 'P1: post-recovery INSERT replicates to n2');
 
-sleep(3);
-my $worker_alive = scalar_query(2,
-    "SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE 'spock apply%'");
-cmp_ok($worker_alive, '>=', '1', 'P1: apply worker still running after re-enable');
+my $post_count = 0;
+my $post_replicated = wait_for(30, sub {
+    $post_count = scalar_query(2, "SELECT count(*) FROM test_missing_rel");
+    $post_count =~ s/\s+//g;
+    return $post_count >= 1;
+});
+ok($post_replicated,
+    "P1: post-recovery INSERT replicates to n2 (count=$post_count)");
+
+my $worker_alive = 0;
+my $worker_running = wait_for(30, sub {
+    $worker_alive = scalar_query(2,
+        "SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE 'spock apply%'");
+    $worker_alive =~ s/\s+//g;
+    return $worker_alive >= 1;
+});
+ok($worker_running,
+    "P1: apply worker still running after re-enable (count=$worker_alive)");
 
 my $still_enabled = scalar_query(2,
     "SELECT sub_enabled FROM spock.subscription WHERE sub_name = 'sub_n1_n2'");

--- a/tests/tap/t/SpockTest.pm
+++ b/tests/tap/t/SpockTest.pm
@@ -23,6 +23,7 @@ our @EXPORT_OK = qw(
     wait_for_sub_status
     wait_for_exception_log
     wait_for_pg_ready
+    output_plugin_libraries_conf
 );
 
 # Test configuration
@@ -149,6 +150,41 @@ sub system_maybe {
     return $rc == 0;
 }
 
+# Return the output_plugin_libraries line a node needs, or '' if the server
+# does not have that GUC (to satisfy security fix 2a29b607dbb).
+#
+# The GUC is absent from servers predating the fix, and an unrecognised
+# parameter in postgresql.conf stops the postmaster from starting at all.
+# A bindir is taken as an argument because a caller may be configuring a node
+# that belongs to some other installation than the one first on PATH.
+#
+# A probe that cannot run at all is a broken install, not an old server, and
+# must not be mistaken for one: returning '' there would omit the setting and
+# turn the failure into a slot creation error thirty seconds later, in another
+# test file.  Die instead.  The answer is per-bindir invariant, so cache it --
+# create_postgresql_conf() runs once per node.
+my %output_plugin_libraries_cache;
+
+sub output_plugin_libraries_conf {
+    my ($pg_bin) = @_;
+    $pg_bin = $PG_BIN unless defined $pg_bin && length $pg_bin;
+
+    return $output_plugin_libraries_cache{$pg_bin}
+        if exists $output_plugin_libraries_cache{$pg_bin};
+
+    my $described = `"$pg_bin/postgres" --describe-config 2>/dev/null`;
+    die "could not run $pg_bin/postgres --describe-config (wait status $?)\n"
+        if $? != 0;
+
+    # Core's defaults are kept alongside spock_output so nothing relying on
+    # them changes behaviour.
+    my $line = $described =~ /^output_plugin_libraries\b/m
+        ? "output_plugin_libraries='pgoutput, test_decoding, spock_output'\n"
+        : '';
+
+    return $output_plugin_libraries_cache{$pg_bin} = $line;
+}
+
 # Create PostgreSQL configuration file
 sub create_postgresql_conf {
     my ($datadir, $port) = @_;
@@ -156,6 +192,7 @@ sub create_postgresql_conf {
     open(my $conf, '>>', "$datadir/postgresql.conf") or die "Cannot open config file: $!";
     print $conf "shared_buffers=1GB\n";
     print $conf "shared_preload_libraries='spock'\n";
+    print $conf output_plugin_libraries_conf($PG_BIN);
     print $conf "wal_level=logical\n";
     print $conf "spock.enable_ddl_replication=on\n";
     print $conf "spock.include_ddl_repset=on\n";


### PR DESCRIPTION
PostgreSQL's fix for CVE-2026-6471 (commit 2a29b607dbb, back-patched through PG14) added the `output_plugin_libraries` GUC: a library may no longer be used as an output plugin unless it is listed there.

The check lives in `StartupDecodingContext()`, which both slot creation and `START_REPLICATION` reach, so this is not confined to new subscriptions. Two consequences: the regression and TAP suites fail wholesale against current minors of every supported major — which is what `pg-stable-test.yml` builds — and an established cluster stops replicating the first time a walsender starts decoding after a minor-version upgrade.

The GUC cannot simply be added to the test configs: on a server predating the fix an unrecognised parameter in `postgresql.conf` stops the postmaster from starting, and the fix shipped in *minor* releases, so the major version says nothing about whether the GUC is there. Every harness probes `postgres --describe-config` instead, and keeps the core defaults alongside `spock_output` so nothing relying on them changes behaviour.

### Back-ported from #572
* **`Makefile` + `tests/regress/regress-output-plugin.conf`** — `regresscheck`  layers the setting in as a second `--temp-config`, computed lazily (`=`, not  `:=`) so the probe runs only when that recipe expands, not on every `make`.
* **`tests/tap/t/SpockTest.pm`** — `output_plugin_libraries_conf()`, cached per  bindir, called from `create_postgresql_conf()`. Dies rather than reporting  "GUC absent" if the probe cannot run at all, so a broken install does not  resurface as a slot error in an unrelated test file.
* **`tests/tap/t/009_zodan_add_remove_nodes.pl`** — the same line for the n3  node it `initdb`s by hand. The only v5 TAP test that builds a node outside  `create_cluster`; standbys in `018`/`020` inherit the primary's conf via  basebackup, and `013`/`104` only append GUCs to already-configured nodes.

### v5-specific adaptations (not in #572)
* **`tests/docker/entrypoint.sh`** — rewritten rather than picked: v5's entrypoint is the pgEdge-CLI variant that edits `data/pg$PGVER/postgresql.conf`  in place, structurally unrelated to main's initdb-based one. It also appends
  only when the setting is absent — unlike the `sed` edits beside it, `cat >>`  is not idempotent and the entrypoint runs again on every container start.
* `tests/run-single-pg18-installcheck.sh`, `010_zodan_add_remove_python.pl`  and `018_upgrade_schema_match.pl` do not exist on this branch, so their hunks were dropped.
