### PR TITLE
Resolve spock.progress's LSN column per endpoint

### DIFF
--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -182,16 +182,10 @@ BEGIN
         RAISE EXCEPTION 'Spock extension not found on new node';
     END IF;
 
-    -- Check new node has required version (compare numerically, not lexically)
-    IF spock.version_to_array(new_version) < spock.version_to_array(min_required_version) THEN
-        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but minimum required version is %. Please upgrade all nodes to at least %.',
-            new_version, min_required_version, min_required_version;
-    END IF;
-
-    -- Allow rolling upgrades: patch differences are fine, but major.minor must match
-    IF spock.version_major_minor(new_version) IS DISTINCT FROM spock.version_major_minor(src_version) THEN
-        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Major.minor versions must match (patch differences are allowed).',
-            new_version, src_version;
+    -- Check new node has required version
+    IF new_version <> '6.0.0'::text THEN
+        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but should be 6.0.0.',
+            new_version;
     END IF;
 
     -- Check all existing nodes in cluster
@@ -213,11 +207,6 @@ BEGIN
                 node_rec.node_name, node_version, min_required_version, min_required_version;
         END IF;
 
-        -- Allow rolling upgrades: patch differences are fine, but major.minor must match
-        IF spock.version_major_minor(node_version) IS DISTINCT FROM spock.version_major_minor(new_version) THEN
-            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Major.minor versions must match (patch differences are allowed).',
-                new_version, node_version;
-        END IF;
     END LOOP;
 
     PERFORM set_config('zodan.donor_spock_version', src_version, false);

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -93,6 +93,40 @@ RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
 $$;
 
 -- ============================================================================
+-- Function: progress_commit_lsn_column
+-- Purpose : Return the name of spock.progress's apply-progress column, renamed
+--           with no overlap at the 6.0.0 boundary: remote_lsn on Spock 5.x,
+--           remote_commit_lsn on 6.x.
+--
+--           The name depends on the Spock running on the node the query will
+--           execute against, which is not always this one.  The sole caller is
+--           the Phase 3 catchup probe, whose SQL is shipped to the donor over
+--           dblink, so this resolves the donor's version as Phase 0 published
+--           it in zodan.donor_spock_version.
+-- Returns  : text, 'remote_commit_lsn' or 'remote_lsn'.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.progress_commit_lsn_column()
+RETURNS text LANGUAGE plpgsql STABLE AS $$
+DECLARE
+    version text;
+    major   int;
+BEGIN
+    version := current_setting('zodan.donor_spock_version', true);
+
+    -- version_to_array() answers NULL, not an error, on a string it cannot parse.
+    major := (spock.version_to_array(version))[1];
+
+    IF major IS NULL THEN
+        RAISE EXCEPTION '% is not a Spock version', quote_literal(version)
+            USING ERRCODE = 'invalid_parameter_value',
+                  HINT = 'Unset it and let spock.check_spock_version_compatibility() establish it.';
+    END IF;
+
+    RETURN CASE WHEN major >= 6 THEN 'remote_commit_lsn' ELSE 'remote_lsn' END;
+END;
+$$;
+
+-- ============================================================================
 -- Procedure: check_spock_version_compatibility
 -- Purpose: Verify all nodes have the same Spock version before adding a node
 -- ============================================================================
@@ -103,6 +137,7 @@ CREATE OR REPLACE PROCEDURE spock.check_spock_version_compatibility(
 ) LANGUAGE plpgsql AS $$
 DECLARE
     min_required_version text := '5.0.9';
+    local_extversion text;
     src_version text;
     new_version text;
     node_rec RECORD;
@@ -110,6 +145,16 @@ DECLARE
     node_version text;
     version_mismatch boolean := false;
 BEGIN
+    -- Z0DAN script should be treated as an integral part of Spock. So, it can
+    -- be called only with current Spock version.
+    SELECT extversion INTO local_extversion
+      FROM pg_extension WHERE extname = 'spock';
+
+    IF (local_extversion <> '6.0.0'::text) THEN
+        RAISE EXCEPTION 'This Z0DAN script cannot be used with Spock %',
+                        local_extversion;
+    END IF;
+
     -- Get source node Spock version
     remotesql := 'SELECT extversion FROM pg_extension WHERE extname = ''spock''';
     IF verb THEN
@@ -174,6 +219,8 @@ BEGIN
                 new_version, node_version;
         END IF;
     END LOOP;
+
+    PERFORM set_config('zodan.donor_spock_version', src_version, false);
 
     IF verb THEN
         RAISE NOTICE 'Version check passed: All nodes running Spock version % or later. Source version is %, new node version is %', min_required_version, src_version, new_version;
@@ -1884,12 +1931,12 @@ BEGIN
             v_prev_statement_timeout text;
         BEGIN
             progress_sql := format(
-                'SELECT p.remote_commit_lsn '
+                'SELECT p.%I '
                 'FROM spock.progress p '
                 'JOIN spock.node n ON n.node_id = p.remote_node_id '
                 'WHERE p.node_id = (SELECT node_id FROM spock.node_info()) '
                 '  AND n.node_name = %L',
-                rec.node_name);
+                spock.progress_commit_lsn_column(), rec.node_name);
 
             RAISE NOTICE '    - Waiting for source node % to apply % changes up to sync LSN %...',
                          src_node_name, rec.node_name, _catchup_lsn;


### PR DESCRIPTION
spock.progress's apply-progress column was renamed with no overlap: remote_lsn on Spock 5.x, remote_commit_lsn on 6.x. zodan.sql is a standalone file whose version is independent of the Spock installed on the nodes, so neither spelling works everywhere and it must resolve the name at run time -- once per endpoint, since add_node and the node it queries over dblink are different servers.

Hard-coding remote_commit_lsn broke add_node on a 5.x mesh from the third node onwards: the failing query lives in a loop over other existing nodes, so a two-node join never reached it. It also failed badly. The retry loop treated a missing column as transient and spun for the whole spock.sync_timeout() budget -- 1800s in the rig that found it -- then reported a replication timeout, while the RAISE NOTICE naming the real cause was suppressed unless verb was set.

So also split permanent errors out of that handler: undefined_column, undefined_table, undefined_function and insufficient_privilege now abort at once saying it is not replication lag, and the surviving transient notice is no longer conditional on verb. This matters beyond the column name -- any future version-dependent reference in this script now costs one clear message instead of half an hour of misattributed timeout.