### PR TITLE
Cherry-pick exception-log and failover-slot fixes onto main

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -640,8 +640,6 @@ handle_begin(StringInfo s)
 	XLogRecPtr	commit_lsn;
 	TimestampTz commit_time;
 	bool		slot_found = false;
-	int			sub_name_len = strlen(MySubscription->name);
-	char	   *slot_name;
 
 	SPOCK_WORKER_DELAY();
 
@@ -703,9 +701,9 @@ handle_begin(StringInfo s)
 		for (int i = 0; i < SpockCtx->total_workers; i++)
 		{
 			exception_log = &exception_log_ptr[i];
-			slot_name = NameStr(exception_log->slot_name);
 
-			if (strncmp(slot_name, MySubscription->name, sub_name_len) == 0)
+			if (namestrcmp(&exception_log->slot_name,
+						   MySubscription->name) == 0)
 			{
 				/* We found our slot in shared memory. */
 				slot_found = true;
@@ -741,9 +739,9 @@ handle_begin(StringInfo s)
 			for (int i = 0; i < SpockCtx->total_workers; i++)
 			{
 				exception_log = &exception_log_ptr[i];
-				slot_name = NameStr(exception_log->slot_name);
 
-				if (strncmp(slot_name, MySubscription->name, sub_name_len) == 0)
+				if (namestrcmp(&exception_log->slot_name,
+							   MySubscription->name) == 0)
 				{
 					/* We found our slot in shared memory. */
 					slot_found = true;
@@ -756,7 +754,8 @@ handle_begin(StringInfo s)
 					break;
 				}
 
-				if (free_slot_index < 0 && strlen(slot_name) == 0)
+				if (free_slot_index < 0 &&
+					NameStr(exception_log->slot_name)[0] == '\0')
 				{
 					free_slot_index = i;
 				}

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -700,7 +700,7 @@ handle_begin(StringInfo s)
 	{
 		first_begin_at_startup = false;
 
-		for (int i = 0; i <= SpockCtx->total_workers; i++)
+		for (int i = 0; i < SpockCtx->total_workers; i++)
 		{
 			exception_log = &exception_log_ptr[i];
 			slot_name = NameStr(exception_log->slot_name);
@@ -738,7 +738,7 @@ handle_begin(StringInfo s)
 			 */
 			LWLockAcquire(SpockCtx->lock, LW_EXCLUSIVE);
 
-			for (int i = 0; i <= SpockCtx->total_workers; i++)
+			for (int i = 0; i < SpockCtx->total_workers; i++)
 			{
 				exception_log = &exception_log_ptr[i];
 				slot_name = NameStr(exception_log->slot_name);

--- a/src/spock_failover_slots.c
+++ b/src/spock_failover_slots.c
@@ -437,10 +437,16 @@ get_database_oid(const char *dbname)
  * This is slightly complicated because we default to primary_conninfo if
  * user didn't explicitly set anything and we might need to request explicit
  * database name override, that's why we need dedicated function for this.
+ *
+ * Returns false if no connection string is available yet, which only happens
+ * on the primary_conninfo path; connstr is left untouched in that case and the
+ * caller must not try to connect.  See the comment on that path below.
  */
-static void
+static bool
 make_sync_failover_slots_dsn(StringInfo connstr, char *db_name)
 {
+	char		conninfo[MAXCONNINFO];
+
 	if (spock_failover_slots_dsn && strlen(spock_failover_slots_dsn) > 0)
 	{
 		if (db_name)
@@ -448,13 +454,31 @@ make_sync_failover_slots_dsn(StringInfo connstr, char *db_name)
 							 db_name);
 		else
 			appendStringInfoString(connstr, spock_failover_slots_dsn);
+
+		return true;
 	}
-	else
-	{
-		Assert(WalRcv);
-		appendStringInfo(connstr, "%s dbname=%s", WalRcv->conninfo,
-						 db_name ? db_name : "postgres");
-	}
+
+	/*
+	 * Fall back to the walreceiver's connection string.
+	 * The field might be legitimately empty for as long as a connection
+	 * attempt is in flight.  WalReceiverMain() clears conninfo before calling
+	 * walrcv_connect() and only fills it in once the connection is fully
+	 * established, so this happens on every walreceiver start and restart --
+	 * not merely in a narrow window while the standby comes up.
+	 */
+	Assert(WalRcv);
+
+	SpinLockAcquire(&WalRcv->mutex);
+	strlcpy(conninfo, (char *) WalRcv->conninfo, sizeof(conninfo));
+	SpinLockRelease(&WalRcv->mutex);
+
+	if (conninfo[0] == '\0')
+		return false;
+
+	appendStringInfo(connstr, "%s dbname=%s", conninfo,
+					 db_name ? db_name : "postgres");
+
+	return true;
 }
 
 /*
@@ -553,7 +577,19 @@ wait_for_primary_slot_catchup(ReplicationSlot *slot, RemoteSlot *remote_slot)
 	 * postgres here because plugin callback below might want to invoke
 	 * extension functions.  Keep connstr alive for reconnect attempts.
 	 */
-	make_sync_failover_slots_dsn(&connstr, remote_slot->database);
+	if (!make_sync_failover_slots_dsn(&connstr, remote_slot->database))
+	{
+		/*
+		 * The walreceiver dropped its connection string while we were getting
+		 * here, so it is reconnecting to the primary.  Give up on this slot for
+		 * now; the caller's next cycle starts over.
+		 */
+		elog(DEBUG1,
+			 "no connection string for the primary yet, not waiting for slot %s",
+			 remote_slot->name);
+		pfree(connstr.data);
+		return false;
+	}
 
 	conn = remote_connect(connstr.data, "spock_failover_slots");
 
@@ -1066,7 +1102,15 @@ synchronize_failover_slots(long sleep_time)
 	elog(DEBUG1, "starting replication slot synchronization from primary");
 
 	initStringInfo(&connstr);
-	make_sync_failover_slots_dsn(&connstr, NULL /* Use default db name */ );
+	if (!make_sync_failover_slots_dsn(&connstr, NULL /* Use default db name */ ))
+	{
+		/* Nothing to connect with yet.  Nap and retry later. */
+		elog(DEBUG1, "no connection string for the primary yet, "
+			 "deferring replication slot synchronization");
+		pfree(connstr.data);
+		return sleep_time;
+	}
+
 	conn = remote_connect(connstr.data, "spock_failover_slots");
 
 	/*


### PR DESCRIPTION
## Description

Three fixes that were reviewed and merged on spoc-627, brought over to main unchanged. Each commit keeps its (cherry picked from commit ...) trailer.

## Commit	Source
- Fix off-by-one scan of the exception log array in handle_begin()	ad49bf99
- Match the exception log slot name exactly, not by prefix	59ab49e1
- Don't kill the failover-slots worker while the walreceiver has no conninfo	d9e911c5