### PR TITLE
Fix replication errors with tables containing generated columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ REGRESS = preseed infofuncs init_fail init preseed_check basic conflict_secondar
 		  interfaces foreign_key copy sequence triggers parallel functions row_filter \
 		  row_filter_sampling att_list column_filter apply_delay \
 		  extended progress_tracking node_origin_cascade multiple_upstreams tuple_origin autoddl \
-		  sync_table drop
+		  sync_table generated_columns drop
 
 # The following test cases are disabled while developing.
 #

--- a/src/spock_apply_heap.c
+++ b/src/spock_apply_heap.c
@@ -547,7 +547,8 @@ fill_missing_defaults(SpockRelation *rel, EState *estate,
 	{
 		Expr	   *defexpr;
 
-		if (TupleDescAttr(desc, attnum)->attisdropped)
+		if (TupleDescAttr(desc, attnum)->attisdropped ||
+			TupleDescAttr(desc, attnum)->attgenerated)
 			continue;
 
 		if (physatt_in_attmap(rel, attnum))

--- a/src/spock_conflict.c
+++ b/src/spock_conflict.c
@@ -1116,10 +1116,10 @@ tuple_to_stringinfo(StringInfo s, TupleDesc tupdesc, HeapTuple tuple)
 		attr = TupleDescAttr(tupdesc, natt);
 
 		/*
-		 * don't print dropped columns, we can't be sure everything is
-		 * available for them
+		 * don't print dropped or generated columns, we can't be sure everything
+		 * is available for them
 		 */
-		if (attr->attisdropped)
+		if (attr->attisdropped || attr->attgenerated)
 			continue;
 
 		/*

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2434,8 +2434,8 @@ Datum spock_show_repset_table_info(PG_FUNCTION_ARGS)
 	{
 		Form_pg_attribute att = TupleDescAttr(reldesc, i);
 
-		/* Skip dropped columns. */
-		if (att->attisdropped)
+		/* Skip dropped and generated columns. */
+		if (att->attisdropped || att->attgenerated)
 			continue;
 
 		/* Skip filtered columns if any. */

--- a/src/spock_jsonb_utils.c
+++ b/src/spock_jsonb_utils.c
@@ -141,7 +141,7 @@ spock_tuple_to_json_cstring(SpockTupleData *tuple, TupleDesc tupleDesc)
 		 * don't print dropped columns, we can't be sure everything is
 		 * available for them
 		 */
-		if (attr->attisdropped)
+		if (attr->attisdropped || attr->attgenerated)
 			continue;
 
 		/*
@@ -216,7 +216,7 @@ heap_tuple_to_json_cstring(HeapTuple *tuple, TupleDesc tupleDesc)
 		 * don't print dropped columns, we can't be sure everything is
 		 * available for them
 		 */
-		if (attr->attisdropped)
+		if (attr->attisdropped || attr->attgenerated)
 			continue;
 
 		/*

--- a/src/spock_proto_json.c
+++ b/src/spock_proto_json.c
@@ -602,7 +602,8 @@ spock_composite_to_json(Datum composite, StringInfo result, bool use_line_feeds)
 		JsonTypeCategory tcategory;
 		Oid			outfuncoid;
 
-		if (TupleDescAttr(tupdesc,i)->attisdropped)
+		if (TupleDescAttr(tupdesc,i)->attisdropped ||
+			TupleDescAttr(tupdesc,i)->attgenerated)
 			continue;
 
 		if (needsep)
@@ -661,7 +662,7 @@ json_write_tuple(StringInfo out, Relation rel, HeapTuple tuple,
 		Oid			outfuncoid;
 
 		/* skip dropped columns */
-		if (att->attisdropped)
+		if (att->attisdropped || att->attgenerated)
 			continue;
 		if (att_list &&
 			!bms_is_member(att->attnum - FirstLowInvalidHeapAttributeNumber,

--- a/src/spock_proto_native.c
+++ b/src/spock_proto_native.c
@@ -113,7 +113,7 @@ spock_write_attrs(StringInfo out, Relation rel, Bitmapset *att_list)
 	{
 		Form_pg_attribute att = TupleDescAttr(desc,i);
 
-		if (att->attisdropped)
+		if (att->attisdropped || att->attgenerated)
 			continue;
 		if (att_list &&
 			!bms_is_member(att->attnum - FirstLowInvalidHeapAttributeNumber,
@@ -134,7 +134,7 @@ spock_write_attrs(StringInfo out, Relation rel, Bitmapset *att_list)
 		uint16			len;
 		const char	   *attname;
 
-		if (att->attisdropped)
+		if (att->attisdropped || att->attgenerated)
 			continue;
 		if (att_list &&
 			!bms_is_member(att->attnum - FirstLowInvalidHeapAttributeNumber,
@@ -372,7 +372,7 @@ spock_write_tuple(StringInfo out, SpockOutputData *data,
 	{
 		Form_pg_attribute att = TupleDescAttr(desc,i);
 
-		if (att->attisdropped)
+		if (att->attisdropped || att->attgenerated)
 			continue;
 		if (att_list &&
 			!bms_is_member(att->attnum - FirstLowInvalidHeapAttributeNumber,
@@ -401,7 +401,7 @@ spock_write_tuple(StringInfo out, SpockOutputData *data,
 		char		transfer_type;
 
 		/* skip dropped columns */
-		if (att->attisdropped)
+		if (att->attisdropped || att->attgenerated)
 			continue;
 		if (att_list &&
 			!bms_is_member(att->attnum - FirstLowInvalidHeapAttributeNumber,

--- a/src/spock_repset.c
+++ b/src/spock_repset.c
@@ -1598,7 +1598,15 @@ get_att_num_by_name(TupleDesc desc, const char *attname)
 			continue;
 
 		if (namestrcmp(&(TupleDescAttr(desc,i)->attname), attname) == 0)
-			return TupleDescAttr(desc,i)->attnum;
+		{
+			if (TupleDescAttr(desc,i)->attgenerated)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+						 errmsg("column %s cannot be declared as generated",
+								attname)));
+			else
+				return TupleDescAttr(desc,i)->attnum;
+		}
 	}
 
 	return FirstLowInvalidHeapAttributeNumber;

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -657,8 +657,9 @@ make_copy_attnamelist(SpockRelation *rel)
 	{
 		int		remoteattnum = physatt_in_attmap(rel, attnum);
 
-		/* Skip dropped attributes. */
-		if (TupleDescAttr(desc,attnum)->attisdropped)
+		/* Skip dropped and generated attributes. */
+		if (TupleDescAttr(desc,attnum)->attisdropped ||
+			TupleDescAttr(desc,attnum)->attgenerated)
 			continue;
 
 		if (remoteattnum < 0)

--- a/tests/regress/expected/generated_columns.out
+++ b/tests/regress/expected/generated_columns.out
@@ -1,0 +1,402 @@
+-- Generated columns replication tests
+-- Tests for ensuring generated columns are properly handled during replication
+SELECT * FROM spock_regress_variables()
+\gset
+\c :provider_dsn
+-- Test 1: Basic table with generated column
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_basic (
+    id integer PRIMARY KEY,
+    base_val integer NOT NULL,
+    doubled integer GENERATED ALWAYS AS (base_val * 2) STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'gen_basic');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_basic (id, base_val) VALUES (1, 10), (2, 20), (3, 30);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_basic ORDER BY id;
+ id | base_val | doubled 
+----+----------+---------
+  1 |       10 |      20
+  2 |       20 |      40
+  3 |       30 |      60
+(3 rows)
+
+-- Test 2: INSERT, UPDATE, DELETE operations with generated columns
+\c :provider_dsn
+INSERT INTO gen_basic (id, base_val) VALUES (4, 40);
+UPDATE gen_basic SET base_val = 15 WHERE id = 1;
+DELETE FROM gen_basic WHERE id = 3;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_basic ORDER BY id;
+ id | base_val | doubled 
+----+----------+---------
+  1 |       15 |      30
+  2 |       20 |      40
+  4 |       40 |      80
+(3 rows)
+
+-- Test 3: Multiple generated columns in different positions
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE gen_multiple (
+    gen1 integer GENERATED ALWAYS AS (id + 100) STORED,
+    id integer PRIMARY KEY,
+    val1 integer NOT NULL,
+    gen2 integer GENERATED ALWAYS AS (val1 * 10) STORED,
+    val2 text,
+    gen3 text GENERATED ALWAYS AS (val2 || '_suffix') STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'gen_multiple');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_multiple (id, val1, val2) VALUES (1, 5, 'test'), (2, 10, 'data');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_multiple ORDER BY id;
+ gen1 | id | val1 | gen2 | val2 |    gen3     
+------+----+------+------+------+-------------
+  101 |  1 |    5 |   50 | test | test_suffix
+  102 |  2 |   10 |  100 | data | data_suffix
+(2 rows)
+
+-- Test 5: Row filter with generated columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_filtered (
+    id integer PRIMARY KEY,
+    amount integer NOT NULL,
+    category text NOT NULL,
+    doubled_amount integer GENERATED ALWAYS AS (amount * 2) STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+-- Filter to only replicate category 'A'
+SELECT * FROM spock.repset_add_table('default', 'gen_filtered', false,
+    row_filter := 'category = ''A''');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_filtered (id, amount, category) VALUES
+    (1, 100, 'A'),
+    (2, 200, 'B'),
+    (3, 300, 'A'),
+    (4, 400, 'B');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+-- Should only see category 'A' rows
+SELECT * FROM gen_filtered ORDER BY id;
+ id | amount | category | doubled_amount 
+----+--------+----------+----------------
+  1 |    100 | A        |            200
+  3 |    300 | A        |            600
+(2 rows)
+
+\c :provider_dsn
+-- Insert more rows, only category 'A' should replicate
+INSERT INTO gen_filtered (id, amount, category) VALUES
+    (5, 500, 'A'),
+    (6, 600, 'B');
+UPDATE gen_filtered SET amount = 150 WHERE id = 1;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_filtered ORDER BY id;
+ id | amount | category | doubled_amount 
+----+--------+----------+----------------
+  1 |    150 | A        |            300
+  3 |    300 | A        |            600
+  5 |    500 | A        |           1000
+(3 rows)
+
+-- Test 6: Table resync with generated columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_resync (
+    id integer PRIMARY KEY,
+    data integer NOT NULL,
+    computed integer GENERATED ALWAYS AS (data + 1000) STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+INSERT INTO gen_resync (id, data) VALUES (1, 1), (2, 2);
+SELECT * FROM spock.repset_add_table('default', 'gen_resync');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+-- Add more data before resync
+INSERT INTO gen_resync (id, data) VALUES (3, 3), (4, 4);
+\c :subscriber_dsn
+SELECT spock.sub_resync_table('test_subscription', 'gen_resync', true);
+ sub_resync_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.table_wait_for_sync('test_subscription', 'gen_resync');
+ table_wait_for_sync 
+---------------------
+ 
+(1 row)
+
+SELECT * FROM gen_resync ORDER BY id;
+ id | data | computed 
+----+------+----------
+  1 |    1 |     1001
+  2 |    2 |     1002
+  3 |    3 |     1003
+  4 |    4 |     1004
+(4 rows)
+
+-- Test 7: Generated column referencing multiple base columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_multi_ref (
+    id integer PRIMARY KEY,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    z integer NOT NULL,
+    sum_xy integer GENERATED ALWAYS AS (x + y) STORED,
+    product_xyz integer GENERATED ALWAYS AS (x * y * z) STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'gen_multi_ref');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_multi_ref (id, x, y, z) VALUES
+    (1, 2, 3, 4),
+    (2, 5, 6, 7);
+UPDATE gen_multi_ref SET x = 10, y = 20 WHERE id = 1;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_multi_ref ORDER BY id;
+ id | x  | y  | z | sum_xy | product_xyz 
+----+----+----+---+--------+-------------
+  1 | 10 | 20 | 4 |     30 |         800
+  2 |  5 |  6 | 7 |     11 |         210
+(2 rows)
+
+-- Test 8: Generated column with NULL handling
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_nulls (
+    id integer PRIMARY KEY,
+    val integer,
+    doubled integer GENERATED ALWAYS AS (val * 2) STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'gen_nulls');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_nulls (id, val) VALUES (1, 10), (2, NULL), (3, 30);
+UPDATE gen_nulls SET val = NULL WHERE id = 1;
+UPDATE gen_nulls SET val = 25 WHERE id = 2;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_nulls ORDER BY id;
+ id | val | doubled 
+----+-----+---------
+  1 |     |        
+  2 |  25 |      50
+  3 |  30 |      60
+(3 rows)
+
+-- Test 9: Column list with generated columns
+-- (Generated columns should be automatically excluded)
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_collist (
+    id integer PRIMARY KEY,
+    col1 integer NOT NULL,
+    gen1 integer GENERATED ALWAYS AS (col1 * 2) STORED,
+    col2 text NOT NULL,
+    gen2 text GENERATED ALWAYS AS (col2 || '_gen') STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+-- Add table with explicit column list (including generated column)
+SELECT * FROM spock.repset_add_table('default', 'gen_collist', false,
+    columns := '{id, col1, col2, gen2}'); -- ERROR
+ERROR:  column gen2 cannot be declared as generated
+SELECT * FROM spock.repset_add_table('default', 'gen_collist', false,
+    columns := '{id, col1, col2}');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_collist (id, col1, col2) VALUES (1, 10, 'test'), (2, 20, 'data');
+INSERT INTO gen_collist (id, col1, col2) VALUES (3, 30, 'more');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM gen_collist ORDER BY id;
+ id | col1 | gen1 | col2 |   gen2   
+----+------+------+------+----------
+  1 |   10 |   20 | test | test_gen
+  2 |   20 |   40 | data | data_gen
+  3 |   30 |   60 | more | more_gen
+(3 rows)
+
+-- Test 10: Mixed dropped and generated columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_mixed (
+    id integer PRIMARY KEY,
+    col1 integer NOT NULL,
+    col2 integer,
+    gen1 integer GENERATED ALWAYS AS (col1 + 10) STORED
+);
+$$);
+ replicate_ddl 
+---------------
+ t
+(1 row)
+
+SELECT * FROM spock.repset_add_table('default', 'gen_mixed');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO gen_mixed (id, col1, col2) VALUES (1, 5, 50);
+-- Now drop col2 on provider
+ALTER TABLE gen_mixed DROP COLUMN col2;
+INSERT INTO gen_mixed (id, col1) VALUES (2, 10);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+-- Drop col2 on subscriber too
+ALTER TABLE gen_mixed DROP COLUMN col2;
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+SELECT * FROM gen_mixed ORDER BY id;
+ id | col1 | gen1 
+----+------+------
+  1 |    5 |   15
+  2 |   10 |   20
+(2 rows)
+
+-- Cleanup
+\c :provider_dsn
+DROP TABLE gen_basic CASCADE;
+NOTICE:  drop cascades to table gen_basic membership in replication set default
+DROP TABLE gen_multiple CASCADE;
+NOTICE:  drop cascades to table gen_multiple membership in replication set default
+DROP TABLE gen_filtered CASCADE;
+NOTICE:  drop cascades to table gen_filtered membership in replication set default
+DROP TABLE gen_resync CASCADE;
+NOTICE:  drop cascades to table gen_resync membership in replication set default
+DROP TABLE gen_multi_ref CASCADE;
+NOTICE:  drop cascades to table gen_multi_ref membership in replication set default
+DROP TABLE gen_nulls CASCADE;
+NOTICE:  drop cascades to table gen_nulls membership in replication set default
+DROP TABLE gen_collist CASCADE;
+NOTICE:  drop cascades to table gen_collist membership in replication set default
+DROP TABLE gen_mixed CASCADE;
+NOTICE:  drop cascades to table gen_mixed membership in replication set default

--- a/tests/regress/expected/sync_table.out
+++ b/tests/regress/expected/sync_table.out
@@ -195,12 +195,72 @@ SELECT sum(x), count(*) FROM test_sync;
      |     0
 (1 row)
 
+-- Generated columns
 \c :provider_dsn
--- Cleanup
-SELECT spock.repset_remove_table('default', 'test_sync', true);
- repset_remove_table 
----------------------
+SELECT spock.replicate_ddl('
+CREATE TABLE g1(col1 INT PRIMARY KEY, col2 INT NOT NULL, col3 int,
+ col4 int generated always as (col3 + 1) stored);
+');
+ replicate_ddl 
+---------------
  t
 (1 row)
 
-DROP TABLE test_sync;
+INSERT INTO g1 (col1, col2, col3) VALUES (1, 10, 100);
+SELECT * FROM spock.repset_add_table('default', 'g1');
+ repset_add_table 
+------------------
+ t
+(1 row)
+
+INSERT INTO g1 (col1, col2, col3) VALUES (2, 20, 200);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT spock.sub_resync_table('test_subscription', 'g1', true);
+ sub_resync_table 
+------------------
+ t
+(1 row)
+
+SELECT spock.table_wait_for_sync('test_subscription', 'g1');
+ table_wait_for_sync 
+---------------------
+ 
+(1 row)
+
+SELECT * FROM g1;
+ col1 | col2 | col3 | col4 
+------+------+------+------
+    1 |   10 |  100 |  101
+    2 |   20 |  200 |  201
+(2 rows)
+
+-- Test UPDATE and DELETE with generated columns
+\c :provider_dsn
+UPDATE g1 SET col3 = 150 WHERE col1 = 1;
+DELETE FROM g1 WHERE col1 = 2;
+INSERT INTO g1 (col1, col2, col3) VALUES (3, 30, 300);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+ wait_slot_confirm_lsn 
+-----------------------
+ 
+(1 row)
+
+\c :subscriber_dsn
+SELECT * FROM g1 ORDER BY col1;
+ col1 | col2 | col3 | col4 
+------+------+------+------
+    1 |   10 |  150 |  151
+    3 |   30 |  300 |  301
+(2 rows)
+
+-- Cleanup
+\c :provider_dsn
+DROP TABLE test_sync, g1 CASCADE;
+NOTICE:  drop cascades to table test_sync membership in replication set default
+NOTICE:  drop cascades to table g1 membership in replication set default

--- a/tests/regress/sql/generated_columns.sql
+++ b/tests/regress/sql/generated_columns.sql
@@ -1,0 +1,228 @@
+-- Generated columns replication tests
+-- Tests for ensuring generated columns are properly handled during replication
+
+SELECT * FROM spock_regress_variables()
+\gset
+
+\c :provider_dsn
+
+-- Test 1: Basic table with generated column
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_basic (
+    id integer PRIMARY KEY,
+    base_val integer NOT NULL,
+    doubled integer GENERATED ALWAYS AS (base_val * 2) STORED
+);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'gen_basic');
+INSERT INTO gen_basic (id, base_val) VALUES (1, 10), (2, 20), (3, 30);
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_basic ORDER BY id;
+
+-- Test 2: INSERT, UPDATE, DELETE operations with generated columns
+\c :provider_dsn
+INSERT INTO gen_basic (id, base_val) VALUES (4, 40);
+UPDATE gen_basic SET base_val = 15 WHERE id = 1;
+DELETE FROM gen_basic WHERE id = 3;
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_basic ORDER BY id;
+
+-- Test 3: Multiple generated columns in different positions
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE gen_multiple (
+    gen1 integer GENERATED ALWAYS AS (id + 100) STORED,
+    id integer PRIMARY KEY,
+    val1 integer NOT NULL,
+    gen2 integer GENERATED ALWAYS AS (val1 * 10) STORED,
+    val2 text,
+    gen3 text GENERATED ALWAYS AS (val2 || '_suffix') STORED
+);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'gen_multiple');
+INSERT INTO gen_multiple (id, val1, val2) VALUES (1, 5, 'test'), (2, 10, 'data');
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_multiple ORDER BY id;
+
+-- Test 5: Row filter with generated columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_filtered (
+    id integer PRIMARY KEY,
+    amount integer NOT NULL,
+    category text NOT NULL,
+    doubled_amount integer GENERATED ALWAYS AS (amount * 2) STORED
+);
+$$);
+
+-- Filter to only replicate category 'A'
+SELECT * FROM spock.repset_add_table('default', 'gen_filtered', false,
+    row_filter := 'category = ''A''');
+INSERT INTO gen_filtered (id, amount, category) VALUES
+    (1, 100, 'A'),
+    (2, 200, 'B'),
+    (3, 300, 'A'),
+    (4, 400, 'B');
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+-- Should only see category 'A' rows
+SELECT * FROM gen_filtered ORDER BY id;
+
+\c :provider_dsn
+-- Insert more rows, only category 'A' should replicate
+INSERT INTO gen_filtered (id, amount, category) VALUES
+    (5, 500, 'A'),
+    (6, 600, 'B');
+
+UPDATE gen_filtered SET amount = 150 WHERE id = 1;
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_filtered ORDER BY id;
+
+-- Test 6: Table resync with generated columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_resync (
+    id integer PRIMARY KEY,
+    data integer NOT NULL,
+    computed integer GENERATED ALWAYS AS (data + 1000) STORED
+);
+$$);
+
+INSERT INTO gen_resync (id, data) VALUES (1, 1), (2, 2);
+SELECT * FROM spock.repset_add_table('default', 'gen_resync');
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+-- Add more data before resync
+INSERT INTO gen_resync (id, data) VALUES (3, 3), (4, 4);
+
+\c :subscriber_dsn
+SELECT spock.sub_resync_table('test_subscription', 'gen_resync', true);
+SELECT spock.table_wait_for_sync('test_subscription', 'gen_resync');
+SELECT * FROM gen_resync ORDER BY id;
+
+-- Test 7: Generated column referencing multiple base columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_multi_ref (
+    id integer PRIMARY KEY,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    z integer NOT NULL,
+    sum_xy integer GENERATED ALWAYS AS (x + y) STORED,
+    product_xyz integer GENERATED ALWAYS AS (x * y * z) STORED
+);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'gen_multi_ref');
+INSERT INTO gen_multi_ref (id, x, y, z) VALUES
+    (1, 2, 3, 4),
+    (2, 5, 6, 7);
+
+UPDATE gen_multi_ref SET x = 10, y = 20 WHERE id = 1;
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_multi_ref ORDER BY id;
+
+-- Test 8: Generated column with NULL handling
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_nulls (
+    id integer PRIMARY KEY,
+    val integer,
+    doubled integer GENERATED ALWAYS AS (val * 2) STORED
+);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'gen_nulls');
+INSERT INTO gen_nulls (id, val) VALUES (1, 10), (2, NULL), (3, 30);
+
+UPDATE gen_nulls SET val = NULL WHERE id = 1;
+UPDATE gen_nulls SET val = 25 WHERE id = 2;
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_nulls ORDER BY id;
+
+-- Test 9: Column list with generated columns
+-- (Generated columns should be automatically excluded)
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_collist (
+    id integer PRIMARY KEY,
+    col1 integer NOT NULL,
+    gen1 integer GENERATED ALWAYS AS (col1 * 2) STORED,
+    col2 text NOT NULL,
+    gen2 text GENERATED ALWAYS AS (col2 || '_gen') STORED
+);
+$$);
+
+-- Add table with explicit column list (including generated column)
+SELECT * FROM spock.repset_add_table('default', 'gen_collist', false,
+    columns := '{id, col1, col2, gen2}'); -- ERROR
+SELECT * FROM spock.repset_add_table('default', 'gen_collist', false,
+    columns := '{id, col1, col2}');
+INSERT INTO gen_collist (id, col1, col2) VALUES (1, 10, 'test'), (2, 20, 'data');
+INSERT INTO gen_collist (id, col1, col2) VALUES (3, 30, 'more');
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+SELECT * FROM gen_collist ORDER BY id;
+
+-- Test 10: Mixed dropped and generated columns
+\c :provider_dsn
+SELECT spock.replicate_ddl($$
+CREATE TABLE public.gen_mixed (
+    id integer PRIMARY KEY,
+    col1 integer NOT NULL,
+    col2 integer,
+    gen1 integer GENERATED ALWAYS AS (col1 + 10) STORED
+);
+$$);
+
+SELECT * FROM spock.repset_add_table('default', 'gen_mixed');
+INSERT INTO gen_mixed (id, col1, col2) VALUES (1, 5, 50);
+
+-- Now drop col2 on provider
+ALTER TABLE gen_mixed DROP COLUMN col2;
+
+INSERT INTO gen_mixed (id, col1) VALUES (2, 10);
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+\c :subscriber_dsn
+-- Drop col2 on subscriber too
+ALTER TABLE gen_mixed DROP COLUMN col2;
+
+SELECT spock.wait_slot_confirm_lsn(NULL, NULL);
+
+SELECT * FROM gen_mixed ORDER BY id;
+
+-- Cleanup
+\c :provider_dsn
+DROP TABLE gen_basic CASCADE;
+DROP TABLE gen_multiple CASCADE;
+DROP TABLE gen_filtered CASCADE;
+DROP TABLE gen_resync CASCADE;
+DROP TABLE gen_multi_ref CASCADE;
+DROP TABLE gen_nulls CASCADE;
+DROP TABLE gen_collist CASCADE;
+DROP TABLE gen_mixed CASCADE;


### PR DESCRIPTION
PostgreSQL generated columns (GENERATED ALWAYS AS ... STORED) were causing errors during Spock replication. The issue occurred because generated columns were being treated as regular columns during:
- Initial table synchronization (COPY operations)
- Logical replication protocol messages
- Default value filling for missing attributes
- Conflict resolution and tuple processing

Generated columns should not be replicated since they are computed automatically on the target database based on their definition.

Solution:
Add checks for attgenerated flag alongside existing attisdropped checks throughout the codebase to skip generated columns in:
- spock_sync.c: COPY attribute list construction
- spock_apply_heap.c: Default value filling
- spock_proto_native.c: Native protocol tuple serialization
- spock_proto_json.c: JSON protocol handling
- spock_conflict.c: Conflict tuple formatting
- spock_jsonb_utils.c: JSONB conversion utilities
- spock_functions.c: Replication set table info
- spock_repset.c: Attribute name lookup

Test Coverage:
Added regression test in sync_table.sql that verifies:
- Table with STORED generated column can be added to replication set
- Initial table synchronization works correctly via sub_resync_table()
- Generated column values are correctly computed on subscriber
- Both initial sync and ongoing replication handle generated columns