### PR TITLE
repset_add_all_tables(): skip what cannot be replicated instead of failing

### DIFF
--- a/docs/spock_functions/functions/spock_repset_add_all_tables.md
+++ b/docs/spock_functions/functions/spock_repset_add_all_tables.md
@@ -23,8 +23,12 @@ specified replication set. Only tables that exist at the time of execution
 are added; tables created afterward must be added separately using
 spock.repset_add_table().
 
-A table that the replication set cannot replicate is skipped and reported with a
-WARNING naming its schema and table; the remaining tables are still added.
+A table that cannot be replicated is skipped and reported with a WARNING naming
+its schema and table; the remaining tables are still added. A table is skipped
+when the replication set replicates UPDATEs or DELETEs and the table has no
+index-based replica identity, or when the table belongs to an extension listed
+in spock.reserved_object. A schema listed in spock.reserved_object is reported
+once and passed over as a whole.
 
 A replication set that replicates UPDATEs or DELETEs has to locate the affected
 row on the subscriber, so it can only take tables with an index-based replica
@@ -36,10 +40,7 @@ replicates only INSERTs and TRUNCATEs.
 
 Unlike spock.repset_add_table(), which raises an error when the table cannot be
 replicated, this function never refuses the whole call on account of a single
-table's replica identity. It does still raise an error for problems with the
-arguments themselves — a schema that does not exist, or a schema listed in
-spock.reserved_object — and for a relation that no replication set may contain,
-such as a table belonging to a reserved extension.
+relation. A schema that does not exist is still an error.
 
 Views, materialized views, sequences, and UNLOGGED and TEMPORARY tables are not
 considered at all.

--- a/docs/spock_functions/functions/spock_repset_add_all_tables.md
+++ b/docs/spock_functions/functions/spock_repset_add_all_tables.md
@@ -9,7 +9,7 @@ synchronize_data boolean)
 
 ### RETURNS
 
-  - true if all tables were successfully added to the replication set.
+  - true if every replicatable table was added to the replication set.
 
   - false if the call has invalid parameters, insufficient privileges, or
     the operation fails.
@@ -22,6 +22,35 @@ This function registers all table objects found in the given schemas with the
 specified replication set. Only tables that exist at the time of execution
 are added; tables created afterward must be added separately using
 spock.repset_add_table().
+
+A table that the replication set cannot replicate is skipped and reported with a
+WARNING naming its schema and table; the remaining tables are still added.
+
+A replication set that replicates UPDATEs or DELETEs has to locate the affected
+row on the subscriber, so it can only take tables with an index-based replica
+identity — a PRIMARY KEY, or a unique index on NOT NULL columns nominated with
+ALTER TABLE ... REPLICA IDENTITY USING INDEX. Note that REPLICA IDENTITY FULL
+and REPLICA IDENTITY NOTHING do not qualify, even when the table has a PRIMARY
+KEY. Tables without an index-based replica identity can be added to a set that
+replicates only INSERTs and TRUNCATEs.
+
+Unlike spock.repset_add_table(), which raises an error when the table cannot be
+replicated, this function never refuses the whole call on account of a single
+table's replica identity. It does still raise an error for problems with the
+arguments themselves — a schema that does not exist, or a schema listed in
+spock.reserved_object — and for a relation that no replication set may contain,
+such as a table belonging to a reserved extension.
+
+Views, materialized views, sequences, and UNLOGGED and TEMPORARY tables are not
+considered at all.
+
+Partitioned tables and their partitions are collected independently, each in its
+own right, and each is checked separately. ALTER TABLE ... REPLICA IDENTITY does
+not cascade to partitions in any supported PostgreSQL version, so a partitioned
+table and its partitions can differ here: a partition may be skipped while its
+parent is added, or the reverse. Spock resolves replication set membership per
+relation, so a skipped partition means changes to the rows stored in that
+partition are not replicated, even when the parent is a member.
 
 The synchronize_data parameter controls whether existing table data is
 immediately synchronized to subscribers. When set to true, a full table copy

--- a/include/spock_repset.h
+++ b/include/spock_repset.h
@@ -70,8 +70,9 @@ extern void alter_replication_set(SpockRepSet *repset);
 extern void drop_replication_set(Oid setid);
 extern void drop_node_replication_sets(Oid nodeid);
 
-extern void replication_set_add_table(Oid setid, Oid reloid,
-									  List *att_list, Node *row_filter);
+extern bool replication_set_add_table(Oid setid, Oid reloid,
+									  List *att_list, Node *row_filter,
+									  bool skip_unreplicatable);
 extern void replication_set_add_seq(Oid setid, Oid seqoid);
 extern List *replication_set_get_tables(Oid setid);
 extern List *replication_set_get_seqs(Oid setid);

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -493,7 +493,7 @@ apply_repset_policy_for_reloid(SpockLocalNode *node, Oid reloid,
 	/* Add if not already present. */
 	if (get_table_replication_row(repset->id, reloid, NULL, NULL) == NULL)
 	{
-		replication_set_add_table(repset->id, reloid, NIL, NULL);
+		replication_set_add_table(repset->id, reloid, NIL, NULL, false);
 		elog(LOG, "table '%s' was added to '%s' replication set.",
 			 get_rel_name(reloid), repset->name);
 	}

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -26,6 +26,7 @@
 #include "access/xlogutils.h"
 
 #include "catalog/catalog.h"
+#include "catalog/dependency.h"
 #include "catalog/heap.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
@@ -36,6 +37,7 @@
 #include "commands/dbcommands.h"
 #include "commands/defrem.h"
 #include "commands/event_trigger.h"
+#include "commands/extension.h"
 #if PG_VERSION_NUM >= 180000
 #include "commands/publicationcmds.h"
 #endif
@@ -1962,18 +1964,17 @@ spock_replication_set_add_all_relations(Name repset_name,
 		HeapTuple	tuple;
 
 		/*
-		 * A schema the caller named is the caller's mistake to hear about:
-		 * scanning it could only produce a warning per relation and an empty
-		 * replication set.  A relation we merely come across inside a schema we
-		 * were told to scan is skipped with a warning instead -- errors are
-		 * about what the caller asked for, warnings about what we found.
+		 * A schema no replication set may draw from is reported once and
+		 * passed over, rather than once per relation it holds.
 		 */
 		if (spock_name_is_reserved(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_REPSET,
 								   nspname))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-					 errmsg("schema %s is excluded from replication", nspname),
+		{
+			ereport(WARNING,
+					(errmsg("skipping schema %s", nspname),
 					 errdetail("Relations of this schema cannot be added to any replication set.")));
+			continue;
+		}
 
 		ScanKeyInit(&skey[0],
 					Anum_pg_class_relnamespace,
@@ -2003,6 +2004,8 @@ spock_replication_set_add_all_relations(Name repset_name,
 				bool		ispartition;
 				bool		added;
 				Relation	targetrel;
+				Oid			extoid;
+				char	   *extname;
 
 				/*
 				 * The same schema may be named twice in nsp_names, and a second
@@ -2021,6 +2024,28 @@ spock_replication_set_add_all_relations(Name repset_name,
 				if (targetrel == NULL)
 					continue;
 				table_close(targetrel, NoLock);
+
+				/*
+				 * A relation belonging to an extension no replication set may
+				 * draw from is passed over here rather than inside the add
+				 * routines, which raise an error: a relation we merely came
+				 * across while walking a schema should not cost the caller the
+				 * rest of that schema.
+				 */
+				extoid = getExtensionOfObject(RelationRelationId, reloid);
+				extname = OidIsValid(extoid) ? get_extension_name(extoid) : NULL;
+				if (extname != NULL &&
+					spock_name_is_reserved(RESERVED_KIND_EXTENSION,
+										   RESERVED_PURPOSE_REPSET, extname))
+				{
+					ereport(WARNING,
+							(errmsg("skipping relation %s.%s",
+									nspname, NameStr(reltup->relname)),
+							 errdetail("Relation belongs to extension %s, which is excluded from replication.",
+									   extname)));
+					UnlockRelationOid(reloid, AccessShareLock);
+					continue;
+				}
 
 				if (relkind == RELKIND_RELATION || relkind == RELKIND_PARTITIONED_TABLE)
 					added = replication_set_add_table(repset->id, reloid, NIL,

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -18,6 +18,7 @@
 #include "access/htup_details.h"
 #include "access/relation.h"
 #include "access/sysattr.h"
+#include "access/table.h"
 #include "access/tupconvert.h"
 #include "access/xact.h"
 #include "access/xlog.h"
@@ -63,6 +64,7 @@
 
 #include "storage/ipc.h"
 #include "storage/latch.h"
+#include "storage/lmgr.h"
 #include "storage/proc.h"
 
 #include "tcop/tcopprot.h"
@@ -1846,7 +1848,8 @@ spock_replication_set_add_table(PG_FUNCTION_ARGS)
 	{
 		Oid			partoid = lfirst_oid(lc);
 
-		replication_set_add_table(repset->id, partoid, att_list, row_filter);
+		replication_set_add_table(repset->id, partoid, att_list, row_filter,
+								  false);
 
 		/* In case of partitions, only synchronize the parent table. */
 		if (synchronize && (partoid == reloid))
@@ -1958,6 +1961,20 @@ spock_replication_set_add_all_relations(Name repset_name,
 		SysScanDesc sysscan;
 		HeapTuple	tuple;
 
+		/*
+		 * A schema the caller named is the caller's mistake to hear about:
+		 * scanning it could only produce a warning per relation and an empty
+		 * replication set.  A relation we merely come across inside a schema we
+		 * were told to scan is skipped with a warning instead -- errors are
+		 * about what the caller asked for, warnings about what we found.
+		 */
+		if (spock_name_is_reserved(RESERVED_KIND_SCHEMA, RESERVED_PURPOSE_REPSET,
+								   nspname))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("schema %s is excluded from replication", nspname),
+					 errdetail("Relations of this schema cannot be added to any replication set.")));
+
 		ScanKeyInit(&skey[0],
 					Anum_pg_class_relnamespace,
 					BTEqualStrategyNumber, F_OIDEQ,
@@ -1984,14 +2001,47 @@ spock_replication_set_add_all_relations(Name repset_name,
 			if (!list_member_oid(existing_relations, reloid))
 			{
 				bool		ispartition;
+				bool		added;
+				Relation	targetrel;
+
+				/*
+				 * The same schema may be named twice in nsp_names, and a second
+				 * visit would try to insert a duplicate catalog row and abort
+				 * the whole call.
+				 */
+				existing_relations = lappend_oid(existing_relations, reloid);
+
+				/*
+				 * Lock the relation and confirm it is still there before we
+				 * touch it.  This scan runs on the catalog snapshot, so a DROP
+				 * TABLE that committed after it started is not reflected in the
+				 * tuple we are holding.
+				 */
+				targetrel = try_table_open(reloid, AccessShareLock);
+				if (targetrel == NULL)
+					continue;
+				table_close(targetrel, NoLock);
 
 				if (relkind == RELKIND_RELATION || relkind == RELKIND_PARTITIONED_TABLE)
-				{
-					replication_set_add_table(repset->id, reloid, NIL, NULL);
-				}
+					added = replication_set_add_table(repset->id, reloid, NIL,
+													  NULL, true);
 				else
+				{
 					/* FIXME: What happens if the id is a snowflake sequence? */
 					replication_set_add_seq(repset->id, reloid);
+					added = true;
+				}
+
+				/*
+				 * A schema full of unreplicatable tables would otherwise fill
+				 * the lock table for no benefit, and block DDL on tables we
+				 * declined to manage.
+				 */
+				if (!added)
+				{
+					UnlockRelationOid(reloid, AccessShareLock);
+					continue;
+				}
 
 				/* don't synchronize the partitions */
 				ispartition = get_rel_relispartition(reloid);
@@ -2218,7 +2268,8 @@ spock_replication_set_add_partition(PG_FUNCTION_ARGS)
 			if (get_table_replication_row(repset->id, partoid, NULL, NULL))
 				continue;
 
-			replication_set_add_table(repset->id, partoid, att_list, row_filter);
+			replication_set_add_table(repset->id, partoid, att_list, row_filter,
+									  false);
 			nrows++;
 		}
 

--- a/src/spock_repset.c
+++ b/src/spock_repset.c
@@ -1130,11 +1130,10 @@ check_relation_replicatable(Relation rel, SpockRepSet *repset,
 				 errhint("Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.")));
 
 	ereport(WARNING,
-			(errmsg("skipping table %s.%s",
+			(errmsg("skipping table %s.%s for replication set %s",
 					get_namespace_name(RelationGetNamespace(rel)),
-					RelationGetRelationName(rel)),
-			 errdetail("Table has no replica identity index, and replication set %s replicates UPDATEs or DELETEs.",
-					   repset->name),
+					RelationGetRelationName(rel), repset->name),
+			 errdetail("Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs."),
 			 errhint("Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.")));
 
 	return false;

--- a/src/spock_repset.c
+++ b/src/spock_repset.c
@@ -1092,11 +1092,67 @@ drop_node_replication_sets(Oid nodeid)
 }
 
 /*
- * Insert new replication set / table mapping.
+ * May this relation join the replication set, as far as its replica identity
+ * goes?  Reports the reason it may not, at WARNING when the caller is walking a
+ * whole schema and at ERROR when it asked for this one relation.
+ *
+ * Replicating an UPDATE or a DELETE means locating the affected row on the
+ * subscriber, which spock does through the relation's replica identity index.
+ * Note that neither REPLICA IDENTITY FULL nor REPLICA IDENTITY NOTHING yields
+ * an index, so both fail this test even when the table has a PRIMARY KEY.  A
+ * relation without an index can still belong to a set that only replicates
+ * INSERTs and TRUNCATEs.
+ *
+ * Both wordings live here, side by side, so that they cannot drift apart, and
+ * because a dynamically assembled message could not be translated.
+ *
+ * The relation must be open.
  */
-void
+static bool
+check_relation_replicatable(Relation rel, SpockRepSet *repset,
+							bool skip_unreplicatable)
+{
+	if (!repset->replicate_update && !repset->replicate_delete)
+		return true;
+
+	if (rel->rd_indexvalid == 0)
+		RelationGetIndexList(rel);
+
+	if (OidIsValid(rel->rd_replidindex))
+		return true;
+
+	if (!skip_unreplicatable)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("table %s cannot be added to replication set %s",
+						RelationGetRelationName(rel), repset->name),
+				 errdetail("Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs."),
+				 errhint("Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.")));
+
+	ereport(WARNING,
+			(errmsg("skipping table %s.%s",
+					get_namespace_name(RelationGetNamespace(rel)),
+					RelationGetRelationName(rel)),
+			 errdetail("Table has no replica identity index, and replication set %s replicates UPDATEs or DELETEs.",
+					   repset->name),
+			 errhint("Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.")));
+
+	return false;
+}
+
+/*
+ * Insert new replication set / table mapping.
+ *
+ * A relation the set cannot replicate row-by-row is normally an error.  With
+ * skip_unreplicatable set, it is reported with a warning and left out instead,
+ * which is what repset_add_all_tables() wants: one such table in a schema
+ * should not cost the caller every other table of that schema.
+ *
+ * Returns true if the mapping was created.
+ */
+bool
 replication_set_add_table(Oid setid, Oid reloid, List *att_list,
-						  Node *row_filter)
+						  Node *row_filter, bool skip_unreplicatable)
 {
 	RangeVar   *rv;
 	Relation	rel;
@@ -1128,18 +1184,17 @@ replication_set_add_table(Oid setid, Oid reloid, List *att_list,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("UNLOGGED and TEMP tables cannot be replicated")));
 
-	if (targetrel->rd_indexvalid == 0)
-		RelationGetIndexList(targetrel);
-	if (!OidIsValid(targetrel->rd_replidindex) &&
-		(repset->replicate_update || repset->replicate_delete))
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("table %s cannot be added to replication set %s",
-						RelationGetRelationName(targetrel), repset->name),
-				 errdetail("table does not have PRIMARY KEY and given "
-						   "replication set is configured to replicate "
-						   "UPDATEs and/or DELETEs"),
-				 errhint("Add a PRIMARY KEY to the table")));
+	if (!check_relation_replicatable(targetrel, repset, skip_unreplicatable))
+	{
+		/*
+		 * Caller's lock, caller's problem: we opened with NoLock if it already
+		 * held one, so releasing here would be releasing something we never
+		 * took.  Bulk callers hand the lock back themselves once we tell them
+		 * the relation is not going in.
+		 */
+		table_close(targetrel, NoLock);
+		return false;
+	}
 
 	EnsureRelationNotIgnored(targetrel);
 
@@ -1198,6 +1253,8 @@ replication_set_add_table(Oid setid, Oid reloid, List *att_list,
 	table_close(rel, RowExclusiveLock);
 
 	CommandCounterIncrement();
+
+	return true;
 }
 
 /*

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -120,8 +120,8 @@ ERROR:  table test_nopkey cannot be added to replication set repset_replicate_in
 DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
 SELECT * FROM spock.repset_add_all_tables('default', '{public}');
-WARNING:  skipping table public.test_nopkey
-DETAIL:  Table has no replica identity index, and replication set default replicates UPDATEs or DELETEs.
+WARNING:  skipping table public.test_nopkey for replication set default
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
@@ -850,17 +850,17 @@ SELECT spock.repset_create('spoc410_upd') IS NOT NULL AS created;
 
 SELECT spock.repset_add_all_tables('spoc410_upd',
 	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
-WARNING:  skipping table spoc410_r1.t_unique_no_pk
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r1.t_unique_no_pk for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
-WARNING:  skipping table spoc410_r2.t_full
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r2.t_full for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
-WARNING:  skipping table spoc410_r3.t_nothing
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r3.t_nothing for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
-WARNING:  skipping table spoc410_r4.t_no_identity
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r4.t_no_identity for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
@@ -935,17 +935,17 @@ SELECT spock.repset_add_all_tables('spoc410_ins',
 
 SELECT spock.repset_add_all_tables('spoc410_upd',
 	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
-WARNING:  skipping table spoc410_r1.t_unique_no_pk
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r1.t_unique_no_pk for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
-WARNING:  skipping table spoc410_r2.t_full
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r2.t_full for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
-WARNING:  skipping table spoc410_r3.t_nothing
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r3.t_nothing for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
-WARNING:  skipping table spoc410_r4.t_no_identity
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r4.t_no_identity for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
@@ -980,8 +980,8 @@ ALTER TABLE spoc410_r1.t_unique_no_pk
 -- still FULL, because FULL never resolves to an index.
 ALTER TABLE spoc410_r2.t_full ADD PRIMARY KEY (id);
 SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
-WARNING:  skipping table spoc410_r2.t_full
-DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_r2.t_full for replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
@@ -1070,8 +1070,8 @@ SELECT spock.repset_create('spoc410_mix_upd') IS NOT NULL AS created;
 (1 row)
 
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
-WARNING:  skipping table spoc410_mix.m_orphan
-DETAIL:  Table has no replica identity index, and replication set spoc410_mix_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_mix.m_orphan for replication set spoc410_mix_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
@@ -1091,8 +1091,8 @@ SELECT set_name, nspname, relname FROM public.spoc410_members
 -- must not report the same relation twice either.
 SELECT spock.repset_add_all_tables('spoc410_mix_upd',
 	'{spoc410_mix,spoc410_mix}');
-WARNING:  skipping table spoc410_mix.m_orphan
-DETAIL:  Table has no replica identity index, and replication set spoc410_mix_upd replicates UPDATEs or DELETEs.
+WARNING:  skipping table spoc410_mix.m_orphan for replication set spoc410_mix_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
@@ -1113,13 +1113,16 @@ SELECT spock.repset_add_table('spoc410_mix_upd', 'spoc410_mix.m_orphan');
 ERROR:  table m_orphan cannot be added to replication set spoc410_mix_upd
 DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
 HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
--- A schema that may never hold replicated relations is an error too.  The
--- caller named it, and scanning it could achieve nothing but a warning per
--- relation: errors are about what the caller asked for, warnings about what we
--- found inside a schema we were told to scan.
+-- A schema no replication set may draw from is reported once and passed over,
+-- not once per relation it holds.
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spock}');
-ERROR:  schema spock is excluded from replication
+WARNING:  skipping schema spock
 DETAIL:  Relations of this schema cannot be added to any replication set.
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
 -- The requirement belongs to the replication set, not to the routine: an
 -- INSERT-only set never has to identify a row, so m_orphan goes in too.
 SELECT spock.repset_create('spoc410_mix_ins',
@@ -1166,6 +1169,58 @@ SELECT set_name, nspname, relname FROM public.spoc410_members
  spoc410_mix_upd | spoc410_mix | m_orphan
  spoc410_mix_upd | spoc410_mix | z_pk
 (6 rows)
+
+-- Every table of the schema is replicatable by now, so the only thing the next
+-- call reports is the failure itself.  Schemas are resolved one at a time, as
+-- the loop reaches them: spoc410_mix is scanned and all of it added to the
+-- fresh set before the second name is looked up and fails.  Everything the
+-- routine writes is an ordinary catalog insert, so that work goes with it.
+SELECT spock.repset_create('spoc410_mix_err') IS NOT NULL AS created;
+ created 
+---------
+ t
+(1 row)
+
+SELECT spock.repset_add_all_tables('spoc410_mix_err',
+	'{spoc410_mix,nosuchschema}');
+ERROR:  schema "nosuchschema" does not exist
+-- ... and the set is left empty, not half full
+SELECT count(*) AS members FROM public.spoc410_members
+ WHERE set_name = 'spoc410_mix_err';
+ members 
+---------
+       0
+(1 row)
+
+-- Same for a relation of an extension no replication set may draw from.
+CREATE TABLE spoc410_mix.e_ext (id int PRIMARY KEY, payload text);
+ALTER EXTENSION spock ADD TABLE spoc410_mix.e_ext;
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
+WARNING:  skipping relation spoc410_mix.e_ext
+DETAIL:  Relation belongs to extension spock, which is excluded from replication.
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+    set_name     |   nspname   | relname  
+-----------------+-------------+----------
+ spoc410_mix_ins | spoc410_mix | a_pk
+ spoc410_mix_ins | spoc410_mix | m_orphan
+ spoc410_mix_ins | spoc410_mix | z_pk
+ spoc410_mix_upd | spoc410_mix | a_pk
+ spoc410_mix_upd | spoc410_mix | m_orphan
+ spoc410_mix_upd | spoc410_mix | z_pk
+(6 rows)
+
+ALTER EXTENSION spock DROP TABLE spoc410_mix.e_ext;
+SELECT spock.repset_drop('spoc410_mix_err');
+ repset_drop 
+-------------
+ t
+(1 row)
 
 SELECT spock.repset_drop('spoc410_mix_upd');
  repset_drop 

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -716,3 +716,359 @@ NOTICE:  drop cascades to table spoc_102l_d membership in replication set defaul
  t
 (1 row)
 
+--
+-- What does spock.repset_add_all_tables() actually collect?
+--
+\set VERBOSITY default
+CREATE SCHEMA spoc410_ok;
+CREATE SCHEMA spoc410_r1;
+CREATE SCHEMA spoc410_r2;
+CREATE SCHEMA spoc410_r3;
+CREATE SCHEMA spoc410_r4;
+-- accepted: single-column PRIMARY KEY, REPLICA IDENTITY DEFAULT
+CREATE TABLE spoc410_ok.t_pk (id int PRIMARY KEY, payload text);
+-- accepted: composite PRIMARY KEY
+CREATE TABLE spoc410_ok.t_pk_multi (a int, b text, payload text,
+	PRIMARY KEY (a, b));
+-- accepted: custom identity -- a unique index over NOT NULL columns
+CREATE TABLE spoc410_ok.t_using_index (a int NOT NULL, b int NOT NULL,
+	payload text);
+CREATE UNIQUE INDEX t_using_index_ri ON spoc410_ok.t_using_index (a, b);
+ALTER TABLE spoc410_ok.t_using_index REPLICA IDENTITY USING INDEX t_using_index_ri;
+-- accepted: the partitioned table AND every partition of it.  Partitions are
+-- plain 'r' relations, so they are collected one by one, in their own right.
+CREATE TABLE spoc410_ok.t_part (id int, ts date, PRIMARY KEY (id, ts))
+	PARTITION BY RANGE (ts);
+CREATE TABLE spoc410_ok.t_part_2025 PARTITION OF spoc410_ok.t_part
+	FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+CREATE TABLE spoc410_ok.t_part_2026 PARTITION OF spoc410_ok.t_part
+	FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+-- never collected: wrong relkind, or not permanent
+CREATE VIEW spoc410_ok.v_view AS SELECT * FROM spoc410_ok.t_pk;
+CREATE MATERIALIZED VIEW spoc410_ok.m_matview AS SELECT * FROM spoc410_ok.t_pk;
+CREATE SEQUENCE spoc410_ok.s_seq;
+CREATE UNLOGGED TABLE spoc410_ok.u_unlogged (id int PRIMARY KEY);
+-- rejected: a UNIQUE NOT NULL index is not enough, the identity is still
+-- DEFAULT and there is no PRIMARY KEY for DEFAULT to point at
+CREATE TABLE spoc410_r1.t_unique_no_pk (id int NOT NULL UNIQUE, payload text);
+-- rejected: REPLICA IDENTITY FULL is not an index
+CREATE TABLE spoc410_r2.t_full (id int NOT NULL, payload text);
+ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY FULL;
+-- rejected: PRIMARY KEY present, but the identity is switched off
+CREATE TABLE spoc410_r3.t_nothing (id int PRIMARY KEY, payload text);
+ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY NOTHING;
+-- rejected: no identity of any kind
+CREATE TABLE spoc410_r4.t_no_identity (id int, payload text);
+-- Reports the replica identity of every relation of the test schemas, plus
+-- the replication sets it belongs to.  identity_index is exactly what the
+-- relcache would put into rd_replidindex, i.e. NULL means "spock will refuse
+-- this table for an UPDATE/DELETE replicating set".
+CREATE VIEW public.spoc410_state AS
+	SELECT n.nspname, c.relname, c.relkind, c.relpersistence, c.relreplident,
+		   CASE c.relreplident
+			   WHEN 'd' THEN (SELECT i.indexrelid::regclass::text
+								FROM pg_index i
+							   WHERE i.indrelid = c.oid AND i.indisprimary)
+			   WHEN 'i' THEN (SELECT i.indexrelid::regclass::text
+								FROM pg_index i
+							   WHERE i.indrelid = c.oid AND i.indisreplident)
+		   END AS identity_index,
+		   s.set_name
+	  FROM pg_class c
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		   LEFT JOIN (SELECT t.set_reloid, r.set_name
+						FROM spock.replication_set_table t
+							 JOIN spock.replication_set r ON r.set_id = t.set_id
+							 JOIN spock.local_node l ON l.node_id = r.set_nodeid)
+			 AS s ON s.set_reloid = c.oid
+	 WHERE n.nspname LIKE 'spoc410\_%'
+	   AND c.relkind IN ('r', 'p', 'v', 'm', 'S');
+-- Calls the routine under test and reports the verdict instead of aborting
+-- the script.  The subtransaction rollback also shows that a failed call
+-- leaves the replication set exactly as it was.
+CREATE FUNCTION public.spoc410_probe(p_repset name, p_schema text)
+RETURNS text LANGUAGE plpgsql AS $$
+BEGIN
+	PERFORM spock.repset_add_all_tables(p_repset, ARRAY[p_schema]);
+	RETURN 'added';
+EXCEPTION WHEN invalid_parameter_value THEN
+	RETURN 'REJECTED: ' || SQLERRM;
+END;
+$$;
+-- Which relations repset_add_all_tables() will even consider
+SELECT nspname, relname, relkind, relpersistence,
+	   (relkind IN ('r', 'p') AND relpersistence = 'p') AS candidate
+  FROM public.spoc410_state
+ ORDER BY nspname, relname;
+  nspname   |    relname     | relkind | relpersistence | candidate 
+------------+----------------+---------+----------------+-----------
+ spoc410_ok | m_matview      | m       | p              | f
+ spoc410_ok | s_seq          | S       | p              | f
+ spoc410_ok | t_part         | p       | p              | t
+ spoc410_ok | t_part_2025    | r       | p              | t
+ spoc410_ok | t_part_2026    | r       | p              | t
+ spoc410_ok | t_pk           | r       | p              | t
+ spoc410_ok | t_pk_multi     | r       | p              | t
+ spoc410_ok | t_using_index  | r       | p              | t
+ spoc410_ok | u_unlogged     | r       | u              | f
+ spoc410_ok | v_view         | v       | p              | f
+ spoc410_r1 | t_unique_no_pk | r       | p              | t
+ spoc410_r2 | t_full         | r       | p              | t
+ spoc410_r3 | t_nothing      | r       | p              | t
+ spoc410_r4 | t_no_identity  | r       | p              | t
+(14 rows)
+
+-- The identity matrix of those candidates.  An empty identity_index is
+-- what makes spock refuse the table.
+SELECT nspname, relname, relreplident, identity_index
+  FROM public.spoc410_state
+ WHERE relkind IN ('r', 'p') AND relpersistence = 'p'
+ ORDER BY nspname, relname;
+  nspname   |    relname     | relreplident |       identity_index        
+------------+----------------+--------------+-----------------------------
+ spoc410_ok | t_part         | d            | spoc410_ok.t_part_pkey
+ spoc410_ok | t_part_2025    | d            | spoc410_ok.t_part_2025_pkey
+ spoc410_ok | t_part_2026    | d            | spoc410_ok.t_part_2026_pkey
+ spoc410_ok | t_pk           | d            | spoc410_ok.t_pk_pkey
+ spoc410_ok | t_pk_multi     | d            | spoc410_ok.t_pk_multi_pkey
+ spoc410_ok | t_using_index  | i            | spoc410_ok.t_using_index_ri
+ spoc410_r1 | t_unique_no_pk | d            | 
+ spoc410_r2 | t_full         | f            | 
+ spoc410_r3 | t_nothing      | n            | 
+ spoc410_r4 | t_no_identity  | d            | 
+(10 rows)
+
+-- A replication set with the default flags replicates UPDATEs and DELETEs,
+-- so the identity requirement is in force.
+SELECT spock.repset_create('spoc410_upd') IS NOT NULL AS created;
+ created 
+---------
+ t
+(1 row)
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_ok');
+ spoc410_probe 
+---------------
+ added
+(1 row)
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
+                                 spoc410_probe                                 
+-------------------------------------------------------------------------------
+ REJECTED: table t_unique_no_pk cannot be added to replication set spoc410_upd
+(1 row)
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+                             spoc410_probe                             
+-----------------------------------------------------------------------
+ REJECTED: table t_full cannot be added to replication set spoc410_upd
+(1 row)
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
+                              spoc410_probe                               
+--------------------------------------------------------------------------
+ REJECTED: table t_nothing cannot be added to replication set spoc410_upd
+(1 row)
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
+                                spoc410_probe                                 
+------------------------------------------------------------------------------
+ REJECTED: table t_no_identity cannot be added to replication set spoc410_upd
+(1 row)
+
+-- Only the well-identified tables of spoc410_ok made it in -- including the
+-- partitioned parent and each of its partitions as separate members.
+SELECT set_name, nspname, relname, relkind
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ ORDER BY set_name, nspname, relname;
+  set_name   |  nspname   |    relname    | relkind 
+-------------+------------+---------------+---------
+ spoc410_upd | spoc410_ok | t_part        | p
+ spoc410_upd | spoc410_ok | t_part_2025   | r
+ spoc410_upd | spoc410_ok | t_part_2026   | r
+ spoc410_upd | spoc410_ok | t_pk          | r
+ spoc410_upd | spoc410_ok | t_pk_multi    | r
+ spoc410_upd | spoc410_ok | t_using_index | r
+(6 rows)
+
+-- The same rejection unwrapped, with DETAIL and HINT
+SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
+ERROR:  table t_full cannot be added to replication set spoc410_upd
+DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
+HINT:  Add a PRIMARY KEY to the table
+-- Atomicity: one bad table in any of the listed schemas and the entire call
+-- is rolled back, so the fresh replication set stays empty.
+SELECT spock.repset_create('spoc410_atomic') IS NOT NULL AS created;
+ created 
+---------
+ t
+(1 row)
+
+SELECT spock.repset_add_all_tables('spoc410_atomic',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+ERROR:  table t_unique_no_pk cannot be added to replication set spoc410_atomic
+DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
+HINT:  Add a PRIMARY KEY to the table
+SELECT count(*) AS members
+  FROM public.spoc410_state WHERE set_name = 'spoc410_atomic';
+ members 
+---------
+       0
+(1 row)
+
+-- An INSERT-only replication set does not need to identify a row, so the
+-- identity of the table is irrelevant and every candidate is collected.
+SELECT spock.repset_create('spoc410_ins',
+	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
+ created 
+---------
+ t
+(1 row)
+
+SELECT spock.repset_add_all_tables('spoc410_ins',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+SELECT set_name, nspname, relname, relkind
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ ORDER BY set_name, nspname, relname;
+  set_name   |  nspname   |    relname     | relkind 
+-------------+------------+----------------+---------
+ spoc410_ins | spoc410_ok | t_part         | p
+ spoc410_ins | spoc410_ok | t_part_2025    | r
+ spoc410_ins | spoc410_ok | t_part_2026    | r
+ spoc410_ins | spoc410_ok | t_pk           | r
+ spoc410_ins | spoc410_ok | t_pk_multi     | r
+ spoc410_ins | spoc410_ok | t_using_index  | r
+ spoc410_ins | spoc410_r1 | t_unique_no_pk | r
+ spoc410_ins | spoc410_r2 | t_full         | r
+ spoc410_ins | spoc410_r3 | t_nothing      | r
+ spoc410_ins | spoc410_r4 | t_no_identity  | r
+ spoc410_upd | spoc410_ok | t_part         | p
+ spoc410_upd | spoc410_ok | t_part_2025    | r
+ spoc410_upd | spoc410_ok | t_part_2026    | r
+ spoc410_upd | spoc410_ok | t_pk           | r
+ spoc410_upd | spoc410_ok | t_pk_multi     | r
+ spoc410_upd | spoc410_ok | t_using_index  | r
+(16 rows)
+
+-- Repeating the call is a no-op: relations already in the set are skipped,
+-- so there is no duplicate key failure.
+SELECT spock.repset_add_all_tables('spoc410_ins',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+SELECT set_name, count(*) AS members
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ GROUP BY set_name ORDER BY set_name;
+  set_name   | members 
+-------------+---------
+ spoc410_ins |      10
+ spoc410_upd |       6
+(2 rows)
+
+-- ... and the set collected this way can no longer be promoted to replicate
+-- UPDATEs or DELETEs.
+SELECT spock.repset_alter('spoc410_ins', replicate_update := true);
+ERROR:  replication set spoc410_ins cannot be altered to replicate UPDATEs or DELETEs because it contains tables without PRIMARY KEY
+-- Now give each rejected table an index-based identity and watch it become
+-- acceptable.  r1 only needs its existing unique index promoted.
+ALTER TABLE spoc410_r1.t_unique_no_pk
+	REPLICA IDENTITY USING INDEX t_unique_no_pk_id_key;
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
+ spoc410_probe 
+---------------
+ added
+(1 row)
+
+-- r2 is the trap: adding a PRIMARY KEY does nothing while the identity is
+-- still FULL, because FULL never resolves to an index.
+ALTER TABLE spoc410_r2.t_full ADD PRIMARY KEY (id);
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+                             spoc410_probe                             
+-----------------------------------------------------------------------
+ REJECTED: table t_full cannot be added to replication set spoc410_upd
+(1 row)
+
+ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY DEFAULT;
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+ spoc410_probe 
+---------------
+ added
+(1 row)
+
+-- r3 had a PRIMARY KEY all along, only the identity was switched off
+ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY DEFAULT;
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
+ spoc410_probe 
+---------------
+ added
+(1 row)
+
+-- r4 genuinely had nothing to identify a row by
+ALTER TABLE spoc410_r4.t_no_identity ADD PRIMARY KEY (id);
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
+ spoc410_probe 
+---------------
+ added
+(1 row)
+
+SELECT DISTINCT nspname, relname, relreplident, identity_index
+  FROM public.spoc410_state
+ WHERE nspname <> 'spoc410_ok'
+ ORDER BY nspname, relname;
+  nspname   |    relname     | relreplident |          identity_index          
+------------+----------------+--------------+----------------------------------
+ spoc410_r1 | t_unique_no_pk | i            | spoc410_r1.t_unique_no_pk_id_key
+ spoc410_r2 | t_full         | d            | spoc410_r2.t_full_pkey
+ spoc410_r3 | t_nothing      | d            | spoc410_r3.t_nothing_pkey
+ spoc410_r4 | t_no_identity  | d            | spoc410_r4.t_no_identity_pkey
+(4 rows)
+
+SELECT set_name, count(*) AS members
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ GROUP BY set_name ORDER BY set_name;
+  set_name   | members 
+-------------+---------
+ spoc410_ins |      10
+ spoc410_upd |      10
+(2 rows)
+
+SELECT spock.repset_add_all_tables('spoc410_ins', '{spoc410_nosuch}');
+ERROR:  schema "spoc410_nosuch" does not exist
+-- Cleanup.  Drop the replication sets first so that dropping the schemas
+-- does not have to cascade through the memberships.
+SELECT spock.repset_drop('spoc410_upd');
+ repset_drop 
+-------------
+ t
+(1 row)
+
+SELECT spock.repset_drop('spoc410_atomic');
+ repset_drop 
+-------------
+ t
+(1 row)
+
+SELECT spock.repset_drop('spoc410_ins');
+ repset_drop 
+-------------
+ t
+(1 row)
+
+DROP VIEW public.spoc410_state;
+DROP FUNCTION public.spoc410_probe(name, text);
+-- the cascade notice just lists the schema contents, keep it out of the output
+SET client_min_messages = warning;
+DROP SCHEMA spoc410_ok, spoc410_r1, spoc410_r2, spoc410_r3, spoc410_r4 CASCADE;
+RESET client_min_messages;

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -1072,3 +1072,101 @@ DROP FUNCTION public.spoc410_probe(name, text);
 SET client_min_messages = warning;
 DROP SCHEMA spoc410_ok, spoc410_r1, spoc410_r2, spoc410_r3, spoc410_r4 CASCADE;
 RESET client_min_messages;
+--
+-- Pin the all-or-nothing restriction behaviour of the repset_add_all_tables()
+--
+CREATE SCHEMA spoc410_mix;
+-- a_pk sorts before m_orphan, so it is already added when the call aborts;
+-- z_pk sorts after it and is never even looked at
+CREATE TABLE spoc410_mix.a_pk (id int PRIMARY KEY, payload text);
+CREATE TABLE spoc410_mix.m_orphan (id int, payload text);
+CREATE TABLE spoc410_mix.z_pk (id int PRIMARY KEY, payload text);
+-- Reports the members of the sets built below.
+CREATE VIEW public.spoc410_members AS
+	SELECT r.set_name, n.nspname, c.relname
+	  FROM spock.replication_set_table t
+		   JOIN spock.replication_set r ON r.set_id = t.set_id
+		   JOIN spock.local_node l ON l.node_id = r.set_nodeid
+		   JOIN pg_class c ON c.oid = t.set_reloid
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+	 WHERE n.nspname = 'spoc410_mix';
+SELECT spock.repset_create('spoc410_mix_upd') IS NOT NULL AS created;
+ created 
+---------
+ t
+(1 row)
+
+-- Today: the whole call dies on the one table that cannot be replicated
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
+ERROR:  table m_orphan cannot be added to replication set spoc410_mix_upd
+DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
+HINT:  Add a PRIMARY KEY to the table
+-- ... and a_pk, which had been accepted, is gone with it
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+ set_name | nspname | relname 
+----------+---------+---------
+(0 rows)
+
+-- An INSERT-only set never has to identify a row, so the same schema goes in
+-- whole, m_orphan included.
+SELECT spock.repset_create('spoc410_mix_ins',
+	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
+ created 
+---------
+ t
+(1 row)
+
+SELECT spock.repset_add_all_tables('spoc410_mix_ins', '{spoc410_mix}');
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+-- Three tables in the replication set
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+    set_name     |   nspname   | relname  
+-----------------+-------------+----------
+ spoc410_mix_ins | spoc410_mix | a_pk
+ spoc410_mix_ins | spoc410_mix | m_orphan
+ spoc410_mix_ins | spoc410_mix | z_pk
+(3 rows)
+
+-- And the ERROR really was only about the missing identity: give m_orphan a
+-- PRIMARY KEY and the very same call succeeds.
+ALTER TABLE spoc410_mix.m_orphan ADD PRIMARY KEY (id);
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+    set_name     |   nspname   | relname  
+-----------------+-------------+----------
+ spoc410_mix_ins | spoc410_mix | a_pk
+ spoc410_mix_ins | spoc410_mix | m_orphan
+ spoc410_mix_ins | spoc410_mix | z_pk
+ spoc410_mix_upd | spoc410_mix | a_pk
+ spoc410_mix_upd | spoc410_mix | m_orphan
+ spoc410_mix_upd | spoc410_mix | z_pk
+(6 rows)
+
+SELECT spock.repset_drop('spoc410_mix_upd');
+ repset_drop 
+-------------
+ t
+(1 row)
+
+SELECT spock.repset_drop('spoc410_mix_ins');
+ repset_drop 
+-------------
+ t
+(1 row)
+
+DROP VIEW public.spoc410_members;
+SET client_min_messages = warning;
+DROP SCHEMA spoc410_mix CASCADE;
+RESET client_min_messages;

--- a/tests/regress/expected/replication_set.out
+++ b/tests/regress/expected/replication_set.out
@@ -99,8 +99,8 @@ SELECT * FROM spock.repset_add_table('repset_replicate_all', 'test_unlogged');
 ERROR:  UNLOGGED and TEMP tables cannot be replicated
 SELECT * FROM spock.repset_add_table('repset_replicate_all', 'test_nopkey');
 ERROR:  table test_nopkey cannot be added to replication set repset_replicate_all
-DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
-HINT:  Add a PRIMARY KEY to the table
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
 -- success
 SELECT * FROM spock.repset_add_table('repset_replicate_instrunc', 'test_nopkey');
  repset_add_table 
@@ -117,12 +117,25 @@ SELECT * FROM spock.repset_alter('repset_replicate_insupd', replicate_truncate :
 -- fail again
 SELECT * FROM spock.repset_add_table('repset_replicate_insupd', 'test_nopkey');
 ERROR:  table test_nopkey cannot be added to replication set repset_replicate_insupd
-DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
-HINT:  Add a PRIMARY KEY to the table
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
 SELECT * FROM spock.repset_add_all_tables('default', '{public}');
-ERROR:  table test_nopkey cannot be added to replication set default
-DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
-HINT:  Add a PRIMARY KEY to the table
+WARNING:  skipping table public.test_nopkey
+DETAIL:  Table has no replica identity index, and replication set default replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+-- test_publicschema has landed in 'default' as well now; take it back out so
+-- that the checks below see the same replication sets as before
+SELECT spock.repset_remove_table('default', 'public.test_publicschema');
+ repset_remove_table 
+---------------------
+ t
+(1 row)
+
 SELECT * FROM spock.repset_alter('repset_replicate_instrunc', replicate_update := true);
 ERROR:  replication set repset_replicate_instrunc cannot be altered to replicate UPDATEs or DELETEs because it contains tables without PRIMARY KEY
 SELECT * FROM spock.repset_alter('repset_replicate_instrunc', replicate_delete := true);
@@ -717,7 +730,7 @@ NOTICE:  drop cascades to table spoc_102l_d membership in replication set defaul
 (1 row)
 
 --
--- What does spock.repset_add_all_tables() actually collect?
+-- What does spock.repset_add_all_tables() collect, and what does it leave behind?
 --
 \set VERBOSITY default
 CREATE SCHEMA spoc410_ok;
@@ -748,21 +761,21 @@ CREATE VIEW spoc410_ok.v_view AS SELECT * FROM spoc410_ok.t_pk;
 CREATE MATERIALIZED VIEW spoc410_ok.m_matview AS SELECT * FROM spoc410_ok.t_pk;
 CREATE SEQUENCE spoc410_ok.s_seq;
 CREATE UNLOGGED TABLE spoc410_ok.u_unlogged (id int PRIMARY KEY);
--- rejected: a UNIQUE NOT NULL index is not enough, the identity is still
+-- skipped: a UNIQUE NOT NULL index is not enough, the identity is still
 -- DEFAULT and there is no PRIMARY KEY for DEFAULT to point at
 CREATE TABLE spoc410_r1.t_unique_no_pk (id int NOT NULL UNIQUE, payload text);
--- rejected: REPLICA IDENTITY FULL is not an index
+-- skipped: REPLICA IDENTITY FULL is not an index
 CREATE TABLE spoc410_r2.t_full (id int NOT NULL, payload text);
 ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY FULL;
--- rejected: PRIMARY KEY present, but the identity is switched off
+-- skipped: PRIMARY KEY present, but the identity is switched off
 CREATE TABLE spoc410_r3.t_nothing (id int PRIMARY KEY, payload text);
 ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY NOTHING;
--- rejected: no identity of any kind
+-- skipped: no identity of any kind
 CREATE TABLE spoc410_r4.t_no_identity (id int, payload text);
 -- Reports the replica identity of every relation of the test schemas, plus
 -- the replication sets it belongs to.  identity_index is exactly what the
--- relcache would put into rd_replidindex, i.e. NULL means "spock will refuse
--- this table for an UPDATE/DELETE replicating set".
+-- relcache would put into rd_replidindex, i.e. NULL means "this table cannot be
+-- replicated by a set that replicates UPDATEs or DELETEs".
 CREATE VIEW public.spoc410_state AS
 	SELECT n.nspname, c.relname, c.relkind, c.relpersistence, c.relreplident,
 		   CASE c.relreplident
@@ -783,18 +796,6 @@ CREATE VIEW public.spoc410_state AS
 			 AS s ON s.set_reloid = c.oid
 	 WHERE n.nspname LIKE 'spoc410\_%'
 	   AND c.relkind IN ('r', 'p', 'v', 'm', 'S');
--- Calls the routine under test and reports the verdict instead of aborting
--- the script.  The subtransaction rollback also shows that a failed call
--- leaves the replication set exactly as it was.
-CREATE FUNCTION public.spoc410_probe(p_repset name, p_schema text)
-RETURNS text LANGUAGE plpgsql AS $$
-BEGIN
-	PERFORM spock.repset_add_all_tables(p_repset, ARRAY[p_schema]);
-	RETURN 'added';
-EXCEPTION WHEN invalid_parameter_value THEN
-	RETURN 'REJECTED: ' || SQLERRM;
-END;
-$$;
 -- Which relations repset_add_all_tables() will even consider
 SELECT nspname, relname, relkind, relpersistence,
 	   (relkind IN ('r', 'p') AND relpersistence = 'p') AS candidate
@@ -818,8 +819,8 @@ SELECT nspname, relname, relkind, relpersistence,
  spoc410_r4 | t_no_identity  | r       | p              | t
 (14 rows)
 
--- The identity matrix of those candidates.  An empty identity_index is
--- what makes spock refuse the table.
+-- The identity matrix of those candidates.  An empty identity_index is what
+-- makes the table unreplicatable.
 SELECT nspname, relname, relreplident, identity_index
   FROM public.spoc410_state
  WHERE relkind IN ('r', 'p') AND relpersistence = 'p'
@@ -838,46 +839,36 @@ SELECT nspname, relname, relreplident, identity_index
  spoc410_r4 | t_no_identity  | d            | 
 (10 rows)
 
--- A replication set with the default flags replicates UPDATEs and DELETEs,
--- so the identity requirement is in force.
+-- A replication set with the default flags replicates UPDATEs and DELETEs, so
+-- the identity requirement is in force.  One call over all five schemas: the
+-- four unreplicatable tables are named and skipped, everything else is added.
 SELECT spock.repset_create('spoc410_upd') IS NOT NULL AS created;
  created 
 ---------
  t
 (1 row)
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_ok');
- spoc410_probe 
----------------
- added
+SELECT spock.repset_add_all_tables('spoc410_upd',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+WARNING:  skipping table spoc410_r1.t_unique_no_pk
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+WARNING:  skipping table spoc410_r2.t_full
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+WARNING:  skipping table spoc410_r3.t_nothing
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+WARNING:  skipping table spoc410_r4.t_no_identity
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+ repset_add_all_tables 
+-----------------------
+ t
 (1 row)
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
-                                 spoc410_probe                                 
--------------------------------------------------------------------------------
- REJECTED: table t_unique_no_pk cannot be added to replication set spoc410_upd
-(1 row)
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
-                             spoc410_probe                             
------------------------------------------------------------------------
- REJECTED: table t_full cannot be added to replication set spoc410_upd
-(1 row)
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
-                              spoc410_probe                               
---------------------------------------------------------------------------
- REJECTED: table t_nothing cannot be added to replication set spoc410_upd
-(1 row)
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
-                                spoc410_probe                                 
-------------------------------------------------------------------------------
- REJECTED: table t_no_identity cannot be added to replication set spoc410_upd
-(1 row)
-
--- Only the well-identified tables of spoc410_ok made it in -- including the
--- partitioned parent and each of its partitions as separate members.
+-- The well-identified tables of spoc410_ok are in -- including the partitioned
+-- parent and each of its partitions as a member of its own.
 SELECT set_name, nspname, relname, relkind
   FROM public.spoc410_state
  WHERE set_name IS NOT NULL
@@ -892,33 +883,8 @@ SELECT set_name, nspname, relname, relkind
  spoc410_upd | spoc410_ok | t_using_index | r
 (6 rows)
 
--- The same rejection unwrapped, with DETAIL and HINT
-SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
-ERROR:  table t_full cannot be added to replication set spoc410_upd
-DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
-HINT:  Add a PRIMARY KEY to the table
--- Atomicity: one bad table in any of the listed schemas and the entire call
--- is rolled back, so the fresh replication set stays empty.
-SELECT spock.repset_create('spoc410_atomic') IS NOT NULL AS created;
- created 
----------
- t
-(1 row)
-
-SELECT spock.repset_add_all_tables('spoc410_atomic',
-	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
-ERROR:  table t_unique_no_pk cannot be added to replication set spoc410_atomic
-DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
-HINT:  Add a PRIMARY KEY to the table
-SELECT count(*) AS members
-  FROM public.spoc410_state WHERE set_name = 'spoc410_atomic';
- members 
----------
-       0
-(1 row)
-
--- An INSERT-only replication set does not need to identify a row, so the
--- identity of the table is irrelevant and every candidate is collected.
+-- An INSERT-only replication set never has to identify a row, so the identity
+-- of the table is irrelevant and every candidate is collected, silently.
 SELECT spock.repset_create('spoc410_ins',
 	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
  created 
@@ -957,10 +923,30 @@ SELECT set_name, nspname, relname, relkind
  spoc410_upd | spoc410_ok | t_using_index  | r
 (16 rows)
 
--- Repeating the call is a no-op: relations already in the set are skipped,
--- so there is no duplicate key failure.
+-- Repeating a call costs nothing for the tables that are already members, so
+-- there is no duplicate key failure.  A skipped table never became a member
+-- though, so it is considered again -- and warned about again.
 SELECT spock.repset_add_all_tables('spoc410_ins',
 	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+SELECT spock.repset_add_all_tables('spoc410_upd',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+WARNING:  skipping table spoc410_r1.t_unique_no_pk
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+WARNING:  skipping table spoc410_r2.t_full
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+WARNING:  skipping table spoc410_r3.t_nothing
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+WARNING:  skipping table spoc410_r4.t_no_identity
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
  repset_add_all_tables 
 -----------------------
  t
@@ -976,50 +962,43 @@ SELECT set_name, count(*) AS members
  spoc410_upd |       6
 (2 rows)
 
--- ... and the set collected this way can no longer be promoted to replicate
--- UPDATEs or DELETEs.
+-- ... and a set filled that way still cannot be promoted to replicate UPDATEs
+-- or DELETEs.
 SELECT spock.repset_alter('spoc410_ins', replicate_update := true);
 ERROR:  replication set spoc410_ins cannot be altered to replicate UPDATEs or DELETEs because it contains tables without PRIMARY KEY
--- Now give each rejected table an index-based identity and watch it become
--- acceptable.  r1 only needs its existing unique index promoted.
+-- spock.repset_add_table() is unaffected by all this: asked for one table by
+-- name, it still refuses rather than silently doing nothing.
+SELECT spock.repset_add_table('spoc410_upd', 'spoc410_r1.t_unique_no_pk');
+ERROR:  table t_unique_no_pk cannot be added to replication set spoc410_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+-- Now give each skipped table an index-based identity.  r1 only needs its
+-- existing unique index promoted.
 ALTER TABLE spoc410_r1.t_unique_no_pk
 	REPLICA IDENTITY USING INDEX t_unique_no_pk_id_key;
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
- spoc410_probe 
----------------
- added
-(1 row)
-
--- r2 is the trap: adding a PRIMARY KEY does nothing while the identity is
+-- r2 is the trap: adding a PRIMARY KEY changes nothing while the identity is
 -- still FULL, because FULL never resolves to an index.
 ALTER TABLE spoc410_r2.t_full ADD PRIMARY KEY (id);
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
-                             spoc410_probe                             
------------------------------------------------------------------------
- REJECTED: table t_full cannot be added to replication set spoc410_upd
+SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
+WARNING:  skipping table spoc410_r2.t_full
+DETAIL:  Table has no replica identity index, and replication set spoc410_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+ repset_add_all_tables 
+-----------------------
+ t
 (1 row)
 
 ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY DEFAULT;
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
- spoc410_probe 
----------------
- added
-(1 row)
-
 -- r3 had a PRIMARY KEY all along, only the identity was switched off
 ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY DEFAULT;
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
- spoc410_probe 
----------------
- added
-(1 row)
-
 -- r4 genuinely had nothing to identify a row by
 ALTER TABLE spoc410_r4.t_no_identity ADD PRIMARY KEY (id);
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
- spoc410_probe 
----------------
- added
+-- With every table replicatable the same call warns about nothing
+SELECT spock.repset_add_all_tables('spoc410_upd',
+	'{spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+ repset_add_all_tables 
+-----------------------
+ t
 (1 row)
 
 SELECT DISTINCT nspname, relname, relreplident, identity_index
@@ -1044,17 +1023,12 @@ SELECT set_name, count(*) AS members
  spoc410_upd |      10
 (2 rows)
 
+-- A schema that does not exist is still an error, not a skip
 SELECT spock.repset_add_all_tables('spoc410_ins', '{spoc410_nosuch}');
 ERROR:  schema "spoc410_nosuch" does not exist
--- Cleanup.  Drop the replication sets first so that dropping the schemas
--- does not have to cascade through the memberships.
+-- Cleanup.  Drop the replication sets first so that dropping the schemas does
+-- not have to cascade through the memberships.
 SELECT spock.repset_drop('spoc410_upd');
- repset_drop 
--------------
- t
-(1 row)
-
-SELECT spock.repset_drop('spoc410_atomic');
  repset_drop 
 -------------
  t
@@ -1067,17 +1041,16 @@ SELECT spock.repset_drop('spoc410_ins');
 (1 row)
 
 DROP VIEW public.spoc410_state;
-DROP FUNCTION public.spoc410_probe(name, text);
 -- the cascade notice just lists the schema contents, keep it out of the output
 SET client_min_messages = warning;
 DROP SCHEMA spoc410_ok, spoc410_r1, spoc410_r2, spoc410_r3, spoc410_r4 CASCADE;
 RESET client_min_messages;
 --
--- Pin the all-or-nothing restriction behaviour of the repset_add_all_tables()
---
+-- Check: one table that does not satisfy replication restrictions must not cost
+-- the caller the whole schema
 CREATE SCHEMA spoc410_mix;
--- a_pk sorts before m_orphan, so it is already added when the call aborts;
--- z_pk sorts after it and is never even looked at
+-- a_pk sorts before m_orphan and z_pk after it, so this also shows that the
+-- scan carries on past the table it skips
 CREATE TABLE spoc410_mix.a_pk (id int PRIMARY KEY, payload text);
 CREATE TABLE spoc410_mix.m_orphan (id int, payload text);
 CREATE TABLE spoc410_mix.z_pk (id int PRIMARY KEY, payload text);
@@ -1096,20 +1069,59 @@ SELECT spock.repset_create('spoc410_mix_upd') IS NOT NULL AS created;
  t
 (1 row)
 
--- Today: the whole call dies on the one table that cannot be replicated
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
-ERROR:  table m_orphan cannot be added to replication set spoc410_mix_upd
-DETAIL:  table does not have PRIMARY KEY and given replication set is configured to replicate UPDATEs and/or DELETEs
-HINT:  Add a PRIMARY KEY to the table
--- ... and a_pk, which had been accepted, is gone with it
+WARNING:  skipping table spoc410_mix.m_orphan
+DETAIL:  Table has no replica identity index, and replication set spoc410_mix_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+-- a_pk and z_pk are in, only m_orphan stayed out
 SELECT set_name, nspname, relname FROM public.spoc410_members
  ORDER BY 1, 2, 3;
- set_name | nspname | relname 
-----------+---------+---------
-(0 rows)
+    set_name     |   nspname   | relname 
+-----------------+-------------+---------
+ spoc410_mix_upd | spoc410_mix | a_pk
+ spoc410_mix_upd | spoc410_mix | z_pk
+(2 rows)
 
--- An INSERT-only set never has to identify a row, so the same schema goes in
--- whole, m_orphan included.
+-- The same schema named twice must not turn into a duplicate key failure, and
+-- must not report the same relation twice either.
+SELECT spock.repset_add_all_tables('spoc410_mix_upd',
+	'{spoc410_mix,spoc410_mix}');
+WARNING:  skipping table spoc410_mix.m_orphan
+DETAIL:  Table has no replica identity index, and replication set spoc410_mix_upd replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+ repset_add_all_tables 
+-----------------------
+ t
+(1 row)
+
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+    set_name     |   nspname   | relname 
+-----------------+-------------+---------
+ spoc410_mix_upd | spoc410_mix | a_pk
+ spoc410_mix_upd | spoc410_mix | z_pk
+(2 rows)
+
+-- Naming that same table explicitly is still an error: the caller asked for
+-- this one table, so silently doing nothing would be worse than failing.
+SELECT spock.repset_add_table('spoc410_mix_upd', 'spoc410_mix.m_orphan');
+ERROR:  table m_orphan cannot be added to replication set spoc410_mix_upd
+DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
+HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
+-- A schema that may never hold replicated relations is an error too.  The
+-- caller named it, and scanning it could achieve nothing but a warning per
+-- relation: errors are about what the caller asked for, warnings about what we
+-- found inside a schema we were told to scan.
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spock}');
+ERROR:  schema spock is excluded from replication
+DETAIL:  Relations of this schema cannot be added to any replication set.
+-- The requirement belongs to the replication set, not to the routine: an
+-- INSERT-only set never has to identify a row, so m_orphan goes in too.
 SELECT spock.repset_create('spoc410_mix_ins',
 	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
  created 
@@ -1123,7 +1135,6 @@ SELECT spock.repset_add_all_tables('spoc410_mix_ins', '{spoc410_mix}');
  t
 (1 row)
 
--- Three tables in the replication set
 SELECT set_name, nspname, relname FROM public.spoc410_members
  ORDER BY 1, 2, 3;
     set_name     |   nspname   | relname  
@@ -1131,10 +1142,12 @@ SELECT set_name, nspname, relname FROM public.spoc410_members
  spoc410_mix_ins | spoc410_mix | a_pk
  spoc410_mix_ins | spoc410_mix | m_orphan
  spoc410_mix_ins | spoc410_mix | z_pk
-(3 rows)
+ spoc410_mix_upd | spoc410_mix | a_pk
+ spoc410_mix_upd | spoc410_mix | z_pk
+(5 rows)
 
--- And the ERROR really was only about the missing identity: give m_orphan a
--- PRIMARY KEY and the very same call succeeds.
+-- Give m_orphan a PRIMARY KEY and a later call picks it up, without touching
+-- the members already there.
 ALTER TABLE spoc410_mix.m_orphan ADD PRIMARY KEY (id);
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
  repset_add_all_tables 

--- a/tests/regress/sql/replication_set.sql
+++ b/tests/regress/sql/replication_set.sql
@@ -552,3 +552,62 @@ DROP FUNCTION public.spoc410_probe(name, text);
 SET client_min_messages = warning;
 DROP SCHEMA spoc410_ok, spoc410_r1, spoc410_r2, spoc410_r3, spoc410_r4 CASCADE;
 RESET client_min_messages;
+
+--
+-- Pin the all-or-nothing restriction behaviour of the repset_add_all_tables()
+--
+
+CREATE SCHEMA spoc410_mix;
+-- a_pk sorts before m_orphan, so it is already added when the call aborts;
+-- z_pk sorts after it and is never even looked at
+CREATE TABLE spoc410_mix.a_pk (id int PRIMARY KEY, payload text);
+CREATE TABLE spoc410_mix.m_orphan (id int, payload text);
+CREATE TABLE spoc410_mix.z_pk (id int PRIMARY KEY, payload text);
+
+-- Reports the members of the sets built below.
+CREATE VIEW public.spoc410_members AS
+	SELECT r.set_name, n.nspname, c.relname
+	  FROM spock.replication_set_table t
+		   JOIN spock.replication_set r ON r.set_id = t.set_id
+		   JOIN spock.local_node l ON l.node_id = r.set_nodeid
+		   JOIN pg_class c ON c.oid = t.set_reloid
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+	 WHERE n.nspname = 'spoc410_mix';
+
+SELECT spock.repset_create('spoc410_mix_upd') IS NOT NULL AS created;
+
+-- Today: the whole call dies on the one table that cannot be replicated
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
+
+-- ... and a_pk, which had been accepted, is gone with it
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+
+-- An INSERT-only set never has to identify a row, so the same schema goes in
+-- whole, m_orphan included.
+SELECT spock.repset_create('spoc410_mix_ins',
+	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
+
+SELECT spock.repset_add_all_tables('spoc410_mix_ins', '{spoc410_mix}');
+
+-- Three tables in the replication set
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+
+-- And the ERROR really was only about the missing identity: give m_orphan a
+-- PRIMARY KEY and the very same call succeeds.
+ALTER TABLE spoc410_mix.m_orphan ADD PRIMARY KEY (id);
+
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
+
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+
+SELECT spock.repset_drop('spoc410_mix_upd');
+
+SELECT spock.repset_drop('spoc410_mix_ins');
+
+DROP VIEW public.spoc410_members;
+SET client_min_messages = warning;
+DROP SCHEMA spoc410_mix CASCADE;
+RESET client_min_messages;

--- a/tests/regress/sql/replication_set.sql
+++ b/tests/regress/sql/replication_set.sql
@@ -50,6 +50,10 @@ SELECT * FROM spock.repset_alter('repset_replicate_insupd', replicate_truncate :
 -- fail again
 SELECT * FROM spock.repset_add_table('repset_replicate_insupd', 'test_nopkey');
 SELECT * FROM spock.repset_add_all_tables('default', '{public}');
+
+-- test_publicschema has landed in 'default' as well now; take it back out so
+-- that the checks below see the same replication sets as before
+SELECT spock.repset_remove_table('default', 'public.test_publicschema');
 SELECT * FROM spock.repset_alter('repset_replicate_instrunc', replicate_update := true);
 SELECT * FROM spock.repset_alter('repset_replicate_instrunc', replicate_delete := true);
 
@@ -333,9 +337,8 @@ SELECT * FROM spoc_102g_d ORDER BY x; -- See (-5).
 SELECT spock.replicate_ddl('DROP TABLE IF EXISTS spoc_102g_d,spoc_102l_d CASCADE');
 
 --
--- What does spock.repset_add_all_tables() actually collect?
+-- What does spock.repset_add_all_tables() collect, and what does it leave behind?
 --
-
 \set VERBOSITY default
 
 CREATE SCHEMA spoc410_ok;
@@ -372,25 +375,25 @@ CREATE MATERIALIZED VIEW spoc410_ok.m_matview AS SELECT * FROM spoc410_ok.t_pk;
 CREATE SEQUENCE spoc410_ok.s_seq;
 CREATE UNLOGGED TABLE spoc410_ok.u_unlogged (id int PRIMARY KEY);
 
--- rejected: a UNIQUE NOT NULL index is not enough, the identity is still
+-- skipped: a UNIQUE NOT NULL index is not enough, the identity is still
 -- DEFAULT and there is no PRIMARY KEY for DEFAULT to point at
 CREATE TABLE spoc410_r1.t_unique_no_pk (id int NOT NULL UNIQUE, payload text);
 
--- rejected: REPLICA IDENTITY FULL is not an index
+-- skipped: REPLICA IDENTITY FULL is not an index
 CREATE TABLE spoc410_r2.t_full (id int NOT NULL, payload text);
 ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY FULL;
 
--- rejected: PRIMARY KEY present, but the identity is switched off
+-- skipped: PRIMARY KEY present, but the identity is switched off
 CREATE TABLE spoc410_r3.t_nothing (id int PRIMARY KEY, payload text);
 ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY NOTHING;
 
--- rejected: no identity of any kind
+-- skipped: no identity of any kind
 CREATE TABLE spoc410_r4.t_no_identity (id int, payload text);
 
 -- Reports the replica identity of every relation of the test schemas, plus
 -- the replication sets it belongs to.  identity_index is exactly what the
--- relcache would put into rd_replidindex, i.e. NULL means "spock will refuse
--- this table for an UPDATE/DELETE replicating set".
+-- relcache would put into rd_replidindex, i.e. NULL means "this table cannot be
+-- replicated by a set that replicates UPDATEs or DELETEs".
 CREATE VIEW public.spoc410_state AS
 	SELECT n.nspname, c.relname, c.relkind, c.relpersistence, c.relreplident,
 		   CASE c.relreplident
@@ -412,68 +415,36 @@ CREATE VIEW public.spoc410_state AS
 	 WHERE n.nspname LIKE 'spoc410\_%'
 	   AND c.relkind IN ('r', 'p', 'v', 'm', 'S');
 
--- Calls the routine under test and reports the verdict instead of aborting
--- the script.  The subtransaction rollback also shows that a failed call
--- leaves the replication set exactly as it was.
-CREATE FUNCTION public.spoc410_probe(p_repset name, p_schema text)
-RETURNS text LANGUAGE plpgsql AS $$
-BEGIN
-	PERFORM spock.repset_add_all_tables(p_repset, ARRAY[p_schema]);
-	RETURN 'added';
-EXCEPTION WHEN invalid_parameter_value THEN
-	RETURN 'REJECTED: ' || SQLERRM;
-END;
-$$;
-
 -- Which relations repset_add_all_tables() will even consider
 SELECT nspname, relname, relkind, relpersistence,
 	   (relkind IN ('r', 'p') AND relpersistence = 'p') AS candidate
   FROM public.spoc410_state
  ORDER BY nspname, relname;
 
--- The identity matrix of those candidates.  An empty identity_index is
--- what makes spock refuse the table.
+-- The identity matrix of those candidates.  An empty identity_index is what
+-- makes the table unreplicatable.
 SELECT nspname, relname, relreplident, identity_index
   FROM public.spoc410_state
  WHERE relkind IN ('r', 'p') AND relpersistence = 'p'
  ORDER BY nspname, relname;
 
--- A replication set with the default flags replicates UPDATEs and DELETEs,
--- so the identity requirement is in force.
+-- A replication set with the default flags replicates UPDATEs and DELETEs, so
+-- the identity requirement is in force.  One call over all five schemas: the
+-- four unreplicatable tables are named and skipped, everything else is added.
 SELECT spock.repset_create('spoc410_upd') IS NOT NULL AS created;
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_ok');
+SELECT spock.repset_add_all_tables('spoc410_upd',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
-
--- Only the well-identified tables of spoc410_ok made it in -- including the
--- partitioned parent and each of its partitions as separate members.
+-- The well-identified tables of spoc410_ok are in -- including the partitioned
+-- parent and each of its partitions as a member of its own.
 SELECT set_name, nspname, relname, relkind
   FROM public.spoc410_state
  WHERE set_name IS NOT NULL
  ORDER BY set_name, nspname, relname;
 
--- The same rejection unwrapped, with DETAIL and HINT
-SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
-
--- Atomicity: one bad table in any of the listed schemas and the entire call
--- is rolled back, so the fresh replication set stays empty.
-SELECT spock.repset_create('spoc410_atomic') IS NOT NULL AS created;
-
-SELECT spock.repset_add_all_tables('spoc410_atomic',
-	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
-
-SELECT count(*) AS members
-  FROM public.spoc410_state WHERE set_name = 'spoc410_atomic';
-
--- An INSERT-only replication set does not need to identify a row, so the
--- identity of the table is irrelevant and every candidate is collected.
+-- An INSERT-only replication set never has to identify a row, so the identity
+-- of the table is irrelevant and every candidate is collected, silently.
 SELECT spock.repset_create('spoc410_ins',
 	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
 
@@ -485,9 +456,13 @@ SELECT set_name, nspname, relname, relkind
  WHERE set_name IS NOT NULL
  ORDER BY set_name, nspname, relname;
 
--- Repeating the call is a no-op: relations already in the set are skipped,
--- so there is no duplicate key failure.
+-- Repeating a call costs nothing for the tables that are already members, so
+-- there is no duplicate key failure.  A skipped table never became a member
+-- though, so it is considered again -- and warned about again.
 SELECT spock.repset_add_all_tables('spoc410_ins',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+
+SELECT spock.repset_add_all_tables('spoc410_upd',
 	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
 
 SELECT set_name, count(*) AS members
@@ -495,36 +470,36 @@ SELECT set_name, count(*) AS members
  WHERE set_name IS NOT NULL
  GROUP BY set_name ORDER BY set_name;
 
--- ... and the set collected this way can no longer be promoted to replicate
--- UPDATEs or DELETEs.
+-- ... and a set filled that way still cannot be promoted to replicate UPDATEs
+-- or DELETEs.
 SELECT spock.repset_alter('spoc410_ins', replicate_update := true);
 
--- Now give each rejected table an index-based identity and watch it become
--- acceptable.  r1 only needs its existing unique index promoted.
+-- spock.repset_add_table() is unaffected by all this: asked for one table by
+-- name, it still refuses rather than silently doing nothing.
+SELECT spock.repset_add_table('spoc410_upd', 'spoc410_r1.t_unique_no_pk');
+
+-- Now give each skipped table an index-based identity.  r1 only needs its
+-- existing unique index promoted.
 ALTER TABLE spoc410_r1.t_unique_no_pk
 	REPLICA IDENTITY USING INDEX t_unique_no_pk_id_key;
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
-
--- r2 is the trap: adding a PRIMARY KEY does nothing while the identity is
+-- r2 is the trap: adding a PRIMARY KEY changes nothing while the identity is
 -- still FULL, because FULL never resolves to an index.
 ALTER TABLE spoc410_r2.t_full ADD PRIMARY KEY (id);
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
 
 ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY DEFAULT;
-
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
 
 -- r3 had a PRIMARY KEY all along, only the identity was switched off
 ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY DEFAULT;
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
-
 -- r4 genuinely had nothing to identify a row by
 ALTER TABLE spoc410_r4.t_no_identity ADD PRIMARY KEY (id);
 
-SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
+-- With every table replicatable the same call warns about nothing
+SELECT spock.repset_add_all_tables('spoc410_upd',
+	'{spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
 
 SELECT DISTINCT nspname, relname, relreplident, identity_index
   FROM public.spoc410_state
@@ -536,30 +511,28 @@ SELECT set_name, count(*) AS members
  WHERE set_name IS NOT NULL
  GROUP BY set_name ORDER BY set_name;
 
+-- A schema that does not exist is still an error, not a skip
 SELECT spock.repset_add_all_tables('spoc410_ins', '{spoc410_nosuch}');
 
--- Cleanup.  Drop the replication sets first so that dropping the schemas
--- does not have to cascade through the memberships.
+-- Cleanup.  Drop the replication sets first so that dropping the schemas does
+-- not have to cascade through the memberships.
 SELECT spock.repset_drop('spoc410_upd');
-
-SELECT spock.repset_drop('spoc410_atomic');
 
 SELECT spock.repset_drop('spoc410_ins');
 
 DROP VIEW public.spoc410_state;
-DROP FUNCTION public.spoc410_probe(name, text);
 -- the cascade notice just lists the schema contents, keep it out of the output
 SET client_min_messages = warning;
 DROP SCHEMA spoc410_ok, spoc410_r1, spoc410_r2, spoc410_r3, spoc410_r4 CASCADE;
 RESET client_min_messages;
 
 --
--- Pin the all-or-nothing restriction behaviour of the repset_add_all_tables()
---
+-- Check: one table that does not satisfy replication restrictions must not cost
+-- the caller the whole schema
 
 CREATE SCHEMA spoc410_mix;
--- a_pk sorts before m_orphan, so it is already added when the call aborts;
--- z_pk sorts after it and is never even looked at
+-- a_pk sorts before m_orphan and z_pk after it, so this also shows that the
+-- scan carries on past the table it skips
 CREATE TABLE spoc410_mix.a_pk (id int PRIMARY KEY, payload text);
 CREATE TABLE spoc410_mix.m_orphan (id int, payload text);
 CREATE TABLE spoc410_mix.z_pk (id int PRIMARY KEY, payload text);
@@ -576,26 +549,42 @@ CREATE VIEW public.spoc410_members AS
 
 SELECT spock.repset_create('spoc410_mix_upd') IS NOT NULL AS created;
 
--- Today: the whole call dies on the one table that cannot be replicated
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
 
--- ... and a_pk, which had been accepted, is gone with it
+-- a_pk and z_pk are in, only m_orphan stayed out
 SELECT set_name, nspname, relname FROM public.spoc410_members
  ORDER BY 1, 2, 3;
 
--- An INSERT-only set never has to identify a row, so the same schema goes in
--- whole, m_orphan included.
+-- The same schema named twice must not turn into a duplicate key failure, and
+-- must not report the same relation twice either.
+SELECT spock.repset_add_all_tables('spoc410_mix_upd',
+	'{spoc410_mix,spoc410_mix}');
+
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+
+-- Naming that same table explicitly is still an error: the caller asked for
+-- this one table, so silently doing nothing would be worse than failing.
+SELECT spock.repset_add_table('spoc410_mix_upd', 'spoc410_mix.m_orphan');
+
+-- A schema that may never hold replicated relations is an error too.  The
+-- caller named it, and scanning it could achieve nothing but a warning per
+-- relation: errors are about what the caller asked for, warnings about what we
+-- found inside a schema we were told to scan.
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spock}');
+
+-- The requirement belongs to the replication set, not to the routine: an
+-- INSERT-only set never has to identify a row, so m_orphan goes in too.
 SELECT spock.repset_create('spoc410_mix_ins',
 	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
 
 SELECT spock.repset_add_all_tables('spoc410_mix_ins', '{spoc410_mix}');
 
--- Three tables in the replication set
 SELECT set_name, nspname, relname FROM public.spoc410_members
  ORDER BY 1, 2, 3;
 
--- And the ERROR really was only about the missing identity: give m_orphan a
--- PRIMARY KEY and the very same call succeeds.
+-- Give m_orphan a PRIMARY KEY and a later call picks it up, without touching
+-- the members already there.
 ALTER TABLE spoc410_mix.m_orphan ADD PRIMARY KEY (id);
 
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');

--- a/tests/regress/sql/replication_set.sql
+++ b/tests/regress/sql/replication_set.sql
@@ -567,10 +567,8 @@ SELECT set_name, nspname, relname FROM public.spoc410_members
 -- this one table, so silently doing nothing would be worse than failing.
 SELECT spock.repset_add_table('spoc410_mix_upd', 'spoc410_mix.m_orphan');
 
--- A schema that may never hold replicated relations is an error too.  The
--- caller named it, and scanning it could achieve nothing but a warning per
--- relation: errors are about what the caller asked for, warnings about what we
--- found inside a schema we were told to scan.
+-- A schema no replication set may draw from is reported once and passed over,
+-- not once per relation it holds.
 SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spock}');
 
 -- The requirement belongs to the replication set, not to the routine: an
@@ -591,6 +589,33 @@ SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
 
 SELECT set_name, nspname, relname FROM public.spoc410_members
  ORDER BY 1, 2, 3;
+
+-- Every table of the schema is replicatable by now, so the only thing the next
+-- call reports is the failure itself.  Schemas are resolved one at a time, as
+-- the loop reaches them: spoc410_mix is scanned and all of it added to the
+-- fresh set before the second name is looked up and fails.  Everything the
+-- routine writes is an ordinary catalog insert, so that work goes with it.
+SELECT spock.repset_create('spoc410_mix_err') IS NOT NULL AS created;
+
+SELECT spock.repset_add_all_tables('spoc410_mix_err',
+	'{spoc410_mix,nosuchschema}');
+
+-- ... and the set is left empty, not half full
+SELECT count(*) AS members FROM public.spoc410_members
+ WHERE set_name = 'spoc410_mix_err';
+
+-- Same for a relation of an extension no replication set may draw from.
+CREATE TABLE spoc410_mix.e_ext (id int PRIMARY KEY, payload text);
+ALTER EXTENSION spock ADD TABLE spoc410_mix.e_ext;
+
+SELECT spock.repset_add_all_tables('spoc410_mix_upd', '{spoc410_mix}');
+
+SELECT set_name, nspname, relname FROM public.spoc410_members
+ ORDER BY 1, 2, 3;
+
+ALTER EXTENSION spock DROP TABLE spoc410_mix.e_ext;
+
+SELECT spock.repset_drop('spoc410_mix_err');
 
 SELECT spock.repset_drop('spoc410_mix_upd');
 

--- a/tests/regress/sql/replication_set.sql
+++ b/tests/regress/sql/replication_set.sql
@@ -331,3 +331,224 @@ SELECT * FROM spoc_102g_d ORDER BY x; -- See (-5).
 -- Cleanup
 \c :provider_dsn
 SELECT spock.replicate_ddl('DROP TABLE IF EXISTS spoc_102g_d,spoc_102l_d CASCADE');
+
+--
+-- What does spock.repset_add_all_tables() actually collect?
+--
+
+\set VERBOSITY default
+
+CREATE SCHEMA spoc410_ok;
+CREATE SCHEMA spoc410_r1;
+CREATE SCHEMA spoc410_r2;
+CREATE SCHEMA spoc410_r3;
+CREATE SCHEMA spoc410_r4;
+
+-- accepted: single-column PRIMARY KEY, REPLICA IDENTITY DEFAULT
+CREATE TABLE spoc410_ok.t_pk (id int PRIMARY KEY, payload text);
+
+-- accepted: composite PRIMARY KEY
+CREATE TABLE spoc410_ok.t_pk_multi (a int, b text, payload text,
+	PRIMARY KEY (a, b));
+
+-- accepted: custom identity -- a unique index over NOT NULL columns
+CREATE TABLE spoc410_ok.t_using_index (a int NOT NULL, b int NOT NULL,
+	payload text);
+CREATE UNIQUE INDEX t_using_index_ri ON spoc410_ok.t_using_index (a, b);
+ALTER TABLE spoc410_ok.t_using_index REPLICA IDENTITY USING INDEX t_using_index_ri;
+
+-- accepted: the partitioned table AND every partition of it.  Partitions are
+-- plain 'r' relations, so they are collected one by one, in their own right.
+CREATE TABLE spoc410_ok.t_part (id int, ts date, PRIMARY KEY (id, ts))
+	PARTITION BY RANGE (ts);
+CREATE TABLE spoc410_ok.t_part_2025 PARTITION OF spoc410_ok.t_part
+	FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+CREATE TABLE spoc410_ok.t_part_2026 PARTITION OF spoc410_ok.t_part
+	FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+
+-- never collected: wrong relkind, or not permanent
+CREATE VIEW spoc410_ok.v_view AS SELECT * FROM spoc410_ok.t_pk;
+CREATE MATERIALIZED VIEW spoc410_ok.m_matview AS SELECT * FROM spoc410_ok.t_pk;
+CREATE SEQUENCE spoc410_ok.s_seq;
+CREATE UNLOGGED TABLE spoc410_ok.u_unlogged (id int PRIMARY KEY);
+
+-- rejected: a UNIQUE NOT NULL index is not enough, the identity is still
+-- DEFAULT and there is no PRIMARY KEY for DEFAULT to point at
+CREATE TABLE spoc410_r1.t_unique_no_pk (id int NOT NULL UNIQUE, payload text);
+
+-- rejected: REPLICA IDENTITY FULL is not an index
+CREATE TABLE spoc410_r2.t_full (id int NOT NULL, payload text);
+ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY FULL;
+
+-- rejected: PRIMARY KEY present, but the identity is switched off
+CREATE TABLE spoc410_r3.t_nothing (id int PRIMARY KEY, payload text);
+ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY NOTHING;
+
+-- rejected: no identity of any kind
+CREATE TABLE spoc410_r4.t_no_identity (id int, payload text);
+
+-- Reports the replica identity of every relation of the test schemas, plus
+-- the replication sets it belongs to.  identity_index is exactly what the
+-- relcache would put into rd_replidindex, i.e. NULL means "spock will refuse
+-- this table for an UPDATE/DELETE replicating set".
+CREATE VIEW public.spoc410_state AS
+	SELECT n.nspname, c.relname, c.relkind, c.relpersistence, c.relreplident,
+		   CASE c.relreplident
+			   WHEN 'd' THEN (SELECT i.indexrelid::regclass::text
+								FROM pg_index i
+							   WHERE i.indrelid = c.oid AND i.indisprimary)
+			   WHEN 'i' THEN (SELECT i.indexrelid::regclass::text
+								FROM pg_index i
+							   WHERE i.indrelid = c.oid AND i.indisreplident)
+		   END AS identity_index,
+		   s.set_name
+	  FROM pg_class c
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		   LEFT JOIN (SELECT t.set_reloid, r.set_name
+						FROM spock.replication_set_table t
+							 JOIN spock.replication_set r ON r.set_id = t.set_id
+							 JOIN spock.local_node l ON l.node_id = r.set_nodeid)
+			 AS s ON s.set_reloid = c.oid
+	 WHERE n.nspname LIKE 'spoc410\_%'
+	   AND c.relkind IN ('r', 'p', 'v', 'm', 'S');
+
+-- Calls the routine under test and reports the verdict instead of aborting
+-- the script.  The subtransaction rollback also shows that a failed call
+-- leaves the replication set exactly as it was.
+CREATE FUNCTION public.spoc410_probe(p_repset name, p_schema text)
+RETURNS text LANGUAGE plpgsql AS $$
+BEGIN
+	PERFORM spock.repset_add_all_tables(p_repset, ARRAY[p_schema]);
+	RETURN 'added';
+EXCEPTION WHEN invalid_parameter_value THEN
+	RETURN 'REJECTED: ' || SQLERRM;
+END;
+$$;
+
+-- Which relations repset_add_all_tables() will even consider
+SELECT nspname, relname, relkind, relpersistence,
+	   (relkind IN ('r', 'p') AND relpersistence = 'p') AS candidate
+  FROM public.spoc410_state
+ ORDER BY nspname, relname;
+
+-- The identity matrix of those candidates.  An empty identity_index is
+-- what makes spock refuse the table.
+SELECT nspname, relname, relreplident, identity_index
+  FROM public.spoc410_state
+ WHERE relkind IN ('r', 'p') AND relpersistence = 'p'
+ ORDER BY nspname, relname;
+
+-- A replication set with the default flags replicates UPDATEs and DELETEs,
+-- so the identity requirement is in force.
+SELECT spock.repset_create('spoc410_upd') IS NOT NULL AS created;
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_ok');
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
+
+-- Only the well-identified tables of spoc410_ok made it in -- including the
+-- partitioned parent and each of its partitions as separate members.
+SELECT set_name, nspname, relname, relkind
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ ORDER BY set_name, nspname, relname;
+
+-- The same rejection unwrapped, with DETAIL and HINT
+SELECT spock.repset_add_all_tables('spoc410_upd', '{spoc410_r2}');
+
+-- Atomicity: one bad table in any of the listed schemas and the entire call
+-- is rolled back, so the fresh replication set stays empty.
+SELECT spock.repset_create('spoc410_atomic') IS NOT NULL AS created;
+
+SELECT spock.repset_add_all_tables('spoc410_atomic',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+
+SELECT count(*) AS members
+  FROM public.spoc410_state WHERE set_name = 'spoc410_atomic';
+
+-- An INSERT-only replication set does not need to identify a row, so the
+-- identity of the table is irrelevant and every candidate is collected.
+SELECT spock.repset_create('spoc410_ins',
+	replicate_update := false, replicate_delete := false) IS NOT NULL AS created;
+
+SELECT spock.repset_add_all_tables('spoc410_ins',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+
+SELECT set_name, nspname, relname, relkind
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ ORDER BY set_name, nspname, relname;
+
+-- Repeating the call is a no-op: relations already in the set are skipped,
+-- so there is no duplicate key failure.
+SELECT spock.repset_add_all_tables('spoc410_ins',
+	'{spoc410_ok,spoc410_r1,spoc410_r2,spoc410_r3,spoc410_r4}');
+
+SELECT set_name, count(*) AS members
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ GROUP BY set_name ORDER BY set_name;
+
+-- ... and the set collected this way can no longer be promoted to replicate
+-- UPDATEs or DELETEs.
+SELECT spock.repset_alter('spoc410_ins', replicate_update := true);
+
+-- Now give each rejected table an index-based identity and watch it become
+-- acceptable.  r1 only needs its existing unique index promoted.
+ALTER TABLE spoc410_r1.t_unique_no_pk
+	REPLICA IDENTITY USING INDEX t_unique_no_pk_id_key;
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r1');
+
+-- r2 is the trap: adding a PRIMARY KEY does nothing while the identity is
+-- still FULL, because FULL never resolves to an index.
+ALTER TABLE spoc410_r2.t_full ADD PRIMARY KEY (id);
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+
+ALTER TABLE spoc410_r2.t_full REPLICA IDENTITY DEFAULT;
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r2');
+
+-- r3 had a PRIMARY KEY all along, only the identity was switched off
+ALTER TABLE spoc410_r3.t_nothing REPLICA IDENTITY DEFAULT;
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r3');
+
+-- r4 genuinely had nothing to identify a row by
+ALTER TABLE spoc410_r4.t_no_identity ADD PRIMARY KEY (id);
+
+SELECT public.spoc410_probe('spoc410_upd', 'spoc410_r4');
+
+SELECT DISTINCT nspname, relname, relreplident, identity_index
+  FROM public.spoc410_state
+ WHERE nspname <> 'spoc410_ok'
+ ORDER BY nspname, relname;
+
+SELECT set_name, count(*) AS members
+  FROM public.spoc410_state
+ WHERE set_name IS NOT NULL
+ GROUP BY set_name ORDER BY set_name;
+
+SELECT spock.repset_add_all_tables('spoc410_ins', '{spoc410_nosuch}');
+
+-- Cleanup.  Drop the replication sets first so that dropping the schemas
+-- does not have to cascade through the memberships.
+SELECT spock.repset_drop('spoc410_upd');
+
+SELECT spock.repset_drop('spoc410_atomic');
+
+SELECT spock.repset_drop('spoc410_ins');
+
+DROP VIEW public.spoc410_state;
+DROP FUNCTION public.spoc410_probe(name, text);
+-- the cascade notice just lists the schema contents, keep it out of the output
+SET client_min_messages = warning;
+DROP SCHEMA spoc410_ok, spoc410_r1, spoc410_r2, spoc410_r3, spoc410_r4 CASCADE;
+RESET client_min_messages;


### PR DESCRIPTION
### Problem

A single table without a replica identity made `spock.repset_add_all_tables()`
raise an error and roll back every table the call had already added. On a schema
of any size that is a poor deal: the caller has to find and fix every offending
table before a single one goes in, and the error names only the first.

The expected behaviour is that all replicatable tables are added and the ones
that cannot be replicated are skipped with a warning.

### What changes

`repset_add_all_tables()` now reports each relation it cannot take and carries on
with the rest of the schema. A relation is passed over when:

- the replication set replicates UPDATEs or DELETEs and the table has no
  index-based replica identity;
- the relation belongs to an extension listed in `spock.reserved_object`.

A schema listed in `spock.reserved_object` is reported once and passed over as a
whole, rather than once per relation it holds.

```
WARNING:  skipping table public.orders for replication set default
DETAIL:  Table has no replica identity index, and the replication set replicates UPDATEs or DELETEs.
HINT:  Add a PRIMARY KEY to the table, or nominate a unique index on NOT NULL columns with ALTER TABLE ... REPLICA IDENTITY USING INDEX.
```

**Unchanged:** `repset_add_table()` still raises an error. Asked for one relation
by name, silently doing nothing would be worse than failing. Errors are also
still raised for problems with the arguments themselves — a schema that does not
exist aborts the call.
