### PR TITLE
Backport of #580 to `v5_STABLE`.

### DIFF
--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -648,6 +648,31 @@ should_log_exception(bool failed)
 }
 
 /*
+ * Reset one exception log entry to the "no failure recorded" state.
+ *
+ * Only the apply worker of the subscription named in slot_name ever writes its
+ * own entry, so no lock is taken here.  The caller must have established that
+ * the recorded failure is not the transaction about to be applied; wiping the
+ * entry of a failure that is still pending would lose the root cause we report
+ * for it.
+ *
+ * local_tuple is included deliberately.  It is a HeapTuple copied into
+ * ApplyOperationContext by the conflict handling code, and every path that
+ * reaches here has already reset that context, so the pointer parked in shared
+ * memory is dangling.
+ */
+static void
+clear_exception_log_entry(SpockExceptionLog *entry)
+{
+	Assert(entry != NULL);
+
+	entry->commit_lsn = InvalidXLogRecPtr;
+	entry->local_tuple = NULL;
+	entry->initial_error_message[0] = '\0';
+	entry->failed_action = 0;
+}
+
+/*
  * Forget the in-flight transaction marker after a transient failure on the
  * normal apply path.
  *
@@ -681,10 +706,7 @@ clear_transient_exception_state(const char *reason)
 		return;
 
 	exception_log = &exception_log_ptr[my_exception_log_index];
-	exception_log->commit_lsn = InvalidXLogRecPtr;
-	exception_log->local_tuple = NULL;
-	exception_log->initial_error_message[0] = '\0';
-	exception_log->failed_action = 0;
+	clear_exception_log_entry(exception_log);
 
 	elog(DEBUG1, "SPOCK %s: cleared transient exception state after %s",
 		 MySubscription->name, reason);

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -963,8 +963,8 @@ handle_begin(StringInfo s)
 	 * the entries. We need to create a slot here as well.
 	 *
 	 * 3. The error log is not empty and we found our entry, but the commit
-	 * lsn does not match. We simply update the commit lsn and move on. This
-	 * case happens when we have not errored out previously.
+	 * lsn does not match. The recorded failure is not this transaction, so we
+	 * clear the entry, leave exception handling off and apply normally.
 	 *
 	 * 4. The error log is not empty, we found our entry and the commit lsn.
 	 * This would mean that we previously errored and restarted. We set the
@@ -1086,6 +1086,33 @@ handle_begin(StringInfo s)
 			 * exception handling, don't go into a fast error loop.
 			 */
 			MySpockWorker->restart_delay = restart_delay_default;
+		}
+		else
+		{
+			/*
+			 * The recorded failure is not this transaction, so this one has not
+			 * been attempted yet and must be applied normally.
+			 *
+			 * use_try_block lives in the worker's shared memory slot and is not
+			 * per-transaction state, so it can still be set from an earlier
+			 * failure.  The case that matters is an error raised between remote
+			 * transactions: apply_work() switches to replay mode even though
+			 * nothing was queued for this cycle, and the flag then belongs to
+			 * whichever transaction the provider sends next.  Leaving it set
+			 * would replay that transaction read-only and, under TRANSDISCARD
+			 * or SUB_DISABLE, discard it -- a transaction that never failed,
+			 * reported as if the exception policy had fired.
+			 *
+			 * Drop the recorded root cause along with the flag.  Nothing will
+			 * be attributed to it now, and leaving it behind would make the
+			 * next genuine exception surface a stale "Initial error".
+			 *
+			 * We only get here on the first BEGIN of an apply cycle, which is
+			 * also the first BEGIN after an exception: apply_work() sets
+			 * first_begin_at_startup back to true when it catches one.
+			 */
+			MyApplyWorker->use_try_block = false;
+			clear_exception_log_entry(exception_log);
 		}
 	}
 
@@ -1421,8 +1448,11 @@ handle_commit(StringInfo s)
 	xact_had_exception = false;
 
 	/*
-	 * This is the only place we can reset the use_try_block = false without
-	 * any risk of going into the error deathloop
+	 * Clearing use_try_block here cannot start an error deathloop: the
+	 * transaction has committed, so there is nothing left to retry.  The only
+	 * other places that may clear it are the ones which have established that
+	 * the incoming transaction is not the failure recorded in the exception log
+	 * (see handle_begin).
 	 */
 	MyApplyWorker->use_try_block = false;
 
@@ -3886,6 +3916,15 @@ stream_replay:
 
 		apply_replay_next = apply_replay_head;
 		in_remote_transaction = false;
+
+		/*
+		 * Re-arm the exception log lookup in handle_begin().  The next BEGIN
+		 * has to compare the recorded commit_lsn against the incoming one:
+		 * that is where exception handling is entered for the transaction that
+		 * failed, and where the recorded failure is dropped if the provider
+		 * sends a different transaction instead.  Without this the stale entry
+		 * would be left to govern transactions it knows nothing about.
+		 */
 		first_begin_at_startup = true;
 		remote_origin_lsn = InvalidXLogRecPtr;
 		remote_origin_id = InvalidRepOriginId;

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -1224,9 +1224,7 @@ handle_commit(StringInfo s)
 				 LSN_FORMAT_ARGS(end_lsn),
 				 exception_log->initial_error_message[0] != '\0' ? ". Initial error: " : "",
 				 exception_log->initial_error_message[0] != '\0' ? exception_log->initial_error_message : "");
-			exception_log->commit_lsn = InvalidXLogRecPtr;
-			exception_log->initial_error_message[0] = '\0';
-			exception_log->failed_action = 0;
+			clear_exception_log_entry(exception_log);
 			MySpockWorker->restart_delay = 0;
 
 			elog(ERROR, "SPOCK %s: exception handling had no exception(s) "
@@ -1295,9 +1293,7 @@ handle_commit(StringInfo s)
 					 MySubscription->name,
 					 exception_log->initial_error_message[0] != '\0' ? ". Initial error: " : "",
 					 exception_log->initial_error_message[0] != '\0' ? exception_log->initial_error_message : "");
-				exception_log->commit_lsn = InvalidXLogRecPtr;
-				exception_log->initial_error_message[0] = '\0';
-				exception_log->failed_action = 0;
+				clear_exception_log_entry(exception_log);
 				MySpockWorker->restart_delay = 0;
 
 				elog(ERROR, "SPOCK %s: exiting because subscription disabled",


### PR DESCRIPTION
## Description

`MyApplyWorker->use_try_block` lives in the apply worker's shared memory slot and
is not per-transaction state. It is cleared on commit, but an error raised
between remote transactions never gets there — `apply_work()` switches to replay
mode regardless, and the flag is left over for whichever transaction the provider
sends next. `handle_begin()` only reasoned about the flag when the incoming
`commit_lsn` matched the recorded failure, so a first-attempt transaction
inherited it, was applied as a read-only replay, and under TRANSDISCARD or
SUB_DISABLE was then discarded and reported as if the policy had fired on a
genuine conflict.

`v5_STABLE` has the same `handle_begin()` shape and the same preconditions:
`apply_work()` restores `first_begin_at_startup` in its `PG_CATCH`, then sets
`use_try_block = true` unconditionally under `need_replay`.

The fix derives the flag from the comparison instead: a transaction that is not
the recorded failure clears it, and drops the recorded root cause with it.
