### PR TITLE
Backport of #579 to v5_STABLE.

### DIFF
--- a/src/compat/15/spock_compat.h
+++ b/src/compat/15/spock_compat.h
@@ -117,4 +117,25 @@
 		ExecuteTruncateGuts(explicit_rels, relids, relids_logged, behavior, \
 							restart_seqs)
 
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/16/spock_compat.h
+++ b/src/compat/16/spock_compat.h
@@ -142,4 +142,25 @@
 #define ReorderBufferChangeHeapTuple(change, tuple_type) \
 	&change->data.tp.tuple_type->tuple
 
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/17/spock_compat.h
+++ b/src/compat/17/spock_compat.h
@@ -124,4 +124,25 @@
 #define ReorderBufferChangeHeapTuple(change, tuple_type) \
 	change->data.tp.tuple_type
 
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/18/spock_compat.h
+++ b/src/compat/18/spock_compat.h
@@ -132,4 +132,25 @@
 #define ExecInitRangeTable(estate, rangeTable, permInfos) \
 	ExecInitRangeTable(estate, rangeTable, permInfos, bms_make_singleton(1))
 
+/*
+ * pg_fallthrough is new in PG19, where c.h picks whichever spelling the
+ * compiler understands.  Provide it for older majors so a deliberate
+ * fall-through between switch labels can be annotated once, portably.  clang
+ * does not accept a plain comment as the annotation the way gcc does, so
+ * without this the switch in handle_queued_message() warns.
+ */
+#ifndef pg_fallthrough
+#if defined(__GNUC__) || defined(__clang__)
+#define pg_fallthrough	__attribute__((fallthrough))
+#else
+#define pg_fallthrough
+#endif
+#endif
+
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ */
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages)
+
 #endif

--- a/src/compat/19/spock_compat.h
+++ b/src/compat/19/spock_compat.h
@@ -156,4 +156,12 @@
 #define replorigin_session_origin_timestamp (replorigin_xact_state.origin_timestamp)
 #define AssertVariableIsOfType StaticAssertVariableIsOfType
 
+/*
+ * PG19 turned log_min_messages into an array indexed by backend type, so that
+ * the threshold can be set per backend type.  Older majors have a single int.
+ * Requires miscadmin.h for MyBackendType.
+ */
+#include "miscadmin.h"
+#define SPOCK_LOG_MIN_MESSAGES	(log_min_messages[MyBackendType])
+
 #endif

--- a/src/spock.c
+++ b/src/spock.c
@@ -64,6 +64,8 @@
 #include "spock_readonly.h"
 #include "spock.h"
 
+#include "spock_compat.h"
+
 PG_MODULE_MAGIC;
 
 static const struct config_enum_entry SpockConflictResolvers[] = {
@@ -940,15 +942,17 @@ log_message_filter(ErrorData *edata)
 
 		if (lower_output_level)
 		{
-			/* Reconsider decision on exposing the message */
-#if PG_VERSION_NUM >= 190000
-			/* PG19 turned log_min_messages into a per-backend-type array */
-			if (log_min_messages[MyBackendType] < edata->elevel)
-#else
-			if (log_min_messages < edata->elevel)
-#endif
+			/*
+			 * Reconsider the decision on exposing the message.  errstart()
+			 * made it for the original elevel, which was LOG and therefore
+			 * loud enough to pass both thresholds; now that the level is
+			 * DEBUG1 the message must be held back wherever DEBUG1 is below
+			 * the threshold.  The test is the same one is_log_level_output()
+			 * applies for a non-LOG elevel: emit when elevel >= the minimum.
+			 */
+			if (edata->elevel < SPOCK_LOG_MIN_MESSAGES)
 				edata->output_to_server = false;
-			if (client_min_messages < edata->elevel)
+			if (edata->elevel < client_min_messages)
 				edata->output_to_client = false;
 		}
 	}

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -94,6 +94,8 @@
 #include "spock_readonly.h"
 #include "spock.h"
 
+#include "spock_compat.h"
+
 #define CATALOG_PROGRESS			"progress"
 #define CATALOG_PROGRESS_PKEY		"progress_pkey"
 
@@ -2769,11 +2771,7 @@ handle_queued_message(HeapTuple msgtup, bool tx_just_started)
 	{
 		case QUEUE_COMMAND_TYPE_DDL:
 			in_spock_queue_ddl_command = true;
-#if PG_VERSION_NUM >= 190000
 			pg_fallthrough;
-#else
-			/* fallthrough */
-#endif
 		case QUEUE_COMMAND_TYPE_SQL:
 			errcallback_arg.action_name = "QUEUED_SQL";
 			handle_sql_or_exception(queued_message, tx_just_started);


### PR DESCRIPTION
## Description

Two independent commits, kept together because the second needs a compat macro that the first introduces, and neither is big enough to be worth its own review.

### 1. Silence the unannotated-fall-through warning in handle_queued_message()

Annotate the deliberate fall-through in `handle_queued_message()` with `pg_fallthrough`. clang does not accept a comment as the annotation the way gcc does. `pg_fallthrough` is new in PG19; it is added to the compat headers for 15-18, keying off the compiler rather than the server version since it is a compiler feature.

This branch already annotated that switch, but behind a `#if PG_VERSION_NUM >= 190000` gate with a plain comment on the other side — so clang warned on every pre-19 build, which is all of them today. Replacing the version gate with the compat macro is what actually silences it:

```
src/spock_apply.c:2777:3: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]
```

### 2. Fix the log level re-check for downgraded retry messages

`spock_error_callback()` lowers two serialization-failure retry messages from LOG to DEBUG1, then reconsiders whether they should still be emitted, because `errstart()` made that decision for the original level. Both comparisons were the wrong way round: they suppressed the message exactly when it should have been shown and showed it when it should have been suppressed.

With default settings the branch was never taken at all — a `log_min_messages` of WARNING is not less than DEBUG1 — so these messages went to the server log at DEBUG1 regardless of the configured threshold, which is the opposite of what this code exists to do.

The comparison now runs in the direction `is_log_level_output()` uses: emit when elevel is at least the configured minimum. `spock_dependency.c` already tests its thresholds this way.

`SPOCK_LOG_MIN_MESSAGES` is added to the compat headers to hide a PG19 difference: `log_min_messages` became an array indexed by backend type there, so comparing it against an elevel compares a pointer with an integer. This replaces the inline `#if PG_VERSION_NUM >= 190000` that was already in `log_message_filter()` for the same reason.
