### PR TITLE
tests: cover outbound large object replication from a joined node

### DIFF
--- a/tests/tap/run_tests.sh
+++ b/tests/tap/run_tests.sh
@@ -417,9 +417,18 @@ run_single_test() {
     plan_line=$(grep -E '^1\.\.[0-9]+' "$tap_log_file" | tail -1 2>/dev/null || true)
     total_tests=$(echo "$plan_line" | sed -n 's/^1\.\.\([0-9]\+\).*$/\1/p' 2>/dev/null || echo "0")
     [ -z "$total_tests" ] && total_tests=0
-    passed_tests=$(grep -cE '^ok ' "$tap_log_file" 2>/dev/null || echo "0")
-    failed_tests=$(grep -cE '^not ok ' "$tap_log_file" 2>/dev/null || echo "0")
-    skipped_tests=$(grep -cE '^ok .*# SKIP' "$tap_log_file" 2>/dev/null || echo "0")
+    # Anchor on the TAP test number. prove's own per-file summary line
+    # ("ok    80615 ms (...)") also begins with "ok", and counting it inflated
+    # every passing file by one, and the suite total by one per passing file.
+    # It puts several spaces before its number, so a single space here excludes
+    # it. Assumes numbered TAP output, which Test::More always emits.
+    passed_tests=$(grep -cE '^ok [0-9]+' "$tap_log_file" 2>/dev/null || echo "0")
+    failed_tests=$(grep -cE '^not ok [0-9]+' "$tap_log_file" 2>/dev/null || echo "0")
+    # TAP reports a skip as a passing "ok" carrying a skip directive, which
+    # Test::More writes lowercase ("ok 2 # skip reason"), so match it without
+    # regard to case. These lines are also counted by passed_tests above; the
+    # subtraction below takes them back out.
+    skipped_tests=$(grep -ciE '^ok [0-9]+.*# skip' "$tap_log_file" 2>/dev/null || echo "0")
     
     # If total_tests is still 0, try alternative parsing
     if [ "$total_tests" = "0" ] && [ -n "$plan_line" ]; then
@@ -432,6 +441,11 @@ run_single_test() {
     passed_tests=$(echo "$passed_tests" | tr -d ' \n\r')
     failed_tests=$(echo "$failed_tests" | tr -d ' \n\r')
     skipped_tests=$(echo "$skipped_tests" | tr -d ' \n\r')
+
+    # generate_summary() sums passed + failed + skipped, so a skipped test left
+    # in both buckets would be counted twice in the suite total and would drag
+    # the success rate down. Report it once, as skipped.
+    passed_tests=$((10#$passed_tests - 10#$skipped_tests))
     
 
     

--- a/tests/tap/t/033_zodan_lolor_add_node.pl
+++ b/tests/tap/t/033_zodan_lolor_add_node.pl
@@ -13,7 +13,9 @@ use SpockTest qw(create_cluster destroy_cluster system_or_bail system_maybe
 #   - reject a new node whose lolor tables already contain data,
 #   - accept a new node with lolor installed and empty, and copy the large
 #     object data from the source during the initial data sync,
-#   - stream large objects created after the join.
+#   - stream large objects created after the join,
+#   - leave the lolor tables in the new node's own default replication set,
+#     so large objects created there replicate back to the existing nodes.
 
 my $cfg   = get_test_config();
 my $PG    = $cfg->{pg_bin};
@@ -150,6 +152,40 @@ ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xfeedface')"),
    'second large object created on n1 after join');
 ok(wait_for_scalar(3, "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'feedface'", '1'),
    'post-join large object streamed to n3');
+
+# --- Outbound: a large object created on n3 must reach n1 and n2 ------------
+#
+# Everything above tests the inbound direction, which rides on n1's
+# replication sets. Outbound rides on n3's own sets, and nothing in the
+# replication machinery copies set membership to a joining node. What
+# populates the sets during a normal join is AutoDDL firing while pg_restore
+# replays the structure dump, and that never sees the lolor tables: they are
+# left out of the dump (reserved_object.exclude_from_dump), so they arrive via
+# CREATE EXTENSION instead, and autoddl_can_proceed() returns false while
+# creating_extension is set. So the lolor tables reach n3's default set only
+# if add_node mirrors the source node's sets onto the new node.
+
+for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
+    is(scalar_query(3,
+        "SELECT set_name FROM spock.tables " .
+        "WHERE nspname = 'lolor' AND relname = '$tbl'"),
+       'default',
+       "lolor.$tbl is in n3 default replication set after the join");
+}
+
+ok(psql_ok(3, "SET lolor.node=3; SELECT lo_from_bytea(0, '\\xc0ffee')"),
+   'large object created on n3 after the join');
+
+for my $node (1, 2) {
+    ok(wait_for_scalar($node,
+        "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'c0ffee'", '1'),
+       "large object created on n3 replicated to n$node");
+    ok(wait_for_scalar($node,
+        "SELECT count(*) FROM lolor.pg_largeobject_metadata m " .
+        "JOIN lolor.pg_largeobject l ON l.loid = m.oid " .
+        "WHERE encode(l.data, 'hex') = 'c0ffee'", '1'),
+       "metadata for the n3 large object replicated to n$node");
+}
 
 destroy_cluster('Destroy zodan lolor test cluster');
 


### PR DESCRIPTION
033 only checked that n3 receives large objects from n1. Outbound rides on n3's own replication sets, the direction that stayed broken until add_node mirrored the source's sets. Assert both lolor tables land in n3's default set, and that a large object created there reaches n1 and n2.

Also stop run_tests.sh counting prove's per-file summary line ("ok    80615
ms (...)") as a passing test. It matched '^ok ', so every passing file
reported one test too many and the suite total was over by one per passing
file. Anchor on the TAP test number instead.