### PR TITLE
autoddl: keep an extension's cleanup DDL node-local

### DIFF
--- a/include/spock.h
+++ b/include/spock.h
@@ -153,6 +153,7 @@ extern int64 sequence_get_last_value(Oid seqoid);
 
 extern bool in_spock_replicate_ddl_command;
 extern bool in_spock_queue_ddl_command;
+extern bool in_spock_extension_drop;
 extern bool spock_auto_replicate_ddl(const char *query, List *replication_sets,
 									 Oid roleoid, Node *stmt);
 extern bool spock_schema_is_ddl_local(const char *nspname);

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -687,6 +687,14 @@ remove_table_from_repsets(Oid nodeid, Oid reloid, bool only_for_update)
  * extension, and the subscriber runs its own copy when it applies the
  * replicated CREATE/DROP, so replicating it would execute that work twice.
  *
+ * For the CREATE side that holds unconditionally.  For the DROP side it holds
+ * only while the event trigger behind the cleanup is ENABLE ALWAYS or ENABLE
+ * REPLICA: the apply worker sets session_replication_role = replica, and a
+ * trigger left at the default fires on the origin only.  An origin-only
+ * trigger running DDL under a DROP EXTENSION therefore has that DDL suppressed
+ * here and not re-derived on the subscriber.  lolor, the case this exists for,
+ * marks its trigger ENABLE ALWAYS.
+ *
  * The two halves come from different places because core only tracks one of
  * them: creating_extension is set by execute_extension_script(), which covers
  * CREATE EXTENSION and ALTER EXTENSION ... UPDATE, but there is no dropping

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -680,6 +680,25 @@ remove_table_from_repsets(Oid nodeid, Oid reloid, bool only_for_update)
 }
 
 /*
+ * True while an extension's own script or cleanup path is running: its
+ * CREATE/UPDATE script, or its DROP-time cleanup.
+ *
+ * DDL from either is an implementation detail of installing or removing the
+ * extension, and the subscriber runs its own copy when it applies the
+ * replicated CREATE/DROP, so replicating it would execute that work twice.
+ *
+ * The two halves come from different places because core only tracks one of
+ * them: creating_extension is set by execute_extension_script(), which covers
+ * CREATE EXTENSION and ALTER EXTENSION ... UPDATE, but there is no dropping
+ * counterpart, so spock_ProcessUtility() maintains that half itself.
+ */
+static inline bool
+in_extension_script(void)
+{
+	return creating_extension || in_spock_extension_drop;
+}
+
+/*
  * Quick precheck if auto-ddl may proceed further.
  *
  * Must be trivial and does not call anything that may need a transaction.
@@ -708,8 +727,8 @@ autoddl_can_proceed(Node *parsetree, ProcessUtilityContext context,
 	if (context == PROCESS_UTILITY_TOPLEVEL)
 		return true;
 
-	/* Guard against CREATE EXTENSION subcommands */
-	if (creating_extension)
+	/* An extension's own script or cleanup path -- see in_extension_script(). */
+	if (in_extension_script())
 		return false;
 
 	/*

--- a/src/spock_executor.c
+++ b/src/spock_executor.c
@@ -148,6 +148,24 @@ spock_prepare_row_filter(Node *row_filter)
 	return exprstate;
 }
 
+/*
+ * Run the rest of the ProcessUtility chain.  Factored out so the DROP
+ * EXTENSION path below can wrap it without duplicating the call.
+ */
+static void
+spock_next_process_utility(PlannedStmt *pstmt, const char *queryString,
+						   bool readOnlyTree, ProcessUtilityContext context,
+						   ParamListInfo params, QueryEnvironment *queryEnv,
+						   DestReceiver *dest, QueryCompletion *qc)
+{
+	if (next_ProcessUtility_hook)
+		next_ProcessUtility_hook(pstmt, queryString, readOnlyTree, context,
+								 params, queryEnv, dest, qc);
+	else
+		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context,
+								params, queryEnv, dest, qc);
+}
+
 static void
 spock_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 					 bool readOnlyTree, ProcessUtilityContext context,
@@ -156,6 +174,7 @@ spock_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 {
 	Node	   *parsetree = pstmt->utilityStmt;
 	NodeTag		toplevel_stmt = nodeTag(parsetree);
+	bool		is_extension_drop;
 
 	dropping_spock_obj = false;
 
@@ -183,12 +202,41 @@ spock_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	Assert(CurrentMemoryContext != TopMemoryContext
 		   && CurrentMemoryContext != CacheMemoryContext);
 
-	if (next_ProcessUtility_hook)
-		next_ProcessUtility_hook(pstmt, queryString, readOnlyTree, context,
-								 params, queryEnv, dest, qc);
+	/*
+	 * An extension's cleanup path runs while the DROP EXTENSION executes -- a
+	 * ddl_command_start event trigger, typically, which is free to run DDL of
+	 * its own through SPI.  That DDL is an implementation detail of dropping
+	 * the extension, not something to ship: the subscriber runs its own copy
+	 * when it applies the replicated DROP, so replicating it would execute the
+	 * cleanup twice there.  Core exposes creating_extension for the CREATE
+	 * side but has no counterpart for DROP, so flag it here and let
+	 * autoddl_can_proceed() skip anything nested inside.
+	 *
+	 * Restored before spock_autoddl_process() below, so the DROP EXTENSION
+	 * itself still replicates.
+	 */
+	is_extension_drop = (nodeTag(parsetree) == T_DropStmt &&
+						 ((DropStmt *) parsetree)->removeType == OBJECT_EXTENSION);
+
+	if (is_extension_drop)
+	{
+		bool		save_in_extension_drop = in_spock_extension_drop;
+
+		in_spock_extension_drop = true;
+		PG_TRY();
+		{
+			spock_next_process_utility(pstmt, queryString, readOnlyTree,
+									   context, params, queryEnv, dest, qc);
+		}
+		PG_FINALLY();
+		{
+			in_spock_extension_drop = save_in_extension_drop;
+		}
+		PG_END_TRY();
+	}
 	else
-		standard_ProcessUtility(pstmt, queryString, readOnlyTree, context,
-								params, queryEnv, dest, qc);
+		spock_next_process_utility(pstmt, queryString, readOnlyTree,
+								   context, params, queryEnv, dest, qc);
 
 	/* Check for AutoDDL */
 	spock_autoddl_process(pstmt, queryString, context, toplevel_stmt);

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -214,6 +214,7 @@ static void check_readonly_for_resync(const char *nspname, const char *relname);
 
 bool		in_spock_replicate_ddl_command = false;
 bool		in_spock_queue_ddl_command = false;
+bool		in_spock_extension_drop = false;
 
 static SpockLocalNode *
 check_local_node(bool for_update)

--- a/tests/tap/t/033_zodan_lolor_add_node.pl
+++ b/tests/tap/t/033_zodan_lolor_add_node.pl
@@ -187,6 +187,73 @@ for my $node (1, 2) {
        "metadata for the n3 large object replicated to n$node");
 }
 
+# --- DROP EXTENSION: lolor's cleanup must not replicate ---------------------
+#
+# lolor's ddl_command_start event trigger calls lolor.disable() through SPI,
+# which issues ~40 "ALTER FUNCTION pg_catalog.lo_*(...) RENAME TO ..."
+# statements to put the native large object API back. Those belong to the node
+# running the drop: every peer runs its own copy when it applies the
+# replicated DROP EXTENSION. Shipping them as well lands the renames on the
+# peer ahead of the drop, leaving lolor disabled out of band, and the drop
+# that follows then fails in migrate_to_native() with "lolor must be enabled
+# before migration to native" -- which stalls apply.
+#
+# Runs last: it removes the extension the rest of this file depends on.
+#
+# spock.allow_ddl_from_functions is enabled deliberately. With it off, DDL
+# arriving from a function is never a replication candidate, and this would
+# pass without exercising the guard at all.
+
+# The queued DDL message is a bare JSON string ("SET search_path ...; <stmt>"),
+# not an object, so #>> '{}' is how the statement text comes back out.
+my $queued = "message #>> '{}'";
+
+# Fence table, used below to show the peers are still applying after the drop.
+ok(psql_ok(1, "CREATE TABLE public.fence (id int primary key, v text)"),
+   'fence table created on n1');
+for my $node (2, 3) {
+    ok(wait_for_scalar($node,
+        "SELECT count(*) FROM information_schema.tables " .
+        "WHERE table_schema = 'public' AND table_name = 'fence'", '1'),
+       "fence table reached n$node");
+}
+
+ok(psql_ok(1, "SET spock.allow_ddl_from_functions = on; DROP EXTENSION lolor"),
+   'lolor dropped on n1');
+
+is(scalar_query(1,
+    "SELECT count(*) FROM spock.queue WHERE $queued ILIKE '%ALTER FUNCTION%RENAME%'"),
+   '0', "lolor.disable()'s ALTER FUNCTION ... RENAME statements were not queued")
+    or diag("queued DDL was:\n" . (psql_capture(1,
+        "SELECT message #>> '{}' FROM spock.queue ORDER BY queued_at"))[1]);
+
+isnt(scalar_query(1,
+    "SELECT count(*) FROM spock.queue WHERE $queued ILIKE '%DROP EXTENSION%lolor%'"),
+   '0', 'the DROP EXTENSION itself was queued for replication');
+
+for my $node (2, 3) {
+    ok(wait_for_scalar($node,
+        "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '0'),
+       "DROP EXTENSION replicated: lolor is gone on n$node");
+
+    # Each peer must have run its OWN cleanup while applying the drop:
+    # disable() renames lo_open_orig back to lo_open, so the _orig name is
+    # gone afterwards. This separates "we suppressed the replication" from
+    # "we suppressed the cleanup".
+    is(scalar_query($node, "SELECT count(*) FROM pg_proc WHERE proname = 'lo_open_orig'"),
+       '0', "n$node ran its own lolor cleanup: native lo_open restored");
+    is(scalar_query($node, "SELECT count(*) FROM pg_proc WHERE proname = 'lo_open'"),
+       '1', "n$node has exactly one lo_open, the native one");
+}
+
+# Apply is still healthy on both peers.
+ok(psql_ok(1, "INSERT INTO public.fence (id, v) VALUES (1, 'after-drop')"),
+   'fence row inserted on n1 after the drop');
+for my $node (2, 3) {
+    ok(wait_for_scalar($node, "SELECT v FROM public.fence WHERE id = 1", 'after-drop'),
+       "fence row reached n$node after the drop, so apply did not stall");
+}
+
 destroy_cluster('Destroy zodan lolor test cluster');
 
 done_testing();

--- a/tests/tap/t/034_reserved_object_ddl.pl
+++ b/tests/tap/t/034_reserved_object_ddl.pl
@@ -38,6 +38,23 @@ my $ports = $cfg->{node_ports};
 my $prov_dsn = "host=$host dbname=$db port=$ports->[0] user=$user password=$pass";
 my $sub_name = 'sub_n1_n2';
 
+# scalar_query() collapses all whitespace (SpockTest.pm), which would run the
+# queued statements together into one unreadable blob -- exactly when a diag
+# is needed. Read the queue with the text intact instead.
+sub queued_ddl {
+    my $pid = open(my $fh, '-|');
+    die "fork failed: $!" unless defined $pid;
+    if ($pid == 0) {
+        open(STDERR, '>&', \*STDOUT) or die "cannot dup STDERR: $!";
+        exec("$cfg->{pg_bin}/psql", '-X', '-p', $ports->[0], '-d', $db, '-At',
+             '-c', "SELECT message #>> '{}' FROM spock.queue ORDER BY queued_at");
+        exit 127;
+    }
+    my $out = do { local $/; <$fh> } // '';
+    close($fh);
+    return $out;
+}
+
 # --------------------------------------------------------------------------
 # Step 1: on the provider (n1), create the reserved pgedge_ace schema and a
 # table in it. This must succeed locally...
@@ -133,6 +150,104 @@ is(scalar_query(2, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'p
 # broken or disabled replication.
 ok(wait_for_sub_status(2, $sub_name, 'replicating', 30),
    'subscription is still enabled/replicating after the fence row');
+
+# --------------------------------------------------------------------------
+# Step 5: DDL that an extension's own cleanup path runs must stay node-local.
+#
+# An extension may register a ddl_command_start event trigger and run DDL of
+# its own through SPI while it is being dropped -- lolor does exactly that,
+# renaming the native large object functions back into place. That DDL is an
+# implementation detail of the drop: a subscriber runs its own copy when it
+# applies the replicated DROP EXTENSION, so shipping it as well would execute
+# the cleanup twice there.
+#
+# Core exposes creating_extension so AutoDDL can recognise the CREATE side,
+# but has no counterpart for DROP, so spock_ProcessUtility() tracks that half
+# itself and autoddl_can_proceed() skips anything nested inside.
+#
+# hstore stands in for any extension with a cleanup path, and the event
+# trigger for the cleanup itself, so this needs no lolor and runs everywhere.
+# spock.allow_ddl_from_functions is enabled deliberately: with it off, DDL
+# arriving from a function is never a replication candidate and the guard
+# would never be reached.
+#
+# The assertions are deliberately provider-side. This subscription requests
+# only 'default', while AutoDDL queues to 'default_insert_only', so no DDL
+# reaches n2 here at all -- checking n2 would prove nothing. What must not
+# happen is the statement being queued in the first place, and that is what
+# spock.queue shows. The end-to-end consequence on a subscriber is covered by
+# 033_zodan_lolor_add_node.
+# --------------------------------------------------------------------------
+
+# The queued DDL message is a bare JSON string ("SET search_path ...; <stmt>"),
+# not an object, so #>> '{}' is how the statement text comes back out.
+my $queued = "message #>> '{}'";
+
+# hstore is contrib and may not be installed. Guard the whole step rather
+# than letting psql_or_bail die part way through: that would skip
+# destroy_cluster, and the nodes share fixed ports and datadirs with every
+# other test, so a leaked postmaster takes the rest of the run down with it
+# (see the comment in destroy_cluster, SpockTest.pm).
+my $have_hstore = scalar_query(1,
+    "SELECT count(*) FROM pg_available_extensions WHERE name = 'hstore'");
+
+SKIP: {
+    skip 'hstore not available (contrib not installed)', 4
+        unless defined $have_hstore && $have_hstore eq '1';
+
+    psql_or_bail(1, "CREATE EXTENSION hstore");
+
+    # IF NOT EXISTS so the trigger stays harmless if it ever fires twice: it
+    # runs on ddl_command_start, so an error here takes the DROP with it.
+    psql_or_bail(1, <<'SQL');
+CREATE FUNCTION public.drop_ext_cleanup() RETURNS event_trigger AS $fn$
+BEGIN
+    EXECUTE 'CREATE TABLE IF NOT EXISTS public.cleanup_marker (id int primary key)';
+END
+$fn$ LANGUAGE plpgsql
+SQL
+    psql_or_bail(1,
+        "CREATE EVENT TRIGGER drop_ext_cleanup ON ddl_command_start " .
+        "WHEN TAG IN ('DROP EXTENSION') " .
+        "EXECUTE FUNCTION public.drop_ext_cleanup()");
+
+    # Count what the drop adds to the queue rather than pattern-matching for
+    # the cleanup statement: the event trigger function's own source
+    # necessarily contains the text of the statement it runs, so any substring
+    # match would hit the CREATE FUNCTION entry and prove nothing.
+    my $queue_before = scalar_query(1, "SELECT count(*) FROM spock.queue");
+
+    psql_or_bail(1, "SET spock.allow_ddl_from_functions = on; DROP EXTENSION hstore");
+
+    # The cleanup ran locally...
+    is(scalar_query(1,
+        "SELECT EXISTS (SELECT 1 FROM information_schema.tables " .
+        "WHERE table_schema = 'public' AND table_name = 'cleanup_marker')"),
+       't', "the event trigger's DDL executed locally during the drop");
+
+    # ...and the drop queued exactly one statement, so the cleanup was not
+    # shipped.
+    is(scalar_query(1, "SELECT count(*) FROM spock.queue") - $queue_before, 1,
+       'the drop queued exactly one statement')
+        or diag("queued DDL was:\n" . queued_ddl());
+
+    # A statement that is not replicated must not be tracked in a repset
+    # either: add_ddl_to_repset() only runs when the DDL was actually queued.
+    is(scalar_query(1,
+        "SELECT count(*) FROM spock.tables " .
+        "WHERE relname = 'cleanup_marker' AND set_name IS NOT NULL"),
+       '0', 'the node-local table was not added to a replication set');
+
+    # The DROP EXTENSION itself must still replicate, or subscribers keep an
+    # extension the provider has removed.
+    is(scalar_query(1,
+        "SELECT count(*) FROM spock.queue WHERE $queued ILIKE '%DROP EXTENSION%hstore%'"),
+       '1', 'and that one statement was the DROP EXTENSION itself');
+
+    # Leave no armed trigger behind: a later DROP EXTENSION in this file would
+    # otherwise fire it again.
+    psql_or_bail(1, "DROP EVENT TRIGGER drop_ext_cleanup");
+}
 
 destroy_cluster('Destroy 2-node reserved-object DDL test cluster');
 


### PR DESCRIPTION
An extension may run DDL of its own while it is being dropped -- lolor registers a ddl_command_start event trigger whose SPI call renames the native large object functions back into place. With spock.allow_ddl_from_functions on, those ~40 statements were queued for replication. Every peer runs its own copy when it applies the DROP EXTENSION, so the shipped renames land first, leave lolor disabled out of band, and the drop that follows then fails in migrate_to_native() with "lolor must be enabled before migration to native", stalling apply.

Core exposes creating_extension, which covers CREATE EXTENSION and ALTER EXTENSION ... UPDATE, but has no counterpart for DROP. Track that half in spock_ProcessUtility() and have autoddl_can_proceed() skip anything nested inside it. The DROP EXTENSION itself is unaffected -- it returns at the toplevel check -- so peers still drop the extension and run their own cleanup.

Covered two ways: 034 exercises the guard generally with a synthetic event trigger and no lolor, 033 covers the lolor path end to end across the three-node mesh.