### PR TITLE
Refuse direct DDL against extension-owned schemas.

### DIFF
--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -272,6 +272,22 @@ AutoDDL has been refactored and hardened:
   `REPLICA IDENTITY FULL` tables are now classified correctly.
 * **Safe `search_path` interpolation** — replicated DDL ships a valid
   `SET search_path` even when the session path is empty.
+* **Direct DDL against `spock` and `snowflake` is refused**
+  (behaviour change) — while `spock.enable_ddl_replication` is on, a
+  statement whose target schema is one of the built-in extension-owned
+  schemas now fails outright:
+
+  ```
+  ERROR:  cannot run DDL against schema snowflake while DDL replication is enabled
+  DETAIL:  The schema is managed by an extension and its objects are not replicated.
+  HINT:  For a deliberate node-local change, run the statement with spock.enable_ddl_replication = off.
+  ```
+
+  These schemas are populated by extension scripts, where AutoDDL is
+  already suppressed, so a runtime statement against them is almost always
+  a mistake.  Previously such a statement half-applied: the command text
+  replicated to peers while the relation was silently kept out of every
+  replication set.  See *Upgrading* for what this affects.
 
 ### Memory and stability
 
@@ -480,6 +496,17 @@ once the binaries are swapped.  The upgrade:
   and it skips slots that are in use at the time. See
   [Logical Slot Failover](logical_slot_failover.md) for how to handle any
   skipped slots.
+
+Check your runbooks and automation for direct DDL against the `spock` or
+`snowflake` schemas before upgrading.  Statements such as
+`DROP TABLE snowflake.x` or `CREATE INDEX` on a `spock` table succeeded on
+5.0.x and now raise an error (see *AutoDDL improvements* above).  Any
+procedure that needs to keep doing this must set
+`spock.enable_ddl_replication = off` for the session first, which is also
+what the error hint says.  The restriction covers only the built-in
+extension-owned schemas: schemas you reserve yourself with
+`spock.reserved_object_add()` are unaffected, and `pgedge_ace` continues to
+accept DDL and keep it node-local.
 
 ## Spock 5.0.11
 

--- a/include/spock.h
+++ b/include/spock.h
@@ -157,6 +157,7 @@ extern bool in_spock_extension_drop;
 extern bool spock_auto_replicate_ddl(const char *query, List *replication_sets,
 									 Oid roleoid, Node *stmt);
 extern bool spock_schema_is_ddl_local(const char *nspname);
+extern void spock_guard_extension_owned_ddl(Node *stmt);
 extern bool name_in_list(List *names, const char *name);
 
 /* spock_readonly.c */

--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -76,7 +76,9 @@ typedef enum ReservedObjectPurpose
 {
 	RESERVED_PURPOSE_DUMP,		/* exclude_from_dump: kept out of structure sync */
 	RESERVED_PURPOSE_REPSET,	/* block_in_repset: cannot join a replication set */
-	RESERVED_PURPOSE_DDL		/* replicate_ddl = false (node-local) */
+	RESERVED_PURPOSE_DDL,		/* replicate_ddl = false (node-local) */
+	RESERVED_PURPOSE_EXTENSION_OWNED	/* built-in, blocked from repsets, DDL
+										 * still replicated: spock, snowflake */
 } ReservedObjectPurpose;
 
 extern List *spock_reserved_object_names(ReservedObjectKind kind,

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -114,6 +114,13 @@ spock_autoddl_process(PlannedStmt *pstmt,
 	if (get_local_node(false, true) == NULL)
 		goto end;
 
+	/*
+	 * Refuse DDL aimed at a built-in extension-owned schema before anything is
+	 * queued.  This is a post-execution hook, so the ERROR aborts the
+	 * transaction and rolls the statement back.
+	 */
+	spock_guard_extension_owned_ddl(parsetree);
+
 	/* Replicate DDL statement */
 	queryString = CleanQuerytext(queryString, &loc, &len);
 	curr_qry = pnstrdup(queryString, len);

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2577,28 +2577,40 @@ spock_schema_is_ddl_local(const char *nspname)
 }
 
 /*
- * Resolve rv to its schema and test replicate_ddl=false.  Runs post-execution,
+ * Resolve rv to its schema and test it against purpose.  Runs post-execution,
  * so CREATE/ALTER targets exist and an unqualified name resolves by opening the
  * relation (relation_openrv, not table_openrv: rv may name an index/view).  A
  * dropped relation is classifiable only when schema-qualified.
+ *
+ * On a match, *matched (when non-NULL) receives the schema name.
  */
 static bool
-rangevar_is_ddl_local(RangeVar *rv)
+rangevar_schema_matches(RangeVar *rv, ReservedObjectPurpose purpose,
+						const char **matched)
 {
 	Relation	rel;
-	bool		local;
+	char	   *nspname;
 
 	if (rv == NULL)
 		return false;
-	if (rv->schemaname != NULL)
-		return spock_schema_is_ddl_local(rv->schemaname);
 
-	rel = relation_openrv_extended(rv, AccessShareLock, true);
-	if (rel == NULL)
+	if (rv->schemaname != NULL)
+		nspname = rv->schemaname;
+	else
+	{
+		rel = relation_openrv_extended(rv, AccessShareLock, true);
+		if (rel == NULL)
+			return false;
+		nspname = get_namespace_name(RelationGetNamespace(rel));
+		relation_close(rel, AccessShareLock);
+	}
+
+	if (!spock_name_is_reserved(RESERVED_KIND_SCHEMA, purpose, nspname))
 		return false;
-	local = spock_schema_is_ddl_local(get_namespace_name(RelationGetNamespace(rel)));
-	relation_close(rel, AccessShareLock);
-	return local;
+
+	if (matched != NULL)
+		*matched = nspname;
+	return true;
 }
 
 /* True if `name` (case-sensitive) appears in a List of C strings. */
@@ -2616,43 +2628,70 @@ name_in_list(List *names, const char *name)
 }
 
 /*
- * Does this DDL target ONLY node-local (replicate_ddl=false) schemas?  Only
- * statement types whose target schema is identifiable are classified; all
- * others replicate as before.  Known gap: dropping a node-local relation by an
- * unqualified name cannot be classified (the relation is already gone).
+ * Are this DDL statement's target schemas reserved for purpose?  Only statement
+ * types whose target schema is identifiable are classified; for all others this
+ * returns false and the statement is handled as before.  Known gap: dropping a
+ * relation by an unqualified name cannot be classified (the relation is
+ * already gone).
  *
- * A DROP is skipped only when EVERY object is node-local.  A statement mixing a
- * node-local object with a replicated one is shipped as-is: the raw command
- * text cannot be rewritten to strip the node-local object, so the subscriber --
- * where that object never existed -- would fail to drop it unless the drop
- * carries IF EXISTS.  Mixing node-local and replicated objects in one DROP is
- * therefore unsupported.
+ * match_all selects the quantifier over a multi-object DROP, and the two
+ * callers need opposite ones:
+ *
+ *	match_all = true   suppression.  A DROP is kept local only when EVERY
+ *					   object is node-local, because a false positive would
+ *					   silently lose DDL.  A statement mixing a node-local
+ *					   object with a replicated one is shipped as-is: the raw
+ *					   command text cannot be rewritten to strip the node-local
+ *					   object, so the subscriber -- where that object never
+ *					   existed -- would fail to drop it unless the drop carries
+ *					   IF EXISTS.  Mixing the two in one DROP is unsupported.
+ *
+ *	match_all = false  the guard rail.  ANY matching object trips it, because a
+ *					   false negative would let a mistake through.
+ *
+ * On a match, *matched (when non-NULL) receives the schema name that matched.
  */
 static bool
-stmt_targets_only_ddl_local(Node *stmt)
+stmt_schema_matches(Node *stmt, ReservedObjectPurpose purpose, bool match_all,
+					const char **matched)
 {
 	switch (nodeTag(stmt))
 	{
 		case T_CreateSchemaStmt:
-			return spock_schema_is_ddl_local(((CreateSchemaStmt *) stmt)->schemaname);
+			{
+				char	   *nspname = ((CreateSchemaStmt *) stmt)->schemaname;
+
+				if (nspname == NULL ||
+					!spock_name_is_reserved(RESERVED_KIND_SCHEMA, purpose, nspname))
+					return false;
+				if (matched != NULL)
+					*matched = nspname;
+				return true;
+			}
 		case T_CreateStmt:
-			return rangevar_is_ddl_local(((CreateStmt *) stmt)->relation);
+			return rangevar_schema_matches(((CreateStmt *) stmt)->relation,
+										   purpose, matched);
 		case T_CreateTableAsStmt:
-			return rangevar_is_ddl_local(((CreateTableAsStmt *) stmt)->into->rel);
+			return rangevar_schema_matches(((CreateTableAsStmt *) stmt)->into->rel,
+										   purpose, matched);
 		case T_AlterTableStmt:
-			return rangevar_is_ddl_local(((AlterTableStmt *) stmt)->relation);
+			return rangevar_schema_matches(((AlterTableStmt *) stmt)->relation,
+										   purpose, matched);
 		case T_ViewStmt:
-			return rangevar_is_ddl_local(((ViewStmt *) stmt)->view);
+			return rangevar_schema_matches(((ViewStmt *) stmt)->view,
+										   purpose, matched);
 		case T_CreateSeqStmt:
-			return rangevar_is_ddl_local(((CreateSeqStmt *) stmt)->sequence);
+			return rangevar_schema_matches(((CreateSeqStmt *) stmt)->sequence,
+										   purpose, matched);
 		case T_IndexStmt:
-			return rangevar_is_ddl_local(((IndexStmt *) stmt)->relation);
+			return rangevar_schema_matches(((IndexStmt *) stmt)->relation,
+										   purpose, matched);
 		case T_DropStmt:
 			{
 				DropStmt   *drop = (DropStmt *) stmt;
 				ListCell   *cell;
-				List	   *local;
-				bool		all_local = true;
+				List	   *reserved;
+				bool		result = match_all;
 
 				if (drop->objects == NIL)
 					return false;
@@ -2663,26 +2702,75 @@ stmt_targets_only_ddl_local(Node *stmt)
 					return false;
 
 				/* One catalog read for the whole (possibly multi-object) DROP. */
-				local = spock_reserved_object_names(RESERVED_KIND_SCHEMA,
-													RESERVED_PURPOSE_DDL);
+				reserved = spock_reserved_object_names(RESERVED_KIND_SCHEMA,
+													   purpose);
 				foreach(cell, drop->objects)
 				{
 					const char *schema = (drop->removeType == OBJECT_SCHEMA)
 						? strVal(lfirst(cell))
 						: makeRangeVarFromNameList((List *) lfirst(cell))->schemaname;
 
-					if (!name_in_list(local, schema))
+					if (name_in_list(reserved, schema) != match_all)
 					{
-						all_local = false;
+						/*
+						 * Decided: an unreserved object under ALL, or a
+						 * reserved one under ANY.  Either way the answer is
+						 * !match_all, and under ANY this object is the one to
+						 * name in the error.
+						 */
+						result = !match_all;
+						if (matched != NULL)
+							*matched = schema;
 						break;
 					}
 				}
-				list_free_deep(local);
-				return all_local;
+				list_free_deep(reserved);
+				return result;
 			}
 		default:
 			return false;
 	}
+}
+
+/* Does this DDL target ONLY node-local (replicate_ddl = false) schemas? */
+static bool
+stmt_targets_only_ddl_local(Node *stmt)
+{
+	return stmt_schema_matches(stmt, RESERVED_PURPOSE_DDL, true, NULL);
+}
+
+/*
+ * spock_guard_extension_owned_ddl
+ *
+ * Refuse direct DDL against a built-in extension-owned schema (spock,
+ * snowflake) while DDL replication is on.
+ *
+ * Nothing legitimate issues runtime DDL in these schemas -- their objects come
+ * from extension scripts, where AutoDDL is already suppressed via
+ * creating_extension -- so such a statement is almost certainly a user
+ * mistake.  Without this it would half-apply: the command text would replicate
+ * to peers while the relation was quietly kept out of every replication set.
+ *
+ * The caller runs this only when spock.enable_ddl_replication is on and the
+ * statement did not arrive from the apply queue, so clearing the GUC for the
+ * session (and repair mode) remains the escape hatch for deliberate
+ * node-local surgery.
+ */
+void
+spock_guard_extension_owned_ddl(Node *stmt)
+{
+	const char *nspname = NULL;
+
+	if (!stmt_schema_matches(stmt, RESERVED_PURPOSE_EXTENSION_OWNED, false,
+							 &nspname))
+		return;
+
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("cannot run DDL against schema %s while DDL replication is enabled",
+					nspname),
+			 errdetail("The schema is managed by an extension and its objects are not replicated."),
+			 errhint("For a deliberate node-local change, run the statement with spock.enable_ddl_replication = off.")));
 }
 
 /*

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -135,6 +135,20 @@ typedef struct SubscriptionTuple
  * DDL is reserved when the object is node-local, i.e. its DDL is not
  * replicated, so replicate_ddl == false means reserved.  A NULL flag (e.g.
  * replicate_ddl is NULL for extensions) is never treated as reserved.
+ *
+ * RESERVED_PURPOSE_EXTENSION_OWNED is the one compound purpose: builtin AND
+ * block_in_repset AND replicate_ddl, which today selects exactly the spock and
+ * snowflake schemas.  Their objects come from extension scripts, so runtime DDL
+ * against them is a user mistake and AutoDDL refuses it.  All three parts
+ * matter:
+ *
+ *   builtin          an operator may reserve a schema to keep it out of the
+ *                    dump and out of replication sets and still legitimately
+ *                    create objects in it, so their rows are never guarded.
+ *   block_in_repset  a reserved schema whose tables may replicate (lolor) is
+ *                    ordinary as far as DDL is concerned.
+ *   replicate_ddl    a node-local schema (pgedge_ace) is the never-replicate
+ *                    class: its DDL stays local silently rather than erroring.
  */
 static bool
 row_reserved_for_purpose(HeapTuple tuple, TupleDesc tuple_desc,
@@ -157,6 +171,18 @@ row_reserved_for_purpose(HeapTuple tuple, TupleDesc tuple_desc,
 			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_replicate_ddl,
 											 tuple_desc, &isnull));
 			return !isnull && !flag;
+		case RESERVED_PURPOSE_EXTENSION_OWNED:
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_builtin,
+											 tuple_desc, &isnull));
+			if (isnull || !flag)
+				return false;
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_block_in_repset,
+											 tuple_desc, &isnull));
+			if (isnull || !flag)
+				return false;
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_replicate_ddl,
+											 tuple_desc, &isnull));
+			return !isnull && flag;
 	}
 	elog(ERROR, "unknown reserved object purpose %d", (int) purpose);
 	return false;	/* unreachable; keeps the compiler quiet */

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -55,6 +55,7 @@ test: 032_lolor_largeobject_repset
 test: 033_zodan_lolor_add_node
 test: 034_reserved_object_ddl
 test: 037_wire_format_datestyle
+test: 038_reserved_schema_ddl_guard
 test: 044_apply_change_logging
 test: 045_lsn_from_commit_ts
 # Upgrade schema match test (builds from source, slow):

--- a/tests/tap/t/038_reserved_schema_ddl_guard.pl
+++ b/tests/tap/t/038_reserved_schema_ddl_guard.pl
@@ -1,0 +1,221 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster
+    get_test_config scalar_query
+);
+
+# =============================================================================
+# Test: 037_reserved_schema_ddl_guard.pl
+#
+# Verifies the AutoDDL guard rail for built-in extension-owned schemas: the
+# reserved_object rows with builtin AND block_in_repset AND replicate_ddl,
+# which today are exactly spock and snowflake.
+#
+# Nothing legitimate issues runtime DDL in those schemas -- their objects come
+# from extension scripts, where AutoDDL is suppressed via creating_extension --
+# so a direct statement against them is almost certainly a user mistake. It
+# must fail loudly rather than half-apply, which is what happened before: the
+# command text replicated to peers while the relation was quietly kept out of
+# every replication set.
+#
+# Three things this must NOT break:
+#   - the never-replicate class (pgedge_ace: replicate_ddl=false), whose DDL
+#     stays silently node-local and must not raise this error;
+#   - operator-added reserved schemas, where creating objects is legitimate;
+#   - the escape hatch, spock.enable_ddl_replication = off in-session, which
+#     leaves deliberate node-local surgery possible.
+#
+# A single node is enough: the guard fires in the utility hook on the node
+# where the statement is issued. create_cluster() sets
+# spock.enable_ddl_replication=on, which is what makes the check live.
+# =============================================================================
+
+create_cluster(1, 'Create 1-node cluster for the reserved-schema DDL guard');
+
+my $cfg  = get_test_config();
+my $bin  = $cfg->{pg_bin};
+my $host = $cfg->{host};
+my $port = $cfg->{node_ports}[0];
+my $db   = $cfg->{db_name};
+my $user = $cfg->{db_user};
+
+# Run SQL, return (exit_code, combined_output).  ON_ERROR_STOP => non-zero on
+# server error, so we can assert both success and failure.
+sub psql_try {
+    my ($sql) = @_;
+    my $out = `$bin/psql -X -h $host -p $port -d $db -U $user -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    return ($? >> 8, $out);
+}
+
+# Assert $sql is refused by the guard, naming $nsp in the message.
+sub refused {
+    my ($sql, $nsp, $label) = @_;
+    my ($rc, $out) = psql_try($sql);
+    isnt($rc, 0, "$label: refused");
+    like($out,
+         qr/cannot run DDL against schema \Q$nsp\E while DDL replication is enabled/,
+         "$label: purposeful error message");
+    like($out, qr/enable_ddl_replication = off/,
+         "$label: hint points at the escape hatch");
+}
+
+# The snowflake schema belongs to a separate extension that is not installed
+# here, and reserved_object guards it by name whether or not it exists.  Plant
+# the schema and a scratch table with the guard off, so the statements below
+# have something to aim at and fail on the guard rather than on a missing
+# schema.  Creating it this way is itself a first exercise of the escape hatch.
+my ($rc_seed, $out_seed) = psql_try(
+    'SET spock.enable_ddl_replication = off; ' .
+    'CREATE SCHEMA snowflake; ' .
+    'CREATE TABLE snowflake.guard_seed (id int primary key, v text)');
+is($rc_seed, 0, "snowflake schema and seed table created with DDL replication off: $out_seed");
+
+# --------------------------------------------------------------------------
+# The refusals. One per statement class named in the acceptance criteria.
+# --------------------------------------------------------------------------
+refused('CREATE TABLE snowflake.t (id int primary key)',
+        'snowflake', 'CREATE TABLE');
+refused('CREATE TABLE spock.t (id int primary key)',
+        'spock', 'CREATE TABLE in the spock schema');
+refused('ALTER TABLE snowflake.guard_seed ADD COLUMN extra int',
+        'snowflake', 'ALTER TABLE');
+refused('CREATE INDEX guard_seed_v_idx ON snowflake.guard_seed (v)',
+        'snowflake', 'CREATE INDEX');
+refused('DROP TABLE snowflake.guard_seed',
+        'snowflake', 'DROP TABLE');
+refused('CREATE TABLE snowflake.ctas AS SELECT 1 AS x',
+        'snowflake', 'CREATE TABLE AS');
+refused('CREATE SEQUENCE snowflake.s',
+        'snowflake', 'CREATE SEQUENCE');
+refused('CREATE VIEW snowflake.v AS SELECT 1 AS x',
+        'snowflake', 'CREATE VIEW');
+refused('DROP SCHEMA snowflake CASCADE',
+        'snowflake', 'DROP SCHEMA');
+
+# A DROP mixing a guarded object with an ordinary one trips on the guarded
+# one: the guard quantifier is ANY, because a false negative would let the
+# mistake through.
+my ($rc_mixed, $out_mixed) = psql_try(
+    'CREATE TABLE public.mixed_ok (id int primary key)');
+is($rc_mixed, 0, "control table for the mixed DROP created: $out_mixed");
+refused('DROP TABLE public.mixed_ok, snowflake.guard_seed',
+        'snowflake', 'DROP mixing a guarded and an ordinary table');
+
+# --------------------------------------------------------------------------
+# The statement was rolled back. This is a post-execution hook, so the ERROR
+# aborts the transaction and undoes the DDL rather than leaving it applied
+# locally and merely unreplicated.
+# --------------------------------------------------------------------------
+is(scalar_query(1,
+    "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " .
+    "WHERE n.nspname = 'snowflake' AND c.relname IN ('t', 'ctas', 's', 'v')"),
+   '0', 'no refused object was left behind on the node');
+is(scalar_query(1,
+    "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " .
+    "WHERE n.nspname = 'snowflake' AND c.relname = 'guard_seed_v_idx'"),
+   '0', 'the refused CREATE INDEX left no index behind');
+is(scalar_query(1,
+    "SELECT count(*) FROM information_schema.columns " .
+    "WHERE table_schema = 'snowflake' AND table_name = 'guard_seed' AND column_name = 'extra'"),
+   '0', 'the refused ALTER TABLE left no column behind');
+is(scalar_query(1,
+    "SELECT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " .
+    "WHERE n.nspname = 'snowflake' AND c.relname = 'guard_seed')"),
+   't', 'the refused DROP TABLE left the table in place');
+is(scalar_query(1, "SELECT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'snowflake')"),
+   't', 'the refused DROP SCHEMA left the schema in place');
+
+# --------------------------------------------------------------------------
+# The escape hatch: the same statements succeed with DDL replication off in
+# the session.
+# --------------------------------------------------------------------------
+my ($rc_off, $out_off) = psql_try(
+    'SET spock.enable_ddl_replication = off; ' .
+    'CREATE TABLE snowflake.t (id int primary key)');
+is($rc_off, 0, "CREATE TABLE snowflake.t succeeds with DDL replication off: $out_off");
+is(scalar_query(1,
+    "SELECT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " .
+    "WHERE n.nspname = 'snowflake' AND c.relname = 't')"),
+   't', 'snowflake.t exists after the node-local create');
+
+my ($rc_off2, $out_off2) = psql_try(
+    'SET spock.enable_ddl_replication = off; DROP TABLE snowflake.t');
+is($rc_off2, 0, "DROP TABLE snowflake.t succeeds with DDL replication off: $out_off2");
+
+# The guard is still live afterwards -- the GUC was per-session, not global.
+refused('CREATE TABLE snowflake.t (id int primary key)',
+        'snowflake', 'guard still live in a fresh session');
+
+# --------------------------------------------------------------------------
+# The never-replicate class must NOT be caught. pgedge_ace carries
+# block_in_repset=true as well, so a guard keyed on that flag alone would
+# wrongly reject it; replicate_ddl=false is what keeps the classes apart.
+# --------------------------------------------------------------------------
+my ($rc_ace, $out_ace) = psql_try('CREATE SCHEMA pgedge_ace');
+is($rc_ace, 0, "CREATE SCHEMA pgedge_ace is not caught by the guard: $out_ace");
+my ($rc_ace2, $out_ace2) = psql_try(
+    'CREATE TABLE pgedge_ace.node_local (id int primary key)');
+is($rc_ace2, 0, "CREATE TABLE pgedge_ace.node_local is not caught by the guard: $out_ace2");
+is(scalar_query(1,
+    "SELECT count(*) FROM spock.tables WHERE nspname = 'pgedge_ace' AND set_name IS NOT NULL"),
+   '0', 'pgedge_ace.node_local still kept out of every replication set');
+
+# lolor is reserved but neither blocked from repsets nor node-local, so its
+# DDL is ordinary and must pass through untouched.
+my ($rc_lolor, $out_lolor) = psql_try('CREATE SCHEMA lolor');
+is($rc_lolor, 0, "CREATE SCHEMA lolor is not caught by the guard: $out_lolor");
+
+# --------------------------------------------------------------------------
+# Ordinary DDL is unaffected.
+# --------------------------------------------------------------------------
+my ($rc_pub, $out_pub) = psql_try(
+    'CREATE TABLE public.guard_control (id int primary key, v text)');
+is($rc_pub, 0, "ordinary CREATE TABLE still succeeds: $out_pub");
+is(scalar_query(1,
+    "SELECT set_name FROM spock.tables WHERE nspname = 'public' AND relname = 'guard_control'"),
+   'default', 'ordinary table still auto-added to the default replication set');
+
+# --------------------------------------------------------------------------
+# CREATE/ALTER EXTENSION for a guarded schema is unaffected: AutoDDL is
+# suppressed inside extension scripts, so the guard never sees those
+# subcommands. spock itself is already installed, so re-running its own
+# ALTER EXTENSION ... UPDATE is the available no-op form.
+# --------------------------------------------------------------------------
+my ($rc_ext, $out_ext) = psql_try("ALTER EXTENSION spock UPDATE");
+is($rc_ext, 0, "ALTER EXTENSION spock UPDATE is unaffected by the guard: $out_ext");
+
+# --------------------------------------------------------------------------
+# An OPERATOR-added reserved schema is NOT guarded, even with exactly the flag
+# combination the built-ins carry. The guard requires builtin=true.
+#
+# This is the boundary of the feature. Reserving a schema is how an operator
+# keeps it out of the structure dump and out of every replication set, and
+# creating objects in such a schema is a legitimate thing to do -- unlike in
+# spock or snowflake, whose objects only ever come from extension scripts. If
+# the guard keyed on the flags alone it would take that away, and it would
+# also make the repset-eviction net in apply_repset_policy_for_reloid
+# unreachable, since AutoDDL would error before ever re-evaluating membership.
+# --------------------------------------------------------------------------
+my ($rc_add, $out_add) = psql_try(
+    "SELECT spock.reserved_object_add('op_reserved', 'schema')");
+is($rc_add, 0, "operator reserved op_reserved: $out_add");
+is(scalar_query(1,
+    "SELECT block_in_repset || '/' || replicate_ddl || '/' || builtin " .
+    "FROM spock.reserved_object WHERE name = 'op_reserved' AND kind = 'schema'"),
+   'true/true/false',
+   'op_reserved carries the guarded flag pair but is not builtin');
+
+my ($rc_op, $out_op) = psql_try(
+    'CREATE SCHEMA op_reserved; CREATE TABLE op_reserved.t (id int primary key)');
+is($rc_op, 0, "DDL against an operator-reserved schema is allowed: $out_op");
+is(scalar_query(1,
+    "SELECT count(*) FROM spock.tables WHERE nspname = 'op_reserved' AND set_name IS NOT NULL"),
+   '0', 'op_reserved.t still kept out of every replication set');
+
+destroy_cluster('Destroy the reserved-schema DDL guard cluster');
+
+done_testing();


### PR DESCRIPTION
DDL against the spock and snowflake schemas used to half-apply: the command text replicated to peers while the relation was silently kept out of every replication set.  Refuse it outright while DDL replication is on, with spock.enable_ddl_replication = off as the escape hatch.  Operator-reserved schemas and the node-local pgedge_ace class are unaffected.