### PR TITLE
[v5_STABLE] Fix `spock.get_lsn_from_commit_ts()` hanging on an idle node

### DIFF
--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -3264,13 +3264,41 @@ spock_resume_apply_workers(PG_FUNCTION_ARGS)
 
 /*
  * Helper function for finding the endptr for a particular commit timestamp
+ *
+ * Scans WAL from the acquired slot's restart_lsn and returns the end position
+ * of the last local commit that is not newer than committs.
+ *
+ * A no-match must stay distinguishable: report it through *found rather than
+ * falling back to restart_lsn, which is a valid-looking position later than
+ * the answer and would make the caller advance a slot past changes it has not
+ * replicated.
+ *
+ * Note "last" is in WAL order, not timestamp order: a transaction takes its
+ * commit timestamp before inserting the record, so under concurrency a commit
+ * with a slightly older timestamp can sit after the record that ends the scan.
+ * The result is therefore never too late, but can be a few records early.
  */
 static XLogRecPtr
-spock_logical_replication_slot_scan(TimestampTz committs)
+spock_logical_replication_slot_scan(TimestampTz committs, bool *found)
 {
 	LogicalDecodingContext *ctx;
 	ResourceOwner old_resowner = CurrentResourceOwner;
-	XLogRecPtr	retlsn;
+	XLogRecPtr	retlsn = InvalidXLogRecPtr;
+	XLogRecPtr	start_lsn = MyReplicationSlot->data.restart_lsn;
+	XLogRecPtr	end_of_wal;
+
+	Assert(!XLogRecPtrIsInvalid(start_lsn));	/* checked by the caller */
+
+	*found = false;
+
+	/*
+	 * Fix the upper bound of the scan before reading anything.
+	 *
+	 * The page_read callback used below waits for WAL rather than reporting
+	 * its end: once the reader catches up with the flush position it sleeps in
+	 * pg_usleep() until somebody appends more, which on an idle node is never.
+	 */
+	end_of_wal = GetFlushRecPtr(NULL);
 
 	PG_TRY();
 	{
@@ -3291,53 +3319,78 @@ spock_logical_replication_slot_scan(TimestampTz committs)
 		 * Start reading at the slot's restart_lsn, which we know to point to
 		 * a valid record.
 		 */
-		XLogBeginRead(ctx->reader, MyReplicationSlot->data.restart_lsn);
-		retlsn = MyReplicationSlot->data.restart_lsn;
+		XLogBeginRead(ctx->reader, start_lsn);
 
 		/* invalidate non-timetravel entries */
 		InvalidateSystemCaches();
 
-		/* Decode at least one record, until we run out of records */
-		while (true)
+		while (ctx->reader->EndRecPtr < end_of_wal)
 		{
 			char	   *errm = NULL;
 			XLogRecord *record;
+			xl_xact_commit *xlrec;
+			uint8		info;
 
-			/*
-			 * Read records.  No changes are generated in fast_forward mode,
-			 * but snapbuilder/slot statuses are updated properly.
-			 */
+			/* Keep this ahead of the continue's below, or they skip it */
+			CHECK_FOR_INTERRUPTS();
+
 			record = XLogReadRecord(ctx->reader, &errm);
 			if (errm)
 				elog(ERROR, "could not find record while advancing replication slot: %s",
 					 errm);
 
-			if (record)
-			{
-				if (record->xl_rmid == RM_XACT_ID)
-				{
-					RepOriginId		nodeid;
-					TimestampTz		ts;
-
-					if (record->xl_xid == InvalidTransactionId)
-						continue;
-
-					TransactionIdGetCommitTsData(record->xl_xid,
-												 &ts, &nodeid);
-
-					if (nodeid == 0 && ts > committs)
-						break;
-
-					if (nodeid == 0)
-						retlsn = ctx->reader->EndRecPtr;
-				}
-			}
-			else
-			{
+			/*
+			 * A NULL record with no message means the reader gave up short of
+			 * end_of_wal - it does that on a historic timeline, say after the
+			 * upstream of a cascading standby was promoted mid-scan.  The scan
+			 * result is then truncated rather than wrong: too early, never too
+			 * late.
+			 */
+			if (record == NULL)
 				break;
-			}
 
-			CHECK_FOR_INTERRUPTS();
+			if (record->xl_rmid != RM_XACT_ID)
+				continue;
+
+			/*
+			 * Only the commit opcodes carry a commit timestamp; aborts,
+			 * prepares and XLOG_XACT_ASSIGNMENT do not.  COMMIT PREPARED has
+			 * to be included even though Spock never produces one: WAL is
+			 * cluster-wide, so another application on this instance can, and
+			 * ignoring its commit lets the scan run past it and return an LSN
+			 * that is too late.
+			 */
+			info = XLogRecGetInfo(ctx->reader) & XLOG_XACT_OPMASK;
+			if (info != XLOG_XACT_COMMIT && info != XLOG_XACT_COMMIT_PREPARED)
+				continue;
+
+			/*
+			 * This origin test is what confines the scan to local commits, and
+			 * nothing below can stand in for it: xact_time is the local commit
+			 * time even on a replicated transaction, so without this a commit
+			 * from another node is indistinguishable from one of ours.
+			 */
+			if (XLogRecGetOrigin(ctx->reader) != InvalidRepOriginId)
+				continue;
+
+			/*
+			 * xl_xact_commit leads the record and xact_time is its first field
+			 * for both commit opcodes, so the timestamp needs no parsing.
+			 *
+			 * Do not reach for pg_commit_ts instead.  Once it has been
+			 * truncated past an xid it reports ts = 0, which reads here as a
+			 * commit older than anything the caller can ask about; it errors
+			 * out entirely when track_commit_timestamp is off; and it costs
+			 * CommitTsLock plus an SLRU lookup on every commit record scanned.
+			 */
+			Assert(XLogRecGetDataLen(ctx->reader) >= MinSizeOfXactCommit);
+			xlrec = (xl_xact_commit *) XLogRecGetData(ctx->reader);
+
+			if (xlrec->xact_time > committs)
+				break;
+
+			retlsn = ctx->reader->EndRecPtr;
+			*found = true;
 		}
 
 		/*
@@ -3365,18 +3418,33 @@ spock_logical_replication_slot_scan(TimestampTz committs)
 }
 
 /*
- * SQL function for moving the position in a replication slot.
+ * SQL function for finding the WAL position of a commit timestamp.
+ *
+ * When no commit matches, the slot's restart_lsn is returned - the result
+ * is then indistinguishable from a real match, so a caller cannot tell that
+ * the question went unanswered.  That is the long-standing behaviour of this
+ * branch and is kept for compatibility; the DEBUG1 line below is what makes
+ * the case visible.
  */
 Datum
 spock_get_lsn_from_commit_ts(PG_FUNCTION_ARGS)
 {
 	Name		slotname = PG_GETARG_NAME(0);
 	TimestampTz	targettz = PG_GETARG_TIMESTAMPTZ(1);
+	XLogRecPtr	start_lsn;
 	XLogRecPtr	endlsn;
+	bool		found;
 
 	Assert(!MyReplicationSlot);
 
 	CheckSlotPermissions();
+
+	if (RecoveryInProgress())
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("recovery is in progress"),
+				 errhint("%s cannot be executed during recovery.",
+						 "spock.get_lsn_from_commit_ts()")));
 
 	/* Acquire the slot so we "own" it */
 #if PG_VERSION_NUM >= 180000
@@ -3393,13 +3461,37 @@ spock_get_lsn_from_commit_ts(PG_FUNCTION_ARGS)
 						NameStr(*slotname)),
 				 errdetail("This slot has never previously reserved WAL, or it has been invalidated.")));
 
+	/*
+	 * Keep a copy of restart_lsn for the log line below: it is emitted after
+	 * the slot has been released, and MyReplicationSlot must not be read then.
+	 */
+	start_lsn = MyReplicationSlot->data.restart_lsn;
+
 	/* Do the actual slot scanning */
 	if (OidIsValid(MyReplicationSlot->data.database))
-		endlsn = spock_logical_replication_slot_scan(targettz);
+		endlsn = spock_logical_replication_slot_scan(targettz, &found);
 	else
 		elog(ERROR, "not a logical replication slot");
 
 	ReplicationSlotRelease();
+
+	/*
+	 * No match.  Keep returning the slot's restart_lsn, as this branch has
+	 * always done on 5.x - callers in the field rely on getting an LSN back,
+	 * and a stable branch is the wrong place to change that.  Note it is a
+	 * position later than the answer would have been, so a caller advancing a
+	 * slot to it skips whatever sits in between; the log line is the only way
+	 * to tell this apart from a real match.
+	 */
+	if (!found)
+	{
+		elog(DEBUG1, "SPOCK get_lsn_from_commit_ts: no commit at or before %s in WAL from %X/%X for slot \"%s\"",
+			 DatumGetCString(DirectFunctionCall1(timestamptz_out,
+												 TimestampTzGetDatum(targettz))),
+			 LSN_FORMAT_ARGS(start_lsn), NameStr(*slotname));
+
+		PG_RETURN_LSN(start_lsn);
+	}
 
 	PG_RETURN_LSN(endlsn);
 }

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -40,6 +40,7 @@ test: 019_stale_fd_epoll_after_conn_death
 test: 021_uc_null_key_skip
 test: 022_apply_mem_context
 test: 025_tiebreaker_equal_warning
+test: 045_lsn_from_commit_ts
 
 # Regression tests
 test: 103_manager_worker_dboid_race

--- a/tests/tap/t/045_lsn_from_commit_ts.pl
+++ b/tests/tap/t/045_lsn_from_commit_ts.pl
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+#
+# =============================================================================
+# Test: 045_lsn_from_commit_ts.pl - spock.get_lsn_from_commit_ts() on idle node
+# =============================================================================
+# The scan behind spock.get_lsn_from_commit_ts() reads WAL
+# through the waiting page_read callback, which never reports end of WAL - it
+# sleeps until somebody appends more.  Without a bound of its own the scan
+# therefore hangs on a node where nothing is happening, and the Control Plane
+# add-node workflow stalls behind it.
+#
+# A single node with no subscriptions is used deliberately: no apply workers,
+# so once the setup settles nobody writes WAL and the pathological case is
+# reproduced exactly.  A regression makes these calls hang until
+# statement_timeout fires rather than fail outright, so every call is bounded
+# server-side by $SERVER_TIMEOUT and then checked two ways here: it must have
+# succeeded (a cancelled statement leaves an error behind) and it must have
+# taken less than $SLOW_THRESHOLD.  Note the threshold has to sit well below
+# the server timeout - above it, a regressed run cancelled at $SERVER_TIMEOUT
+# would still count as fast enough and the check would pass on broken code.
+#
+# Also checks that a commit made before the requested timestamp is found and
+# reported at or past its own LSN, and that an unanswerable question - one
+# about a time before the slot existed - comes back as the slot's restart_lsn.
+# =============================================================================
+
+use strict;
+use warnings;
+use Test::More;
+use Time::HiRes qw(time);
+use lib '.';
+use SpockTest qw(create_cluster destroy_cluster get_test_config psql_or_bail scalar_query);
+
+my $SERVER_TIMEOUT = 30;	# statement_timeout for each call
+my $SLOW_THRESHOLD = 5;		# a call slower than this is treated as hung
+
+# Single node, no subscriptions - nothing to generate WAL in the background.
+create_cluster(1, 'Create 1-node cluster for commit timestamp scan');
+
+# Any logical slot will do: the scan reads raw WAL and never decodes it.  Use
+# test_decoding rather than spock_output - it is in the default
+# output_plugin_libraries, so the slot can be created on servers carrying the
+# security fix that restricts that list.
+psql_or_bail(1, "SELECT pg_create_logical_replication_slot('cts_probe', 'test_decoding')");
+
+# One local commit for the scan to find.  It has to write WAL of its own: a
+# transaction that merely takes an xid does not flush its commit record on the
+# way out, and the scan stops at the flush position.  The message prefix is not
+# spock's, so nothing decodes it.
+my $probe_lsn = scalar_query(1, "SELECT pg_logical_emit_message(true, 'cts_test', 'probe')");
+like($probe_lsn, qr{^[0-9A-Fa-f]+/[0-9A-Fa-f]+$}, "probe commit written at $probe_lsn");
+
+# scalar_query() strips whitespace, so ask for the ISO 8601 'T' form of the
+# timestamp - what comes back has to remain a valid timestamptz literal.  Spell
+# the format out rather than relying on now()::text, whose layout follows
+# DateStyle.  The separator is concatenated instead of quoted inside the
+# to_char pattern, because that needs double quotes and the query travels
+# through a double-quoted shell argument.  now() is stable within the
+# statement, so both halves see the same instant.
+my $after_commit = scalar_query(1,
+	"SELECT to_char(now(), 'YYYY-MM-DD') || 'T' || to_char(now(), 'HH24:MI:SS.USOF')");
+like($after_commit, qr{^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}},
+	'captured a commit timestamp to search for');
+
+# Let the node fall silent.  From here on nothing appends WAL, so a scan
+# without a bound of its own has nothing to wake it up.
+sleep(5);
+
+# Run a query with a server-side timeout and measure how long it took.  The
+# timeout goes through PGOPTIONS rather than a SET statement so that psql does
+# not print the extra command tag into the result we are about to parse.
+# scalar_query() drops stderr, so a failing statement is indistinguishable
+# from one returning the empty string.  Run psql directly instead, with stderr
+# folded in and a server-side timeout so a regressed build cannot wedge the
+# suite: without the timeout the scan waits for WAL this idle node will never
+# write, and prove() waits with it.
+my $config = get_test_config();
+my $psql = "$config->{pg_bin}/psql";
+my $port = $config->{node_ports}[0];
+my $dbname = $config->{db_name};
+
+sub query_output
+{
+	my ($sql) = @_;
+	local $ENV{PGOPTIONS} = "-c statement_timeout=${SERVER_TIMEOUT}s";
+	my $out = `$psql -X -p $port -d $dbname -t -c "$sql" 2>&1`;
+	chomp($out);
+	$out =~ s/^\s+|\s+$//g;
+	return $out;
+}
+
+# Run a query that is expected to succeed, and fail the test if it either
+# errored out or took long enough to look like the hang this file guards
+# against.  Checking both matters: a hung call is cancelled by
+# statement_timeout, which turns into an error rather than a slow success.
+sub timed_query
+{
+	my ($sql, $what) = @_;
+	my $started = time();
+	my $result = query_output($sql);
+	my $elapsed = time() - $started;
+
+	unlike($result, qr/^ERROR:|^psql:/, "$what completed without error");
+	cmp_ok($elapsed, '<', $SLOW_THRESHOLD,
+		sprintf('%s returned in %.1fs (slow threshold %ds)',
+			$what, $elapsed, $SLOW_THRESHOLD));
+
+	return $result;
+}
+
+# The commit made above is not newer than $after_commit, so it is found.  This
+# is the call that used to hang: it reaches the end of WAL and, before the fix,
+# waited there for WAL that this idle node was never going to produce.  The
+# answer is the end of the commit record, so it is at or past the message LSN.
+my $found = timed_query(
+	"SELECT coalesce((spock.get_lsn_from_commit_ts('cts_probe', '$after_commit') >= '$probe_lsn'::pg_lsn)::text, 'NULL')",
+	'scan for a recent commit');
+is($found, 'true', 'recent commit resolved to an LSN at or past the probe');
+
+# Nothing was committed before the year 2000, and the scan cannot look behind
+# the slot's restart_lsn anyway, so the question is unanswerable.  The answer
+# is then restart_lsn itself, which a caller cannot tell from a real match -
+# long-standing behaviour of this branch, asserted here so that a change to it
+# is a deliberate one.
+my $restart_lsn = scalar_query(1,
+	"SELECT restart_lsn FROM pg_replication_slots WHERE slot_name = 'cts_probe'");
+like($restart_lsn, qr{^[0-9A-Fa-f]+/[0-9A-Fa-f]+$}, "probe slot sits at $restart_lsn");
+
+my $unknown = timed_query(
+	"SELECT coalesce((spock.get_lsn_from_commit_ts('cts_probe', '2000-01-01T00:00:00+00') = '$restart_lsn'::pg_lsn)::text, 'NULL')",
+	'scan for an ancient commit');
+is($unknown, 'true', 'unanswerable question falls back to the slot restart_lsn');
+
+# The function is STRICT, so a NULL argument short-circuits to NULL.
+my $null_arg = scalar_query(1,
+	"SELECT coalesce(spock.get_lsn_from_commit_ts('cts_probe', NULL)::text, 'NULL')");
+is($null_arg, 'NULL', 'NULL commit timestamp yields NULL');
+
+# A physical slot has no database and must be refused, not scanned.
+psql_or_bail(1, "SELECT pg_create_physical_replication_slot('cts_phys', true)");
+my $phys_err = query_output("SELECT spock.get_lsn_from_commit_ts('cts_phys', now())");
+like($phys_err, qr/not a logical replication slot/, 'physical slot is rejected');
+psql_or_bail(1, "SELECT pg_drop_replication_slot('cts_phys')");
+
+psql_or_bail(1, "SELECT pg_drop_replication_slot('cts_probe')");
+
+destroy_cluster('Destroy the cluster');
+
+done_testing();


### PR DESCRIPTION
## What is in this PR

The same change as on `main` (see that PR for the full reasoning):

- bound the scan by the flush position taken before the first read, the way
  core bounds the same loop in `LogicalSlotAdvanceAndCheckSnapState()`;
- move `CHECK_FOR_INTERRUPTS()` to the top of the loop body;
- take the commit timestamp and the origin from the WAL record instead of
  `pg_commit_ts`, which requires filtering on `XLOG_XACT_OPMASK` and brings
  `COMMIT PREPARED` into scope;
- refuse to run during recovery, where the scan would compare local commit
  timestamps against WAL replayed from a primary.

## Deliberate differences from `main`

**A no-match still returns the slot's `restart_lsn`.** On `main` it became
NULL, because that position is a valid-looking answer later than the real one.
On a stable branch that is a breaking change for callers already in the field,
so the old behaviour is kept and the case is instead reported at DEBUG1:

```
SPOCK get_lsn_from_commit_ts: no commit at or before <ts> in WAL from <lsn> for slot "<name>"
```

The comment above the return says plainly that the result cannot be
distinguished from a real match. The TAP test asserts the fallback, so changing
it later has to be deliberate.

**`sql/spock--5.0.0.sql` is untouched.** 5.0.0 is released and installed in the
field; its script is not edited. The contract is documented in the C comment
only. (On `main` the corresponding comment went into `spock--6.0.0.sql`, which
is still in development.)

**The test creates its probe slot with `test_decoding`, not `spock_output`.**
The scan reads raw WAL and never decodes, so the plugin is irrelevant to what
is being tested, and `test_decoding` is in the default
`output_plugin_libraries` — see the infrastructure note below.