### PR TITLE
Fix the log level re-check for downgraded retry messages, and silence three warnings

### DIFF
--- a/src/compat/15/spock_compat.h
+++ b/src/compat/15/spock_compat.h
@@ -125,4 +125,10 @@
 #endif
 #endif
 
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/15/spock_compat.h
+++ b/src/compat/15/spock_compat.h
@@ -110,5 +110,19 @@
 							restart_seqs, run_as_table_owner) \
 		ExecuteTruncateGuts(explicit_rels, relids, relids_logged, behavior, \
 							restart_seqs)
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
 
 #endif

--- a/src/compat/16/spock_compat.h
+++ b/src/compat/16/spock_compat.h
@@ -135,5 +135,19 @@
 /* Must use this interface for access HeapTuple in ReorderBufferChange */
 #define ReorderBufferChangeHeapTuple(change, tuple_type) \
 	&change->data.tp.tuple_type->tuple
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
 
 #endif

--- a/src/compat/16/spock_compat.h
+++ b/src/compat/16/spock_compat.h
@@ -150,4 +150,10 @@
 #endif
 #endif
 
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/17/spock_compat.h
+++ b/src/compat/17/spock_compat.h
@@ -117,5 +117,19 @@
 /* Must use this interface for access HeapTuple in ReorderBufferChange */
 #define ReorderBufferChangeHeapTuple(change, tuple_type) \
 	change->data.tp.tuple_type
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
 
 #endif

--- a/src/compat/17/spock_compat.h
+++ b/src/compat/17/spock_compat.h
@@ -132,4 +132,10 @@
 #endif
 #endif
 
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/18/spock_compat.h
+++ b/src/compat/18/spock_compat.h
@@ -143,4 +143,10 @@ extern bool check_simple_rowfilter_expr(Node *node, ParseState *pstate);
 #endif
 #endif
 
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/18/spock_compat.h
+++ b/src/compat/18/spock_compat.h
@@ -128,5 +128,19 @@
 
 #include "parser/parse_node.h"
 extern bool check_simple_rowfilter_expr(Node *node, ParseState *pstate);
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
 
 #endif

--- a/src/compat/19/spock_compat.h
+++ b/src/compat/19/spock_compat.h
@@ -177,4 +177,12 @@ extern bool check_simple_rowfilter_expr(Node *node, ParseState *pstate);
 #define isQueryUsingTempRelation(query) \
 	query_uses_temp_object((query), &(ObjectAddress){0})
 
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ * Requires miscadmin.h for MyBackendType.
+ */
+#include "miscadmin.h"
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages[MyBackendType])
+
 #endif

--- a/src/spock.c
+++ b/src/spock.c
@@ -69,6 +69,8 @@
 #include "spock_shmem.h"
 #include "spock.h"
 
+#include "spock_compat.h"
+
 #if PG_VERSION_NUM >= 180000
 PG_MODULE_MAGIC_EXT(
 	.name = "spock",
@@ -988,10 +990,17 @@ log_message_filter(ErrorData *edata)
 
 		if (lower_output_level)
 		{
-			/* Reconsider decision on exposing the message */
-			if (log_min_messages < edata->elevel)
+			/*
+			 * Reconsider the decision on exposing the message.  errstart()
+			 * made it for the original elevel, which was LOG and therefore
+			 * loud enough to pass both thresholds; now that the level is
+			 * DEBUG1 the message must be held back wherever DEBUG1 is below
+			 * the threshold.  The test is the same one is_log_level_output()
+			 * applies for a non-LOG elevel: emit when elevel >= the minimum.
+			 */
+			if (edata->elevel < SPOCK_LOG_MIN_MESSAGES)
 				edata->output_to_server = false;
-			if (client_min_messages < edata->elevel)
+			if (edata->elevel < client_min_messages)
 				edata->output_to_client = false;
 		}
 	}

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -90,6 +90,8 @@
 #include "spock.h"
 #include "spock_injection.h"
 
+#include "spock_compat.h"
+
 
 PGDLLEXPORT void spock_apply_main(Datum main_arg);
 
@@ -2803,7 +2805,7 @@ handle_queued_message(HeapTuple msgtup, bool tx_just_started)
 	{
 		case QUEUE_COMMAND_TYPE_DDL:
 			in_spock_queue_ddl_command = true;
-			/* fallthrough */
+			pg_fallthrough;
 		case QUEUE_COMMAND_TYPE_SQL:
 			errcallback_arg.action_name = "QUEUED_SQL";
 			handle_sql_or_exception(queued_message, tx_just_started);

--- a/src/spock_group.c
+++ b/src/spock_group.c
@@ -165,8 +165,8 @@ spock_group_shmem_startup(bool found)
 		spock_group_resource_load();
 
 		elog(DEBUG1,
-			 "spock_group_shmem_startup: hash initialized with %lu entries from resource file",
-			 hash_get_num_entries(SpockGroupHash));
+			 "spock_group_shmem_startup: hash initialized with " INT64_FORMAT " entries from resource file",
+			 (int64) hash_get_num_entries(SpockGroupHash));
 	}
 }
 

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -988,7 +988,7 @@ get_node_interface_by_name(Oid nodeid, const char *name, bool missing_ok)
  * INTERNAL dependency type.
  */
 static inline Oid
-generate_subscription_id()
+generate_subscription_id(void)
 {
 	RangeVar   *rv;
 	Relation	rel;


### PR DESCRIPTION
## Description

Two independent commits, kept together because the second needs the compat macro and neither is big enough to be worth its own review.

### 1. Silence three compiler warnings

Annotate the deliberate fall-through in handle_queued_message() with pg_fallthrough. clang does not accept a comment as the annotation the way gcc does. pg_fallthrough is new in PG19; added to the older compat headers, keying off the compiler rather than the server version since it is a compiler feature.
hash_get_num_entries() returns int64 as of PG19, which no longer matches the %lu in spock_group_shmem_startup()'s debug message. Cast and use INT64_FORMAT, correct on every supported major and where long is 32 bits.
Give generate_subscription_id() a (void) parameter list. An empty list is a declaration without a prototype — deprecated in all C versions, rejected in C23.

### 2. Fix the log level re-check for downgraded retry messages

spock_error_callback() lowers two serialization-failure retry messages from LOG to DEBUG1, then reconsiders whether they should still be emitted, because errstart() made that decision for the original level. Both comparisons were the wrong way round: they suppressed the message exactly when it should have been shown and showed it when it should have been suppressed. With default settings the branch was never taken at all — log_min_messages of WARNING is not less than DEBUG1 — so the messages went to the server log at DEBUG1 regardless of the threshold, the opposite of what this code exists to do.

PG19 made the mistake visible: log_min_messages is now an array indexed by backend type, so comparing it against an elevel compares a pointer with an integer and clang warns. SPOCK_LOG_MIN_MESSAGES hides that difference in the compat headers, and the comparison now runs in the direction is_log_level_output() uses — emit when elevel is at least the configured minimum. spock_dependency.c already tests its thresholds this way.