### PR TITLE
Fix `spock.get_lsn_from_commit_ts()` hanging on an idle node

### DIFF
--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -892,7 +892,8 @@ AS 'MODULE_PATHNAME', 'spock_repair_mode';
 -- Function to determine LSN from commit timestamp
 -- ----
 -- Returns the end LSN of the last local commit not newer than commit_ts,
--- scanning from the slot's restart_lsn to the end of WAL.  Returns NULL when
+-- scanning from the slot's restart_lsn up to the flush position captured at the
+-- start of this call; WAL flushed later is not looked at.  Returns NULL when
 -- nothing matched, which means "cannot answer" - the scan cannot look behind
 -- restart_lsn - rather than "no such commit exists".  A caller that has to
 -- have an answer, such as one about to advance a slot, should check for NULL

--- a/sql/spock--6.0.0.sql
+++ b/sql/spock--6.0.0.sql
@@ -891,6 +891,12 @@ AS 'MODULE_PATHNAME', 'spock_repair_mode';
 -- ----
 -- Function to determine LSN from commit timestamp
 -- ----
+-- Returns the end LSN of the last local commit not newer than commit_ts,
+-- scanning from the slot's restart_lsn to the end of WAL.  Returns NULL when
+-- nothing matched, which means "cannot answer" - the scan cannot look behind
+-- restart_lsn - rather than "no such commit exists".  A caller that has to
+-- have an answer, such as one about to advance a slot, should check for NULL
+-- and complain itself.
 CREATE FUNCTION spock.get_lsn_from_commit_ts(slot_name name, commit_ts timestamptz)
 RETURNS pg_lsn STRICT VOLATILE LANGUAGE c AS 'MODULE_PATHNAME', 'spock_get_lsn_from_commit_ts';
 

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -4042,13 +4042,41 @@ spock_resume_apply_workers(PG_FUNCTION_ARGS)
 
 /*
  * Helper function for finding the endptr for a particular commit timestamp
+ *
+ * Scans WAL from the acquired slot's restart_lsn and returns the end position
+ * of the last local commit that is not newer than committs.
+ *
+ * A no-match must stay distinguishable: report it through *found rather than
+ * falling back to restart_lsn, which is a valid-looking position later than
+ * the answer and would make the caller advance a slot past changes it has not
+ * replicated.
+ *
+ * Note "last" is in WAL order, not timestamp order: a transaction takes its
+ * commit timestamp before inserting the record, so under concurrency a commit
+ * with a slightly older timestamp can sit after the record that ends the scan.
+ * The result is therefore never too late, but can be a few records early.
  */
 static XLogRecPtr
-spock_logical_replication_slot_scan(TimestampTz committs)
+spock_logical_replication_slot_scan(TimestampTz committs, bool *found)
 {
 	LogicalDecodingContext *ctx;
 	ResourceOwner old_resowner = CurrentResourceOwner;
-	XLogRecPtr	retlsn;
+	XLogRecPtr	retlsn = InvalidXLogRecPtr;
+	XLogRecPtr	start_lsn = MyReplicationSlot->data.restart_lsn;
+	XLogRecPtr	end_of_wal;
+
+	Assert(!XLogRecPtrIsInvalid(start_lsn));	/* checked by the caller */
+
+	*found = false;
+
+	/*
+	 * Fix the upper bound of the scan before reading anything.
+	 *
+	 * The page_read callback used below waits for WAL rather than reporting
+	 * its end: once the reader catches up with the flush position it sleeps in
+	 * pg_usleep() until somebody appends more, which on an idle node is never.
+	 */
+	end_of_wal = GetFlushRecPtr(NULL);
 
 	PG_TRY();
 	{
@@ -4069,53 +4097,78 @@ spock_logical_replication_slot_scan(TimestampTz committs)
 		 * Start reading at the slot's restart_lsn, which we know to point to
 		 * a valid record.
 		 */
-		XLogBeginRead(ctx->reader, MyReplicationSlot->data.restart_lsn);
-		retlsn = MyReplicationSlot->data.restart_lsn;
+		XLogBeginRead(ctx->reader, start_lsn);
 
 		/* invalidate non-timetravel entries */
 		InvalidateSystemCaches();
 
-		/* Decode at least one record, until we run out of records */
-		while (true)
+		while (ctx->reader->EndRecPtr < end_of_wal)
 		{
 			char	   *errm = NULL;
 			XLogRecord *record;
+			xl_xact_commit *xlrec;
+			uint8		info;
 
-			/*
-			 * Read records.  No changes are generated in fast_forward mode,
-			 * but snapbuilder/slot statuses are updated properly.
-			 */
+			/* Keep this ahead of the continue's below, or they skip it */
+			CHECK_FOR_INTERRUPTS();
+
 			record = XLogReadRecord(ctx->reader, &errm);
 			if (errm)
 				elog(ERROR, "could not find record while advancing replication slot: %s",
 					 errm);
 
-			if (record)
-			{
-				if (record->xl_rmid == RM_XACT_ID)
-				{
-					RepOriginId nodeid;
-					TimestampTz ts;
-
-					if (record->xl_xid == InvalidTransactionId)
-						continue;
-
-					TransactionIdGetCommitTsData(record->xl_xid,
-												 &ts, &nodeid);
-
-					if (nodeid == 0 && ts > committs)
-						break;
-
-					if (nodeid == 0)
-						retlsn = ctx->reader->EndRecPtr;
-				}
-			}
-			else
-			{
+			/*
+			 * A NULL record with no message means the reader gave up short of
+			 * end_of_wal - it does that on a historic timeline, say after the
+			 * upstream of a cascading standby was promoted mid-scan.  The scan
+			 * result is then truncated rather than wrong: too early, never too
+			 * late.
+			 */
+			if (record == NULL)
 				break;
-			}
 
-			CHECK_FOR_INTERRUPTS();
+			if (record->xl_rmid != RM_XACT_ID)
+				continue;
+
+			/*
+			 * Only the commit opcodes carry a commit timestamp; aborts,
+			 * prepares and XLOG_XACT_ASSIGNMENT do not.  COMMIT PREPARED has
+			 * to be included even though Spock never produces one: WAL is
+			 * cluster-wide, so another application on this instance can, and
+			 * ignoring its commit lets the scan run past it and return an LSN
+			 * that is too late.
+			 */
+			info = XLogRecGetInfo(ctx->reader) & XLOG_XACT_OPMASK;
+			if (info != XLOG_XACT_COMMIT && info != XLOG_XACT_COMMIT_PREPARED)
+				continue;
+
+			/*
+			 * This origin test is what confines the scan to local commits, and
+			 * nothing below can stand in for it: xact_time is the local commit
+			 * time even on a replicated transaction, so without this a commit
+			 * from another node is indistinguishable from one of ours.
+			 */
+			if (XLogRecGetOrigin(ctx->reader) != InvalidRepOriginId)
+				continue;
+
+			/*
+			 * xl_xact_commit leads the record and xact_time is its first field
+			 * for both commit opcodes, so the timestamp needs no parsing.
+			 *
+			 * Do not reach for pg_commit_ts instead.  Once it has been
+			 * truncated past an xid it reports ts = 0, which reads here as a
+			 * commit older than anything the caller can ask about; it errors
+			 * out entirely when track_commit_timestamp is off; and it costs
+			 * CommitTsLock plus an SLRU lookup on every commit record scanned.
+			 */
+			Assert(XLogRecGetDataLen(ctx->reader) >= MinSizeOfXactCommit);
+			xlrec = (xl_xact_commit *) XLogRecGetData(ctx->reader);
+
+			if (xlrec->xact_time > committs)
+				break;
+
+			retlsn = ctx->reader->EndRecPtr;
+			*found = true;
 		}
 
 		/*
@@ -4143,18 +4196,32 @@ spock_logical_replication_slot_scan(TimestampTz committs)
 }
 
 /*
- * SQL function for moving the position in a replication slot.
+ * SQL function for finding the WAL position of a commit timestamp.
+ *
+ * Returns NULL when no commit matched, which means "cannot answer" rather than
+ * "no such commit exists" - the scan cannot look behind the slot's restart_lsn.
+ * Callers must check for it and abandon whatever they meant to do with the
+ * result; any LSN we could invent here would be one they would act on.
  */
 Datum
 spock_get_lsn_from_commit_ts(PG_FUNCTION_ARGS)
 {
 	Name		slotname = PG_GETARG_NAME(0);
 	TimestampTz targettz = PG_GETARG_TIMESTAMPTZ(1);
+	XLogRecPtr	start_lsn;
 	XLogRecPtr	endlsn;
+	bool		found;
 
 	Assert(!MyReplicationSlot);
 
 	CheckSlotPermissions();
+
+	if (RecoveryInProgress())
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("recovery is in progress"),
+				 errhint("%s cannot be executed during recovery.",
+						 "spock.get_lsn_from_commit_ts()")));
 
 	/* Acquire the slot so we "own" it */
 #if PG_VERSION_NUM >= 180000
@@ -4171,13 +4238,29 @@ spock_get_lsn_from_commit_ts(PG_FUNCTION_ARGS)
 						NameStr(*slotname)),
 				 errdetail("This slot has never previously reserved WAL, or it has been invalidated.")));
 
+	/*
+	 * Keep a copy of restart_lsn for the log line below: it is emitted after
+	 * the slot has been released, and MyReplicationSlot must not be read then.
+	 */
+	start_lsn = MyReplicationSlot->data.restart_lsn;
+
 	/* Do the actual slot scanning */
 	if (OidIsValid(MyReplicationSlot->data.database))
-		endlsn = spock_logical_replication_slot_scan(targettz);
+		endlsn = spock_logical_replication_slot_scan(targettz, &found);
 	else
 		elog(ERROR, "not a logical replication slot");
 
 	ReplicationSlotRelease();
+
+	if (!found)
+	{
+		elog(DEBUG1, "SPOCK get_lsn_from_commit_ts: no commit at or before %s in WAL from %X/%X for slot \"%s\"",
+			 DatumGetCString(DirectFunctionCall1(timestamptz_out,
+												 TimestampTzGetDatum(targettz))),
+			 LSN_FORMAT_ARGS(start_lsn), NameStr(*slotname));
+
+		PG_RETURN_NULL();
+	}
 
 	PG_RETURN_LSN(endlsn);
 }

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -55,6 +55,7 @@ test: 032_lolor_largeobject_repset
 test: 033_zodan_lolor_add_node
 test: 034_reserved_object_ddl
 test: 044_apply_change_logging
+test: 045_lsn_from_commit_ts
 # Upgrade schema match test (builds from source, slow):
 #test: 018_upgrade_schema_match
 #

--- a/tests/tap/t/045_lsn_from_commit_ts.pl
+++ b/tests/tap/t/045_lsn_from_commit_ts.pl
@@ -1,0 +1,142 @@
+#!/usr/bin/perl
+#
+# =============================================================================
+# Test: 045_lsn_from_commit_ts.pl - spock.get_lsn_from_commit_ts() on idle node
+# =============================================================================
+# The scan behind spock.get_lsn_from_commit_ts() reads WAL
+# through the waiting page_read callback, which never reports end of WAL - it
+# sleeps until somebody appends more.  Without a bound of its own the scan
+# therefore hangs on a node where nothing is happening, and the Control Plane
+# add-node workflow stalls behind it.
+#
+# A single node with no subscriptions is used deliberately: no apply workers,
+# so once the setup settles nobody writes WAL and the pathological case is
+# reproduced exactly.  A regression makes these calls hang until
+# statement_timeout fires rather than fail outright, so every call is bounded
+# server-side by $SERVER_TIMEOUT and then checked two ways here: it must have
+# succeeded (a cancelled statement leaves an error behind) and it must have
+# taken less than $SLOW_THRESHOLD.  Note the threshold has to sit well below
+# the server timeout - above it, a regressed run cancelled at $SERVER_TIMEOUT
+# would still count as fast enough and the check would pass on broken code.
+#
+# Also checks that a commit made before the requested timestamp is found and
+# reported at or past its own LSN, and that an unanswerable question - one
+# about a time before the slot existed - comes back as NULL.
+# =============================================================================
+
+use strict;
+use warnings;
+use Test::More;
+use Time::HiRes qw(time);
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster get_test_config psql_or_bail scalar_query);
+
+my $SERVER_TIMEOUT = 30;	# statement_timeout for each call
+my $SLOW_THRESHOLD = 5;		# a call slower than this is treated as hung
+
+# Single node, no subscriptions - nothing to generate WAL in the background.
+create_cluster(1, 'Create 1-node cluster for commit timestamp scan');
+
+# Any logical slot will do: the scan reads raw WAL and never decodes it.
+psql_or_bail(1, "SELECT pg_create_logical_replication_slot('cts_probe', 'spock_output')");
+
+# One local commit for the scan to find.  It has to write WAL of its own: a
+# transaction that merely takes an xid does not flush its commit record on the
+# way out, and the scan stops at the flush position.  The message prefix is not
+# spock's, so nothing decodes it.
+my $probe_lsn = scalar_query(1, "SELECT pg_logical_emit_message(true, 'cts_test', 'probe')");
+like($probe_lsn, qr{^[0-9A-Fa-f]+/[0-9A-Fa-f]+$}, "probe commit written at $probe_lsn");
+
+# scalar_query() strips whitespace, so ask for the ISO 8601 'T' form of the
+# timestamp - what comes back has to remain a valid timestamptz literal.  Spell
+# the format out rather than relying on now()::text, whose layout follows
+# DateStyle.  The separator is concatenated instead of quoted inside the
+# to_char pattern, because that needs double quotes and the query travels
+# through a double-quoted shell argument.  now() is stable within the
+# statement, so both halves see the same instant.
+my $after_commit = scalar_query(1,
+	"SELECT to_char(now(), 'YYYY-MM-DD') || 'T' || to_char(now(), 'HH24:MI:SS.USOF')");
+like($after_commit, qr{^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}},
+	'captured a commit timestamp to search for');
+
+# Let the node fall silent.  From here on nothing appends WAL, so a scan
+# without a bound of its own has nothing to wake it up.
+sleep(5);
+
+# Run a query with a server-side timeout and measure how long it took.  The
+# timeout goes through PGOPTIONS rather than a SET statement so that psql does
+# not print the extra command tag into the result we are about to parse.
+# scalar_query() drops stderr, so a failing statement is indistinguishable
+# from one returning the empty string.  Run psql directly instead, with stderr
+# folded in and a server-side timeout so a regressed build cannot wedge the
+# suite: without the timeout the scan waits for WAL this idle node will never
+# write, and prove() waits with it.
+my $config = get_test_config();
+my $psql = "$config->{pg_bin}/psql";
+my $port = $config->{node_ports}[0];
+my $dbname = $config->{db_name};
+
+sub query_output
+{
+	my ($sql) = @_;
+	local $ENV{PGOPTIONS} = "-c statement_timeout=${SERVER_TIMEOUT}s";
+	my $out = `$psql -X -p $port -d $dbname -t -c "$sql" 2>&1`;
+	chomp($out);
+	$out =~ s/^\s+|\s+$//g;
+	return $out;
+}
+
+# Run a query that is expected to succeed, and fail the test if it either
+# errored out or took long enough to look like the hang this file guards
+# against.  Checking both matters: a hung call is cancelled by
+# statement_timeout, which turns into an error rather than a slow success.
+sub timed_query
+{
+	my ($sql, $what) = @_;
+	my $started = time();
+	my $result = query_output($sql);
+	my $elapsed = time() - $started;
+
+	unlike($result, qr/^ERROR:|^psql:/, "$what completed without error");
+	cmp_ok($elapsed, '<', $SLOW_THRESHOLD,
+		sprintf('%s returned in %.1fs (slow threshold %ds)',
+			$what, $elapsed, $SLOW_THRESHOLD));
+
+	return $result;
+}
+
+# The commit made above is not newer than $after_commit, so it is found.  This
+# is the call that used to hang: it reaches the end of WAL and, before the fix,
+# waited there for WAL that this idle node was never going to produce.  The
+# answer is the end of the commit record, so it is at or past the message LSN.
+my $found = timed_query(
+	"SELECT coalesce((spock.get_lsn_from_commit_ts('cts_probe', '$after_commit') >= '$probe_lsn'::pg_lsn)::text, 'NULL')",
+	'scan for a recent commit');
+is($found, 'true', 'recent commit resolved to an LSN at or past the probe');
+
+# Nothing was committed before the year 2000, and the scan cannot look behind
+# the slot's restart_lsn anyway, so the question is unanswerable.  NULL rather
+# than an error: other callers may be fine with a negative answer.  Note a
+# caller about to advance a slot is not - pg_replication_slot_advance() is
+# STRICT and would take the NULL as "do nothing, successfully".
+my $unknown = timed_query(
+	"SELECT coalesce(spock.get_lsn_from_commit_ts('cts_probe', '2000-01-01T00:00:00+00')::text, 'NULL')",
+	'scan for an ancient commit');
+is($unknown, 'NULL', 'unanswerable question reports NULL');
+
+# The function is STRICT, so a NULL argument short-circuits to NULL.
+my $null_arg = scalar_query(1,
+	"SELECT coalesce(spock.get_lsn_from_commit_ts('cts_probe', NULL)::text, 'NULL')");
+is($null_arg, 'NULL', 'NULL commit timestamp yields NULL');
+
+# A physical slot has no database and must be refused, not scanned.
+psql_or_bail(1, "SELECT pg_create_physical_replication_slot('cts_phys', true)");
+my $phys_err = query_output("SELECT spock.get_lsn_from_commit_ts('cts_phys', now())");
+like($phys_err, qr/not a logical replication slot/, 'physical slot is rejected');
+psql_or_bail(1, "SELECT pg_drop_replication_slot('cts_phys')");
+
+psql_or_bail(1, "SELECT pg_drop_replication_slot('cts_probe')");
+
+destroy_cluster('Destroy the cluster');
+
+done_testing();


### PR DESCRIPTION
## Problem

`spock.get_lsn_from_commit_ts()` never returned on a quiet node. The reported
case had the Control Plane add-node workflow stalled behind it for over eleven
minutes; no error, no log line, and every downstream step
(`ReplicationOriginAdvanceResource`, enabling the subscription) blocked behind
it because the workflow is sequential.

## Root cause

`spock_logical_replication_slot_scan()` reads WAL through
`read_local_xlog_page()` — the *waiting* page_read callback. When the reader
catches up with the flush position, that callback does not report end of WAL:
it loops on `pg_usleep(1000)` until somebody appends more
(`xlogutils.c`, `read_local_xlog_page_guts()`).

The scan loop had no bound of its own (`while (true)`), so `XLogReadRecord()`
never returned NULL and the `else break` was unreachable. The only real exit
was finding a local commit newer than the requested timestamp — which on an
idle node never happens. The call returned only when someone else wrote to the
database.

## What this changes

**Bound the loop.** Take the flush position before reading anything and stop
there: `while (ctx->reader->EndRecPtr < end_of_wal)`. This is how core bounds
the same kind of loop in `LogicalSlotAdvanceAndCheckSnapState()`, which also
uses the waiting callback but stops at its `moveto` argument. Deliberately not
`read_local_xlog_page_no_wait()`: it does not exist before PG16 and would need
a shim in `src/compat/15/`, whereas the bound is version-neutral.

`CHECK_FOR_INTERRUPTS()` moved to the top of the loop body — the `continue`s
below used to skip it.

**Take the commit timestamp and origin from the record**, not from
`pg_commit_ts`. Once `pg_commit_ts` has been truncated past an xid it reports
`ts = 0`, which the old code — ignoring the function's return value — read as a
commit older than anything asked about and moved the answer onto it. That
yields an LSN *later* than the caller wanted, and a slot advanced past changes
it has not replicated loses them silently. `pg_commit_ts` also errors out when
`track_commit_timestamp` is off, and costs `CommitTsLock` plus an SLRU lookup
per commit record.

Reading `xl_xact_commit.xact_time` directly requires filtering on
`XLOG_XACT_OPMASK` first (otherwise the cast lands on an abort or a prepare),
and that filter brings `XLOG_XACT_COMMIT_PREPARED` into scope. Spock never
produces one, but WAL is cluster-wide and any other application on the instance
can — skipping it would let the scan run past a commit newer than the target.
These two changes are one unit and cannot be reviewed separately.

**A no-match is now NULL.** It used to be the slot's `restart_lsn`: a
valid-looking position later than the answer, which the caller would then
advance a slot to. NULL means "cannot answer" — the scan cannot look behind
`restart_lsn`, so a timestamp older than the slot itself has no answer here —
and callers must check for it and give up. The function stays `STRICT`, so the
signature does not change.

**Refuse to run during recovery.** Logical decoding on a standby is allowed
from PG16 on, so the scan would otherwise start and compare local commit
timestamps against WAL replayed from a primary. The message follows the core
convention (`recovery is in progress` + hint).