### PR TITLE
Route a reserved extension's tables into a replication set.

### DIFF
--- a/docs/spock_functions/repset_mgmt.md
+++ b/docs/spock_functions/repset_mgmt.md
@@ -130,6 +130,17 @@ applicable), while `exclude_from_dump`/`block_in_repset` apply to both.
 sets: its tables must replicate so that large objects survive a
 `DROP EXTENSION` on every node, not only where the drop was issued.
 
+Because a reserved object is left out of the structure dump, nothing else would
+ever place its tables in a set, so AutoDDL routes them itself when
+`CREATE EXTENSION` (or `ALTER EXTENSION ... UPDATE`) runs on a Spock node: any
+table the extension owns that is not yet in a set goes to `default` or
+`default_insert_only` by the usual primary key / replica identity rule. This
+applies only to reserved objects with `block_in_repset = no` — `lolor` today —
+and it never moves a table that already belongs to a set, so a custom placement
+is kept. It matters most after a `DROP EXTENSION`: the membership rows are
+cascade-dropped with the tables, and the routing is what puts them back when the
+extension is re-created.
+
 `pgedge_ace` is the schema used by the pgEdge ACE utility. It is node-local
 configuration/state, not application data: its DDL is kept local for the
 classified statement kinds above (`replicate_ddl=no`), and its tables can

--- a/docs/spock_release_notes.md
+++ b/docs/spock_release_notes.md
@@ -272,6 +272,15 @@ AutoDDL has been refactored and hardened:
   `REPLICA IDENTITY FULL` tables are now classified correctly.
 * **Safe `search_path` interpolation** — replicated DDL ships a valid
   `SET search_path` even when the session path is empty.
+* **Extension tables are routed into a replication set** — with
+  `spock.include_ddl_repset` enabled, `CREATE EXTENSION` and
+  `ALTER EXTENSION … UPDATE` now place the tables of a reserved object with
+  `block_in_repset = no` (`lolor`) into `default` or `default_insert_only`.
+  Such an object is left out of the structure dump, so nothing else would
+  place them, and `DROP EXTENSION` cascades the membership away with the
+  tables — after which large objects created against a re-created `lolor`
+  were silently not replicated.  Tables already in a set are left where they
+  are, so custom placements survive.
 * **Direct DDL against `spock` and `snowflake` is refused**
   (behaviour change) — while `spock.enable_ddl_replication` is on, a
   statement whose target schema is one of the built-in extension-owned

--- a/include/spock_node.h
+++ b/include/spock_node.h
@@ -77,8 +77,10 @@ typedef enum ReservedObjectPurpose
 	RESERVED_PURPOSE_DUMP,		/* exclude_from_dump: kept out of structure sync */
 	RESERVED_PURPOSE_REPSET,	/* block_in_repset: cannot join a replication set */
 	RESERVED_PURPOSE_DDL,		/* replicate_ddl = false (node-local) */
-	RESERVED_PURPOSE_EXTENSION_OWNED	/* built-in, blocked from repsets, DDL
+	RESERVED_PURPOSE_EXTENSION_OWNED,	/* built-in, blocked from repsets, DDL
 										 * still replicated: spock, snowflake */
+	RESERVED_PURPOSE_REPSET_MEMBER	/* block_in_repset = false: reserved, but
+									 * its tables are meant to replicate */
 } ReservedObjectPurpose;
 
 extern List *spock_reserved_object_names(ReservedObjectKind kind,

--- a/src/spock_autoddl.c
+++ b/src/spock_autoddl.c
@@ -11,12 +11,16 @@
  */
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/relation.h"
 #include "access/table.h"
 
+#include "catalog/dependency.h"
 #include "catalog/index.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_authid_d.h"
+#include "catalog/pg_depend.h"
+#include "catalog/pg_extension.h"
 #include "catalog/pg_inherits.h"
 
 #include "commands/defrem.h"
@@ -24,6 +28,7 @@
 
 #include "tcop/utility.h"
 #include "utils/builtins.h"
+#include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
@@ -63,6 +68,7 @@ static AlterPkRiChange classify_alter_pkri_change(AlterTableStmt *atstmt,
 static void classify_repset_membership(Oid nodeid, Oid reloid,
 									   bool *in_any_upd_del,
 									   bool *in_any_custom);
+static void route_extension_tables(SpockLocalNode *node, const char *extname);
 
 /*
  * spock_autoddl_process
@@ -154,6 +160,8 @@ end:
  *		Route a just-executed DDL statement into the appropriate replication
  *		set(s). Only tables are auto-managed.
  *
+ * CREATE/ALTER EXTENSION is handled separately, see route_extension_tables().
+ *
  * Pipeline:
  *	1. extract_ddl_target() inspects the parse tree, decides if this DDL
  *	   targets a table, and reports the target.
@@ -176,6 +184,20 @@ add_ddl_to_repset(Node *parsetree)
 
 	if (!spock_include_ddl_repset)
 		return;
+
+	/* The script's own CREATE TABLEs are invisible here; route them by hand. */
+	if (IsA(parsetree, CreateExtensionStmt) || IsA(parsetree, AlterExtensionStmt))
+	{
+		node = get_local_node(false, true);
+		if (!node)
+			return;
+
+		route_extension_tables(node,
+							   IsA(parsetree, CreateExtensionStmt)
+							   ? castNode(CreateExtensionStmt, parsetree)->extname
+							   : castNode(AlterExtensionStmt, parsetree)->extname);
+		return;
+	}
 
 	if (!extract_ddl_target(parsetree, &relation, &reloid, &missing_ok,
 							&check_alter_stickiness))
@@ -209,6 +231,84 @@ add_ddl_to_repset(Node *parsetree)
 
 	foreach(lc, reloids)
 		apply_repset_policy_for_reloid(node, lfirst_oid(lc), atstmt);
+}
+
+/*
+ * route_extension_tables
+ *		Put an extension's tables into a replication set.
+ *
+ * autoddl_can_proceed() skips everything nested inside an extension script, so
+ * the tables a script creates never reach add_ddl_to_repset() on their own.
+ * For lolor -- reserved with block_in_repset = false -- they have to: they hold
+ * user data and are kept out of the structure dump as well, so nothing else
+ * places them.  Without this a re-CREATE after a DROP EXTENSION leaves them in
+ * no set at all and later writes silently stop replicating.
+ *
+ * Additive: a table already in a set keeps its placement.
+ */
+static void
+route_extension_tables(SpockLocalNode *node, const char *extname)
+{
+	Oid				extoid;
+	Relation		depRel;
+	ScanKeyData		key[2];
+	SysScanDesc		scan;
+	HeapTuple		tup;
+	List		   *reloids = NIL;
+	ListCell	   *lc;
+
+	if (!spock_name_is_reserved(RESERVED_KIND_EXTENSION,
+								RESERVED_PURPOSE_REPSET_MEMBER, extname))
+		return;
+
+	extoid = get_extension_oid(extname, true);
+	if (!OidIsValid(extoid))
+		return;
+
+	/* Collect the members first, so the writes below run with no scan open. */
+	depRel = table_open(DependRelationId, AccessShareLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_depend_refclassid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(ExtensionRelationId));
+	ScanKeyInit(&key[1],
+				Anum_pg_depend_refobjid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(extoid));
+
+	scan = systable_beginscan(depRel, DependReferenceIndexId, true,
+							  NULL, 2, key);
+
+	while (HeapTupleIsValid(tup = systable_getnext(scan)))
+	{
+		Form_pg_depend		dep = (Form_pg_depend) GETSTRUCT(tup);
+		char				relkind;
+
+		if (dep->deptype != DEPENDENCY_EXTENSION ||
+			dep->classid != RelationRelationId ||
+			dep->objsubid != 0)
+			continue;
+
+		relkind = get_rel_relkind(dep->objid);
+		if (relkind != RELKIND_RELATION && relkind != RELKIND_PARTITIONED_TABLE)
+			continue;
+
+		reloids = lappend_oid(reloids, dep->objid);
+	}
+
+	systable_endscan(scan);
+	table_close(depRel, AccessShareLock);
+
+	foreach(lc, reloids)
+	{
+		Oid		reloid = lfirst_oid(lc);
+
+		if (get_table_replication_sets(node->node->id, reloid) != NIL)
+			continue;
+
+		apply_repset_policy_for_reloid(node, reloid, NULL);
+	}
 }
 
 /*

--- a/src/spock_node.c
+++ b/src/spock_node.c
@@ -128,9 +128,10 @@ typedef struct SubscriptionTuple
  * Each purpose is decided by one boolean column, but the column and the sense
  * of "reserved" differ, so keep that knowledge in one place:
  *
- *   RESERVED_PURPOSE_DUMP    exclude_from_dump  reserved when true
- *   RESERVED_PURPOSE_REPSET  block_in_repset    reserved when true
- *   RESERVED_PURPOSE_DDL     replicate_ddl      reserved when *false*
+ *   RESERVED_PURPOSE_DUMP           exclude_from_dump  reserved when true
+ *   RESERVED_PURPOSE_REPSET         block_in_repset    reserved when true
+ *   RESERVED_PURPOSE_DDL            replicate_ddl      reserved when *false*
+ *   RESERVED_PURPOSE_REPSET_MEMBER  block_in_repset    reserved when *false*
  *
  * DDL is reserved when the object is node-local, i.e. its DDL is not
  * replicated, so replicate_ddl == false means reserved.  A NULL flag (e.g.
@@ -149,6 +150,11 @@ typedef struct SubscriptionTuple
  *                    ordinary as far as DDL is concerned.
  *   replicate_ddl    a node-local schema (pgedge_ace) is the never-replicate
  *                    class: its DDL stays local silently rather than erroring.
+ *
+ * RESERVED_PURPOSE_REPSET_MEMBER is the inverse of RESERVED_PURPOSE_REPSET: a
+ * reserved object whose tables are meant to replicate (lolor).  AutoDDL routes
+ * those into a set when the extension script creates them, since being out of
+ * the dump means nothing else ever will.
  */
 static bool
 row_reserved_for_purpose(HeapTuple tuple, TupleDesc tuple_desc,
@@ -169,6 +175,10 @@ row_reserved_for_purpose(HeapTuple tuple, TupleDesc tuple_desc,
 			return !isnull && flag;
 		case RESERVED_PURPOSE_DDL:
 			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_replicate_ddl,
+											 tuple_desc, &isnull));
+			return !isnull && !flag;
+		case RESERVED_PURPOSE_REPSET_MEMBER:
+			flag = DatumGetBool(heap_getattr(tuple, Anum_reserved_block_in_repset,
 											 tuple_desc, &isnull));
 			return !isnull && !flag;
 		case RESERVED_PURPOSE_EXTENSION_OWNED:

--- a/tests/tap/schedule
+++ b/tests/tap/schedule
@@ -56,6 +56,7 @@ test: 033_zodan_lolor_add_node
 test: 034_reserved_object_ddl
 test: 037_wire_format_datestyle
 test: 038_reserved_schema_ddl_guard
+test: 039_lolor_recreate_repset
 test: 044_apply_change_logging
 test: 045_lsn_from_commit_ts
 # Upgrade schema match test (builds from source, slow):

--- a/tests/tap/t/032_lolor_largeobject_repset.pl
+++ b/tests/tap/t/032_lolor_largeobject_repset.pl
@@ -8,9 +8,10 @@ use SpockTest qw(create_cluster destroy_cluster system_maybe get_test_config
 # lolor stores large objects in ordinary tables in the "lolor" schema. Those
 # tables must be allowed into a replication set, otherwise a DROP EXTENSION
 # migrates the objects only on the node where it ran and the other nodes are
-# left with unreachable data. This test verifies that the tables replicate,
-# that other protected schemas (spock) stay blocked, and that add-node
-# structure sync still works when lolor is present on both ends.
+# left with unreachable data. This test verifies that CREATE EXTENSION routes
+# the tables into the default set by itself, that repset_add_table still
+# accepts them, that other protected schemas (spock) stay blocked, and that
+# add-node structure sync still works when lolor is present on both ends.
 
 my $cfg   = get_test_config();
 my $PG    = $cfg->{pg_bin};
@@ -47,11 +48,21 @@ ok(
 ok(wait_for_sub_status(2, 'sub_n1_n2', 'replicating', 60),
    'subscription reached replicating (structure sync excluded lolor)');
 
-# The fix: lolor tables may now be added to a replication set.
+# CREATE EXTENSION routes the tables into 'default' by itself; being out of the
+# structure dump, nothing else would.
+for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
+    is(scalar_query(1,
+        "SELECT set_name FROM spock.tables " .
+        "WHERE nspname = 'lolor' AND relname = '$tbl'"),
+       'default',
+       "lolor.$tbl routed into the default set by CREATE EXTENSION");
+}
+
+# They are still ordinary members: a remove/add round trip has to work.
+ok(psql_ok(1, "SELECT spock.repset_remove_table('default', 'lolor.pg_largeobject')"),
+   'lolor.pg_largeobject removed from replication set');
 ok(psql_ok(1, "SELECT spock.repset_add_table('default', 'lolor.pg_largeobject')"),
-   'lolor.pg_largeobject added to replication set');
-ok(psql_ok(1, "SELECT spock.repset_add_table('default', 'lolor.pg_largeobject_metadata')"),
-   'lolor.pg_largeobject_metadata added to replication set');
+   'lolor.pg_largeobject added back to replication set');
 
 # The guard still protects other schemas: spock relations stay excluded.
 ok(!psql_ok(1, "SELECT spock.repset_add_table('default', 'spock.node')"),

--- a/tests/tap/t/033_zodan_lolor_add_node.pl
+++ b/tests/tap/t/033_zodan_lolor_add_node.pl
@@ -83,15 +83,17 @@ ok(psql_ok(3, "CREATE EXTENSION IF NOT EXISTS dblink"), 'dblink installed on n3'
 
 # lolor on the source cluster, its tables in the default replication set.
 # n1 and n2 are cross-wired with automatic DDL replication, so CREATE
-# EXTENSION on n1 arrives on n2 by itself.
+# EXTENSION on n1 arrives on n2 by itself, routing the tables on each node.
 ok(psql_ok(1, "CREATE EXTENSION lolor"), 'lolor installed on n1');
 ok(wait_for_scalar(2, "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '1'),
    'lolor arrived on n2 via DDL replication');
 for my $node (1, 2) {
-    ok(psql_ok($node, "SELECT spock.repset_add_table('default', 'lolor.pg_largeobject')"),
-       "lolor.pg_largeobject in default repset on n$node");
-    ok(psql_ok($node, "SELECT spock.repset_add_table('default', 'lolor.pg_largeobject_metadata')"),
-       "lolor.pg_largeobject_metadata in default repset on n$node");
+    for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
+        ok(wait_for_scalar($node,
+            "SELECT set_name FROM spock.tables " .
+            "WHERE nspname = 'lolor' AND relname = '$tbl'", 'default'),
+           "lolor.$tbl in default repset on n$node");
+    }
 }
 
 # Large object on n1; sanity-check it reaches n2 before involving zodan.
@@ -161,9 +163,10 @@ ok(wait_for_scalar(3, "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(da
 # populates the sets during a normal join is AutoDDL firing while pg_restore
 # replays the structure dump, and that never sees the lolor tables: they are
 # left out of the dump (reserved_object.exclude_from_dump), so they arrive via
-# CREATE EXTENSION instead, and autoddl_can_proceed() returns false while
-# creating_extension is set. So the lolor tables reach n3's default set only
-# if add_node mirrors the source node's sets onto the new node.
+# CREATE EXTENSION instead. AutoDDL does route them at that point, but only on a
+# registered Spock node, and n3's registration was dropped above -- lolor went in
+# while it looked freshly prepared. So here the tables reach n3's default set
+# only if add_node mirrors the source node's sets onto the new node.
 
 for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
     is(scalar_query(3,

--- a/tests/tap/t/039_lolor_recreate_repset.pl
+++ b/tests/tap/t/039_lolor_recreate_repset.pl
@@ -1,0 +1,140 @@
+use strict;
+use warnings;
+use Test::More;
+use lib '.';
+use lib 't';
+use SpockTest qw(create_cluster destroy_cluster system_maybe get_test_config
+                 cross_wire scalar_query ensure_lolor);
+
+# DROP EXTENSION lolor cascade-drops the lolor tables' replication set
+# membership along with the tables themselves. A CREATE EXTENSION afterwards
+# brings the tables back, and AutoDDL has to put them back in the default set on
+# every node -- nothing else would, since lolor is kept out of the structure
+# dump. Otherwise large objects created from then on go unreplicated with no
+# error anywhere.
+
+my $cfg  = get_test_config();
+my $PG   = $cfg->{pg_bin};
+my $DB   = $cfg->{db_name};
+
+plan skip_all => "lolor extension unavailable (clone/build failed)"
+    unless ensure_lolor();
+
+# psql helper: 1-based node index, returns true on success (output to log).
+sub psql_ok {
+    my ($node, $sql) = @_;
+    my $port = $cfg->{node_ports}[$node - 1];
+    return system_maybe("$PG/psql", '-X', '-p', $port, '-d', $DB,
+                        '-v', 'ON_ERROR_STOP=1', '-c', $sql);
+}
+
+# Poll a scalar query on a node until it returns $expected.
+sub wait_for_scalar {
+    my ($node, $sql, $expected, $timeout) = @_;
+    $timeout //= 60;
+    for (1 .. $timeout) {
+        my $v = scalar_query($node, $sql);
+        return 1 if defined $v && $v eq $expected;
+        sleep(1);
+    }
+    return 0;
+}
+
+sub wait_for_lo {
+    my ($node, $hex) = @_;
+    return wait_for_scalar($node,
+        "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = '$hex'",
+        '1', 30);
+}
+
+sub repset_of {
+    my ($node, $tbl) = @_;
+    return scalar_query($node, "SELECT set_name FROM spock.tables " .
+                               "WHERE nspname = 'lolor' AND relname = '$tbl'");
+}
+
+create_cluster(3, 'Create 3 instances for lolor re-create test');
+cross_wire(3, ['n1', 'n2', 'n3'], 'Cross-wire n1, n2 and n3');
+
+# --- First install: CREATE EXTENSION routes the tables on every node ---------
+
+ok(psql_ok(1, "CREATE EXTENSION lolor"), 'lolor installed on n1');
+for my $node (2, 3) {
+    ok(wait_for_scalar($node, "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '1'),
+       "lolor arrived on n$node via DDL replication");
+}
+for my $node (1, 2, 3) {
+    for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
+        ok(wait_for_scalar($node,
+            "SELECT set_name FROM spock.tables WHERE nspname = 'lolor' AND relname = '$tbl'",
+            'default'),
+           "lolor.$tbl routed into the default set on n$node");
+    }
+}
+
+ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xdeadbeefcafe')"),
+   'large object created on n1');
+ok(wait_for_lo(2, 'deadbeefcafe'), 'large object replicated to n2');
+ok(wait_for_lo(3, 'deadbeefcafe'), 'large object replicated to n3');
+
+# --- DROP: the extension and the membership both go on every node -----------
+#
+# lolor's event trigger migrates the objects into pg_catalog as each node
+# applies the drop, so the data is moved, not lost.
+
+ok(psql_ok(1, "SET spock.allow_ddl_from_functions = on; DROP EXTENSION lolor"),
+   'lolor dropped on n1');
+for my $node (1, 2, 3) {
+    ok(wait_for_scalar($node, "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '0'),
+       "lolor is gone on n$node");
+    ok(wait_for_scalar($node, "SELECT count(*) FROM pg_catalog.pg_largeobject_metadata", '1'),
+       "n$node migrated its large object into pg_catalog");
+    is(scalar_query($node, "SELECT count(*) FROM spock.replication_set_table rst " .
+                           "JOIN pg_class c ON c.oid = rst.set_reloid " .
+                           "JOIN pg_namespace n ON n.oid = c.relnamespace " .
+                           "WHERE n.nspname = 'lolor'"),
+       '0', "membership cascade-dropped with the tables on n$node");
+}
+
+# --- Re-create: membership has to come back, or new objects go nowhere -------
+
+ok(psql_ok(1, "CREATE EXTENSION lolor"), 'lolor re-created on n1');
+for my $node (2, 3) {
+    ok(wait_for_scalar($node, "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '1'),
+       "re-created lolor arrived on n$node");
+}
+for my $node (1, 2, 3) {
+    for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
+        ok(wait_for_scalar($node,
+            "SELECT set_name FROM spock.tables WHERE nspname = 'lolor' AND relname = '$tbl'",
+            'default'),
+           "lolor.$tbl back in the default set on n$node after re-create");
+    }
+}
+
+ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xfeedface')"),
+   'large object created on n1 after the re-create');
+ok(wait_for_lo(2, 'feedface'), 'large object after re-create replicated to n2');
+ok(wait_for_lo(3, 'feedface'), 'large object after re-create replicated to n3');
+
+# The objects left behind in pg_catalog by the drop do not get in the way of a
+# second round trip either.
+ok(psql_ok(3, "SET lolor.node=3; SELECT lo_from_bytea(0, '\\xc0ffee')"),
+   'large object created on n3');
+ok(wait_for_lo(1, 'c0ffee'), 'large object from n3 replicated to n1');
+ok(wait_for_lo(2, 'c0ffee'), 'large object from n3 replicated to n2');
+
+# --- A custom placement must survive the routing ----------------------------
+
+ok(psql_ok(1, "SELECT spock.repset_create('lolor_custom')"), 'custom repset created on n1');
+ok(psql_ok(1, "SELECT spock.repset_remove_table('default', 'lolor.pg_largeobject')"),
+   'lolor.pg_largeobject taken out of the default set on n1');
+ok(psql_ok(1, "SELECT spock.repset_add_table('lolor_custom', 'lolor.pg_largeobject')"),
+   'lolor.pg_largeobject placed in the custom set on n1');
+ok(psql_ok(1, "ALTER EXTENSION lolor UPDATE"), 'ALTER EXTENSION lolor UPDATE on n1');
+is(repset_of(1, 'pg_largeobject'), 'lolor_custom',
+   'custom placement survived ALTER EXTENSION');
+
+destroy_cluster('Destroy lolor re-create test cluster');
+
+done_testing();


### PR DESCRIPTION
DROP EXTENSION cascades away lolor's replication set membership, and the CREATE EXTENSION that follows cannot restore it: autoddl_can_proceed() skips everything nested inside an extension script, so large objects created afterwards were silently not replicated.  Route the member tables of a reserved object with block_in_repset = false, leaving placements be.

#SPOC-669