### PR TITLE
Resolve unqualified DROP targets before the extension-owned guard.

### DIFF
--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -277,7 +277,7 @@ AutoDDL has been refactored and hardened:
   statement whose target schema is one of the built-in extension-owned
   schemas now fails outright:
 
-  ```
+  ```text
   ERROR:  cannot run DDL against schema snowflake while DDL replication is enabled
   DETAIL:  The schema is managed by an extension and its objects are not replicated.
   HINT:  For a deliberate node-local change, run the statement with spock.enable_ddl_replication = off.

--- a/include/spock.h
+++ b/include/spock.h
@@ -158,6 +158,8 @@ extern bool spock_auto_replicate_ddl(const char *query, List *replication_sets,
 									 Oid roleoid, Node *stmt);
 extern bool spock_schema_is_ddl_local(const char *nspname);
 extern void spock_guard_extension_owned_ddl(Node *stmt);
+extern List *spock_resolve_drop_target_schemas(Node *stmt);
+extern List *spock_set_drop_target_schemas(List *schemas);
 extern bool name_in_list(List *names, const char *name);
 
 /* spock_readonly.c */

--- a/src/spock_executor.c
+++ b/src/spock_executor.c
@@ -175,6 +175,7 @@ spock_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	Node	   *parsetree = pstmt->utilityStmt;
 	NodeTag		toplevel_stmt = nodeTag(parsetree);
 	bool		is_extension_drop;
+	List	   *save_drop_nsps;
 
 	dropping_spock_obj = false;
 
@@ -218,28 +219,51 @@ spock_ProcessUtility(PlannedStmt *pstmt, const char *queryString,
 	is_extension_drop = (nodeTag(parsetree) == T_DropStmt &&
 						 ((DropStmt *) parsetree)->removeType == OBJECT_EXTENSION);
 
-	if (is_extension_drop)
-	{
-		bool		save_in_extension_drop = in_spock_extension_drop;
+	/*
+	 * Resolve the schemas of any unqualified DROP target now, while the
+	 * relations still exist.  The AutoDDL hook below runs after the DROP, and
+	 * an unqualified name cannot be classified there: the relation is gone and
+	 * the parse tree never carried a schema.  Saved and restored around the
+	 * pair because DDL nests -- an event trigger is free to run its own.
+	 */
+	save_drop_nsps = spock_set_drop_target_schemas(
+						 spock_resolve_drop_target_schemas(parsetree));
 
-		in_spock_extension_drop = true;
-		PG_TRY();
+	PG_TRY();
+	{
+		if (is_extension_drop)
 		{
+			bool		save_in_extension_drop = in_spock_extension_drop;
+
+			in_spock_extension_drop = true;
+			PG_TRY();
+			{
+				spock_next_process_utility(pstmt, queryString, readOnlyTree,
+										   context, params, queryEnv, dest, qc);
+			}
+			PG_FINALLY();
+			{
+				in_spock_extension_drop = save_in_extension_drop;
+			}
+			PG_END_TRY();
+		}
+		else
 			spock_next_process_utility(pstmt, queryString, readOnlyTree,
 									   context, params, queryEnv, dest, qc);
-		}
-		PG_FINALLY();
-		{
-			in_spock_extension_drop = save_in_extension_drop;
-		}
-		PG_END_TRY();
-	}
-	else
-		spock_next_process_utility(pstmt, queryString, readOnlyTree,
-								   context, params, queryEnv, dest, qc);
 
-	/* Check for AutoDDL */
-	spock_autoddl_process(pstmt, queryString, context, toplevel_stmt);
+		/* Check for AutoDDL */
+		spock_autoddl_process(pstmt, queryString, context, toplevel_stmt);
+	}
+	PG_FINALLY();
+	{
+		/*
+		 * Restore only.  On the error path the context holding the list may
+		 * already have been reset, so freeing it here would be a use after
+		 * free; it goes away with the statement's context either way.
+		 */
+		(void) spock_set_drop_target_schemas(save_drop_nsps);
+	}
+	PG_END_TRY();
 }
 
 /*

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -2627,12 +2627,103 @@ name_in_list(List *names, const char *name)
 	return false;
 }
 
+/* Does this DROP name relations, i.e. objects a RangeVar can address? */
+static bool
+drop_type_is_relation(ObjectType removeType)
+{
+	return removeType == OBJECT_TABLE || removeType == OBJECT_INDEX ||
+		removeType == OBJECT_SEQUENCE || removeType == OBJECT_VIEW ||
+		removeType == OBJECT_MATVIEW || removeType == OBJECT_FOREIGN_TABLE;
+}
+
+/*
+ * Schemas of the relations a DROP names, resolved before the DROP executed.
+ *
+ * AutoDDL's hook is post-execution, and by then an unqualified DROP target
+ * cannot be classified: the relation is gone, so the parse tree's RangeVar
+ * still carries schemaname == NULL and nothing else says which schema it was
+ * in.  So `SET search_path TO snowflake; DROP TABLE guard_seed` walked past
+ * spock_guard_extension_owned_ddl() and was queued for replication, while the
+ * qualified spelling of the same statement was refused.
+ *
+ * spock_ProcessUtility resolves the targets while they still exist and leaves
+ * the answers here: one entry per drop->objects element, in the same order,
+ * NULL where the name was already qualified or did not resolve.
+ */
+static List *drop_target_nsps = NIL;
+
+/*
+ * Resolve the DROP targets that only the search_path can identify.
+ *
+ * Returns NIL -- reading no catalog at all -- for everything that cannot need
+ * it: a non-DROP, a DROP of something other than a relation, a DROP whose
+ * names are all schema-qualified, or a session where AutoDDL is not going to
+ * look at the statement anyway.
+ */
+List *
+spock_resolve_drop_target_schemas(Node *stmt)
+{
+	DropStmt   *drop;
+	ListCell   *cell;
+	List	   *result = NIL;
+	bool		any_resolved = false;
+
+	if (!spock_enable_ddl_replication || spock_replication_repair_mode)
+		return NIL;
+	if (in_spock_queue_ddl_command || in_spock_replicate_ddl_command)
+		return NIL;
+	if (stmt == NULL || !IsA(stmt, DropStmt))
+		return NIL;
+
+	drop = (DropStmt *) stmt;
+	if (!drop_type_is_relation(drop->removeType))
+		return NIL;
+
+	foreach(cell, drop->objects)
+	{
+		RangeVar   *rv = makeRangeVarFromNameList((List *) lfirst(cell));
+		char	   *nspname = NULL;
+
+		if (rv->schemaname == NULL)
+		{
+			/*
+			 * NoLock: this is a classification read, and the DROP takes the
+			 * lock it needs a moment later.  Acquiring one here would change
+			 * the lock order of every DROP for the sake of a check.
+			 */
+			Oid			relid = RangeVarGetRelid(rv, NoLock, true);
+
+			if (OidIsValid(relid))
+			{
+				nspname = get_namespace_name(get_rel_namespace(relid));
+				any_resolved = true;
+			}
+		}
+		result = lappend(result, nspname);
+	}
+
+	if (!any_resolved)
+	{
+		list_free(result);
+		return NIL;
+	}
+	return result;
+}
+
+/* Install a resolved-target list, returning the one it replaces. */
+List *
+spock_set_drop_target_schemas(List *schemas)
+{
+	List	   *prev = drop_target_nsps;
+
+	drop_target_nsps = schemas;
+	return prev;
+}
+
 /*
  * Are this DDL statement's target schemas reserved for purpose?  Only statement
  * types whose target schema is identifiable are classified; for all others this
- * returns false and the statement is handled as before.  Known gap: dropping a
- * relation by an unqualified name cannot be classified (the relation is
- * already gone).
+ * returns false and the statement is handled as before.
  *
  * match_all selects the quantifier over a multi-object DROP, and the two
  * callers need opposite ones:
@@ -2692,13 +2783,12 @@ stmt_schema_matches(Node *stmt, ReservedObjectPurpose purpose, bool match_all,
 				ListCell   *cell;
 				List	   *reserved;
 				bool		result = match_all;
+				int			idx = 0;
 
 				if (drop->objects == NIL)
 					return false;
 				if (drop->removeType != OBJECT_SCHEMA &&
-					drop->removeType != OBJECT_TABLE && drop->removeType != OBJECT_INDEX &&
-					drop->removeType != OBJECT_SEQUENCE && drop->removeType != OBJECT_VIEW &&
-					drop->removeType != OBJECT_MATVIEW && drop->removeType != OBJECT_FOREIGN_TABLE)
+					!drop_type_is_relation(drop->removeType))
 					return false;
 
 				/* One catalog read for the whole (possibly multi-object) DROP. */
@@ -2706,9 +2796,24 @@ stmt_schema_matches(Node *stmt, ReservedObjectPurpose purpose, bool match_all,
 													   purpose);
 				foreach(cell, drop->objects)
 				{
-					const char *schema = (drop->removeType == OBJECT_SCHEMA)
-						? strVal(lfirst(cell))
-						: makeRangeVarFromNameList((List *) lfirst(cell))->schemaname;
+					const char *schema;
+
+					if (drop->removeType == OBJECT_SCHEMA)
+						schema = strVal(lfirst(cell));
+					else
+					{
+						schema = makeRangeVarFromNameList((List *) lfirst(cell))->schemaname;
+
+						/*
+						 * Unqualified: the schema came from the search_path,
+						 * and the relation is gone by the time this runs.
+						 * Use what spock_ProcessUtility resolved before the
+						 * DROP executed.
+						 */
+						if (schema == NULL && idx < list_length(drop_target_nsps))
+							schema = (const char *) list_nth(drop_target_nsps, idx);
+					}
+					idx++;
 
 					if (name_in_list(reserved, schema) != match_all)
 					{

--- a/tests/tap/t/038_reserved_schema_ddl_guard.pl
+++ b/tests/tap/t/038_reserved_schema_ddl_guard.pl
@@ -106,6 +106,29 @@ refused('DROP TABLE public.mixed_ok, snowflake.guard_seed',
         'snowflake', 'DROP mixing a guarded and an ordinary table');
 
 # --------------------------------------------------------------------------
+# An unqualified target, resolved through the search_path. The parse tree
+# carries no schema, and the relation is gone by the time the post-execution
+# hook looks, so this used to walk straight past the guard and queue the DROP
+# while the qualified spelling of the same statement was refused.
+# --------------------------------------------------------------------------
+refused('SET search_path TO snowflake, public; DROP TABLE guard_seed',
+        'snowflake', 'unqualified DROP through a guarded search_path');
+is(scalar_query(1,
+    "SELECT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " .
+    "WHERE n.nspname = 'snowflake' AND c.relname = 'guard_seed')"),
+   't', 'the refused unqualified DROP left the table in place');
+
+my ($rc_mixed2, $out_mixed2) = psql_try(
+    'CREATE TABLE public.mixed_ok2 (id int primary key)');
+is($rc_mixed2, 0, "second control table for the mixed DROP created: $out_mixed2");
+refused('SET search_path TO snowflake, public; DROP TABLE public.mixed_ok2, guard_seed',
+        'snowflake', 'DROP mixing an ordinary table with an unqualified guarded one');
+is(scalar_query(1,
+    "SELECT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace " .
+    "WHERE n.nspname = 'public' AND c.relname = 'mixed_ok2')"),
+   't', 'the ordinary table in the refused mixed DROP survived too');
+
+# --------------------------------------------------------------------------
 # The statement was rolled back. This is a post-execution hook, so the ERROR
 # aborts the transaction and undoes the DDL rather than leaving it applied
 # locally and merely unreplicated.
@@ -164,6 +187,19 @@ is(scalar_query(1,
     "SELECT count(*) FROM spock.tables WHERE nspname = 'pgedge_ace' AND set_name IS NOT NULL"),
    '0', 'pgedge_ace.node_local still kept out of every replication set');
 
+# The same blind spot in the other direction: an unqualified DROP of a
+# node-local table used to be replicated, because the suppression check could
+# not tell which schema the bare name resolved to either.
+my ($rc_ace3, $out_ace3) = psql_try(
+    'CREATE TABLE pgedge_ace.node_local2 (id int primary key)');
+is($rc_ace3, 0, "second pgedge_ace table created: $out_ace3");
+my $queue_ace = scalar_query(1, 'SELECT count(*) FROM spock.queue');
+my ($rc_ace4, $out_ace4) = psql_try(
+    'SET search_path TO pgedge_ace; DROP TABLE node_local2');
+is($rc_ace4, 0, "unqualified DROP of a node-local table succeeds: $out_ace4");
+is(scalar_query(1, 'SELECT count(*) FROM spock.queue') - $queue_ace, 0,
+   'and it was not queued for replication');
+
 # lolor is reserved but neither blocked from repsets nor node-local, so its
 # DDL is ordinary and must pass through untouched.
 my ($rc_lolor, $out_lolor) = psql_try('CREATE SCHEMA lolor');
@@ -178,6 +214,15 @@ is($rc_pub, 0, "ordinary CREATE TABLE still succeeds: $out_pub");
 is(scalar_query(1,
     "SELECT set_name FROM spock.tables WHERE nspname = 'public' AND relname = 'guard_control'"),
    'default', 'ordinary table still auto-added to the default replication set');
+
+# ...including an unqualified DROP of one. Resolving the search_path for the
+# guard must not turn into a blanket block on bare names.
+my $queue_pub = scalar_query(1, 'SELECT count(*) FROM spock.queue');
+my ($rc_dpub, $out_dpub) = psql_try(
+    'SET search_path TO public; DROP TABLE guard_control');
+is($rc_dpub, 0, "unqualified DROP in an ordinary schema still succeeds: $out_dpub");
+cmp_ok(scalar_query(1, 'SELECT count(*) FROM spock.queue') - $queue_pub, '>=', 1,
+   'and it was still queued for replication');
 
 # --------------------------------------------------------------------------
 # CREATE/ALTER EXTENSION for a guarded schema is unaffected: AutoDDL is


### PR DESCRIPTION
The guard reads the parse tree, but AutoDDL's hook runs after the statement. For an unqualified DROP the RangeVar carries no schema and the relation is already gone, so `SET search_path TO snowflake; DROP TABLE guard_seed` was replicated while the qualified spelling of it was refused.  The same gap let an unqualified DROP of a node-local pgedge_ace table replicate as well.

spock_ProcessUtility() now resolves the targets while they still exist, and reads no catalog unless it has to.  Covered both ways in 038.

Also label the fenced error block in the release notes, for markdownlint MD040.