### PR TITLE
docs: document how to size Postgres resources for Spock

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -8,16 +8,19 @@ wal_level = 'logical'
 max_worker_processes = 20   # supervisor + one per database + one per
                             # subscription + sync workers, and shared with
                             # parallel query - see the sizing guide
-max_replication_slots = 12  # one per subscriber, plus one per in-progress sync
-max_wal_senders = 10        # one per subscriber, plus one per in-progress sync
+max_replication_slots = 12  # two per subscriber, per replicated database
+max_wal_senders = 10        # two per subscriber, per replicated database
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 ```
 
 These values suit a small cluster of two or three nodes replicating a single
-database. For anything larger, or for an instance hosting several databases
-or other extensions that use background workers, size each parameter with the
-formulas in
+database. Subscriptions - and the workers, walsenders, and slots that follow
+from them - scale with node count *multiplied by* the number of replicated
+databases, so an instance replicating several databases needs proportionally
+more of each. For anything larger, or for an instance hosting several
+databases or other extensions that use background workers, size each parameter
+with the formulas in
 [Sizing Postgres Resources for Spock](sizing.md). All three require a server
 restart to change.
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -5,11 +5,14 @@ replication scenario before creating the Spock extension:
 
 ```sql
 wal_level = 'logical'
-max_worker_processes = 20   # supervisor + one per database + one per
-                            # subscription + sync workers, and shared with
-                            # parallel query - see the sizing guide
-max_replication_slots = 12  # two per subscriber, per replicated database
-max_wal_senders = 10        # two per subscriber, per replicated database
+max_worker_processes = 20   # supervisor + slot sync worker + one per
+                            # database + one per subscription + sync workers,
+                            # and shared with parallel query - see the
+                            # sizing guide
+max_replication_slots = 10  # two per subscriber, per replicated database,
+                            # plus one per physical standby; 10 covers a
+                            # four-node mesh replicating one database
+max_wal_senders = 10        # keep equal to max_replication_slots
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 ```
@@ -226,7 +229,7 @@ the upstream server disappears unexpectedly. To disable them add
 For Spock replication, set `wal_sender_timeout` to a conservative value such
 as `5min` (300000ms) on each node in `postgresql.conf`:
 
-```
+```ini
 wal_sender_timeout = '5min'
 ```
 
@@ -245,7 +248,7 @@ the TCP connection alive but stops sending data. The timer resets on any
 received message. Set to `0` to disable and rely solely on TCP keepalive for
 liveness detection. Default: `300` (5 minutes).
 
-```
+```ini
 spock.apply_idle_timeout = 300
 ```
 
@@ -263,7 +266,7 @@ where a node joins in seconds; when catchup legitimately takes minutes or hours,
 the routines fail with a timeout long before the work is done. It can be raised
 for a single operation rather than cluster-wide:
 
-```
+```sql
 SET spock.sync_timeout = '2h';
 CALL spock.add_node(...);
 ```
@@ -273,7 +276,7 @@ that additionally bound each remote probe - so that one unresponsive peer
 cannot consume the entire budget - keep their own, much smaller limit for that
 purpose.
 
-```
+```ini
 spock.sync_timeout = 0
 ```
 
@@ -293,7 +296,7 @@ immediately). Valid range is `0` to `100`. Default: `5`. Changes take
 effect on `SIGHUP` (for example, `SELECT pg_reload_conf()`); a server
 restart is not required.
 
-```
+```ini
 spock.read_retry_count = 5
 ```
 
@@ -309,9 +312,13 @@ The behaviour depends on the PostgreSQL version:
 
 | PostgreSQL | Slot sync mechanism | Spock worker |
 |---|---|---|
-| 15, 16 | Spock built-in `spock_failover_slots` worker | Always runs |
+| 15, 16 | Spock built-in `spock_failover_slots` worker | Runs on every node |
 | 17 | Spock worker OR native `sync_replication_slots` | Spock worker yields to native if enabled |
 | 18+ | Native `sync_replication_slots` (required) | Not registered |
+
+Whichever mechanism applies, a slot sync worker is present on every node,
+primary and standby alike, so include one in the worker budget - see
+[Sizing Postgres Resources for Spock](sizing.md).
 
 #### PostgreSQL 17 and Later (Native Slot Sync)
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -5,13 +5,21 @@ replication scenario before creating the Spock extension:
 
 ```sql
 wal_level = 'logical'
-max_worker_processes = 10   # one per database needed on provider node
-                            # one per node needed on subscriber node
-max_replication_slots = 10  # one per node needed on provider node
-max_wal_senders = 10        # one per node needed on provider node
+max_worker_processes = 20   # supervisor + one per database + one per
+                            # subscription + sync workers, and shared with
+                            # parallel query - see the sizing guide
+max_replication_slots = 12  # one per subscriber, plus one per in-progress sync
+max_wal_senders = 10        # one per subscriber, plus one per in-progress sync
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 ```
+
+These values suit a small cluster of two or three nodes replicating a single
+database. For anything larger, or for an instance hosting several databases
+or other extensions that use background workers, size each parameter with the
+formulas in
+[Sizing Postgres Resources for Spock](sizing.md). All three require a server
+restart to change.
 
 After modifying the parameters and restarting the Postgres server with your
 OS-specific restart command, connect with psql and create the Spock

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -206,13 +206,22 @@ replication and load the Spock extension:
 
 ```sql
  wal_level = logical
-max_worker_processes = 10   # one per database on provider, one per node on subscriber
-max_replication_slots = 10  # one per node on provider
-max_wal_senders = 10        # one per node on provider
+max_worker_processes = 20   # see the sizing guide
+max_replication_slots = 12  # one per subscriber, plus one per in-progress sync
+max_wal_senders = 10        # one per subscriber, plus one per in-progress sync
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 listen_addresses = '*'
 ```
+
+!!! info "Sizing `max_worker_processes`"
+
+    This parameter covers more than one worker per node: Spock runs a
+    supervisor, a manager for *every* connectable database in the instance
+    (including `postgres` and `template1`), an apply worker per subscription,
+    and a sync worker per subscription during table synchronization. The pool
+    is also shared with parallel query workers. See
+    [Sizing Postgres Resources for Spock](sizing.md) for the formulas.
 
 !!! note
 
@@ -510,7 +519,7 @@ Your two-node Spock cluster is now operational. The following documents describe
 If you encounter issues, review the following common problems and solutions.
 
 - Check the `pg_hba.conf` entries and ensure the nodes can connect to each other if replication is not starting.
-- Verify that `max_replication_slots` and `max_wal_senders` are set to sufficient values when a subscription is stuck initializing.
+- Verify that `max_replication_slots` and `max_wal_senders` are set to sufficient values when a subscription is stuck initializing. A subscription that is synchronizing needs a second slot and walsender on the provider in addition to those held by its apply stream; see [Sizing Postgres Resources for Spock](sizing.md).
 - If DDL is not replicating, confirm that the automatic DDL replication settings are enabled on both nodes.
 - If errors are not clear, review the PostgreSQL logs for detailed error messages.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -207,8 +207,10 @@ replication and load the Spock extension:
 ```sql
  wal_level = logical
 max_worker_processes = 20   # see the sizing guide
-max_replication_slots = 12  # two per subscriber, per replicated database
-max_wal_senders = 10        # two per subscriber, per replicated database
+max_replication_slots = 10  # two per subscriber, per replicated database,
+                            # plus one per physical standby; 10 covers a
+                            # four-node mesh replicating one database
+max_wal_senders = 10        # keep equal to max_replication_slots
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 listen_addresses = '*'
@@ -217,7 +219,8 @@ listen_addresses = '*'
 !!! info "Sizing `max_worker_processes`"
 
     This parameter covers more than one worker per node: Spock runs a
-    supervisor, a manager for *every* connectable database in the instance
+    supervisor, a slot sync worker (present on every node, primary or
+    standby), a manager for *every* connectable database in the instance
     (including `postgres` and `template1`), an apply worker per subscription,
     and a sync worker per subscription during table synchronization.
     Subscriptions are created per database, so their count is the number of

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -207,8 +207,8 @@ replication and load the Spock extension:
 ```sql
  wal_level = logical
 max_worker_processes = 20   # see the sizing guide
-max_replication_slots = 12  # one per subscriber, plus one per in-progress sync
-max_wal_senders = 10        # one per subscriber, plus one per in-progress sync
+max_replication_slots = 12  # two per subscriber, per replicated database
+max_wal_senders = 10        # two per subscriber, per replicated database
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on # needed for conflict resolution
 listen_addresses = '*'
@@ -219,7 +219,9 @@ listen_addresses = '*'
     This parameter covers more than one worker per node: Spock runs a
     supervisor, a manager for *every* connectable database in the instance
     (including `postgres` and `template1`), an apply worker per subscription,
-    and a sync worker per subscription during table synchronization. The pool
+    and a sync worker per subscription during table synchronization.
+    Subscriptions are created per database, so their count is the number of
+    other nodes *multiplied by* the number of replicated databases. The pool
     is also shared with parallel query workers. See
     [Sizing Postgres Resources for Spock](sizing.md) for the formulas.
 
@@ -227,12 +229,14 @@ listen_addresses = '*'
 
     - PostgreSQL 15-17: The `max_replication_slots` parameter controls
       both slots and replication origin states. Account for both when
-      sizing (typically one origin per subscription).
+      sizing (one origin per subscription, and subscriptions are counted
+      per replicated database).
 
     - PostgreSQL 18+: A new parameter `max_active_replication_origins`
       separately controls origin states. The default value is 10, which
       may be insufficient. Set the value to at least the number of
-      subscriptions plus headroom.
+      subscriptions this node applies - `(nodes - 1) x replicated
+      databases` in a full mesh - plus headroom.
 
 After modifying `postgresql.conf`, restart PostgreSQL using your
 OS-specific command.

--- a/docs/install_spock.md
+++ b/docs/install_spock.md
@@ -127,8 +127,9 @@ track_commit_timestamp = on
 The values above are a working starting point for a small cluster (two or
 three nodes, one replicated database). They are not one-size-fits-all: Spock
 launches one background worker per database in the instance plus one per
-subscription, and `max_worker_processes` is shared with parallel query
-workers. See
+subscription, subscription counts scale with node count multiplied by the
+number of replicated databases, and `max_worker_processes` is shared with
+parallel query workers. See
 [Sizing Postgres Resources for Spock](sizing.md) for the formulas and
 per-cluster recommendations before going to production.
 
@@ -136,12 +137,13 @@ Note on replication origin states:
 
 - PostgreSQL 15-17: The `max_replication_slots` parameter controls both the
   number of replication slots and the number of replication origin states;
-  when sizing this parameter, account for both slots and origins (typically
-  one origin per subscription).
+  when sizing this parameter, account for both slots and origins (one origin
+  per subscription, and subscriptions are counted per replicated database).
 - PostgreSQL 18+: A new parameter `max_active_replication_origins` was
   introduced to separately control the number of replication origin states;
   the default value is 10, which may be insufficient for clusters with many
-  subscriptions; set this to at least the number of subscriptions plus some
+  subscriptions; set this to at least the number of subscriptions this node
+  applies - `(nodes - 1) x replicated databases` in a full mesh - plus some
   headroom (similar sizing to `max_replication_slots`).
 
 After modifying the Postgres parameters, use your OS-specific command to

--- a/docs/install_spock.md
+++ b/docs/install_spock.md
@@ -118,7 +118,7 @@ required Postgres parameters to the end of the file:
 ```sql
 wal_level = logical
 max_worker_processes = 20   # see the sizing guide below
-max_replication_slots = 12
+max_replication_slots = 10
 max_wal_senders = 10
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
@@ -126,10 +126,10 @@ track_commit_timestamp = on
 
 The values above are a working starting point for a small cluster (two or
 three nodes, one replicated database). They are not one-size-fits-all: Spock
-launches one background worker per database in the instance plus one per
-subscription, subscription counts scale with node count multiplied by the
-number of replicated databases, and `max_worker_processes` is shared with
-parallel query workers. See
+launches a supervisor, a slot sync worker, one background worker per database
+in the instance, and one per subscription; subscription counts scale with node count multiplied by the number of
+replicated databases, and `max_worker_processes` is shared with parallel query
+workers. See
 [Sizing Postgres Resources for Spock](sizing.md) for the formulas and
 per-cluster recommendations before going to production.
 

--- a/docs/install_spock.md
+++ b/docs/install_spock.md
@@ -117,12 +117,20 @@ required Postgres parameters to the end of the file:
 
 ```sql
 wal_level = logical
-max_worker_processes = 10
-max_replication_slots = 10
+max_worker_processes = 20   # see the sizing guide below
+max_replication_slots = 12
 max_wal_senders = 10
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
 ```
+
+The values above are a working starting point for a small cluster (two or
+three nodes, one replicated database). They are not one-size-fits-all: Spock
+launches one background worker per database in the instance plus one per
+subscription, and `max_worker_processes` is shared with parallel query
+workers. See
+[Sizing Postgres Resources for Spock](sizing.md) for the formulas and
+per-cluster recommendations before going to production.
 
 Note on replication origin states:
 

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -19,9 +19,19 @@ and a full re-sync of all subscriber tables.
 
 | PostgreSQL | Slot sync mechanism | Spock worker |
 |---|---|---|
-| 15, 16 | Spock built-in `spock_failover_slots` worker | Always runs on standby |
+| 15, 16 | Spock built-in `spock_failover_slots` worker | Registered on every node; synchronizes only while in recovery |
 | 17 | Spock worker **or** native `sync_replication_slots` | Yields to native if enabled |
 | 18+ | Native `sync_replication_slots` (required) | Not registered |
+
+The mechanism changes with the version, but the requirement does not: a slot
+sync worker is running on every node of the cluster, primary and standby
+alike. It is started before the server knows which role it will hold, so on a
+primary it stays resident and idle, waking only to check whether the server
+has entered recovery. Spock's own worker is registered from
+`shared_preload_libraries` and occupies one `max_worker_processes` slot;
+PostgreSQL's native worker is a dedicated postmaster process outside that
+pool. Budget a worker for it on every node either way - see
+[Sizing Postgres Resources for Spock](sizing.md).
 
 On **PostgreSQL 17+**, Spock marks every logical slot with the `FAILOVER` flag
 at creation time. This enables PostgreSQL's built-in slotsync worker to pick
@@ -45,18 +55,17 @@ wal_level = logical
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
 max_worker_processes = 20
-max_replication_slots = 12
+max_replication_slots = 10
 max_wal_senders = 10
 ```
 
 Size these for your cluster rather than copying the numbers - see
 [Sizing Postgres Resources for Spock](sizing.md). Slots, walsenders, and
 origins scale with the number of other nodes multiplied by the number of
-replicated databases in the instance. Note that a physical standby
-adds to both `max_wal_senders` and `max_replication_slots` on the primary, and
-that on PostgreSQL 15-17 the `spock_failover_slots` worker occupies one
-`max_worker_processes` slot on every node (it is not registered on PostgreSQL
-18+).
+replicated databases in the instance, and `max_replication_slots` and
+`max_wal_senders` should be set to the same value. Note that a physical
+standby adds a slot to that value on the primary, and that a slot sync worker
+occupies one `max_worker_processes` slot on every node.
 
 On PostgreSQL 18, also size `max_active_replication_origins` (default 10) to at
 least the number of subscriptions this node applies - `(nodes - 1) x replicated
@@ -157,12 +166,15 @@ synchronized LSN with no data loss and no slot recreation required.
 
 ## Setup: PostgreSQL 15 and 16 (Spock Worker)
 
-On PostgreSQL 15 and 16, the `spock_failover_slots` background worker runs
-on the standby and periodically copies slot state from the primary.
+On PostgreSQL 15 and 16, the `spock_failover_slots` background worker
+periodically copies slot state from the primary. The worker is registered on
+every node, but it only does this work while the server is in recovery; on a
+primary it idles.
 
 ### Requirements
 
-- `hot_standby_feedback = on` on the standby (required for the worker to run)
+- `hot_standby_feedback = on` on the standby (required before the worker will
+  synchronize anything)
 - The standby must be able to connect to the primary
 
 ### Configuration GUCs
@@ -279,6 +291,12 @@ FROM pg_stat_activity
 WHERE application_name = 'spock_failover_slots worker';
 ```
 
+This row is present on primaries too, where the worker is resident but idle,
+so a hit here confirms only that the worker was registered - not that slots
+are being synchronized. Confirm that on the standby by comparing
+`confirmed_flush_lsn` against the primary, and look for the
+`slot synchronization from primary now active` message in the standby log.
+
 ## FAQ
 
 **Q: Do I need to do anything after a failover?**
@@ -286,8 +304,10 @@ WHERE application_name = 'spock_failover_slots worker';
 On PG17+: Just update the subscriber's `host=` in their DSN. No slot
 recreation needed.
 
-On PG15/16: Spock's worker on the standby (now primary) stops running
-since it is no longer in recovery. Subscribers reconnect automatically.
+On PG15/16: Spock's worker on the standby (now primary) stops
+synchronizing slots, since the server is no longer in recovery. The worker
+process itself remains, idle, and still holds its `max_worker_processes` slot.
+Subscribers reconnect automatically.
 
 **Q: What if `sync_replication_slots` is not configured on PG18?**
 

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -50,14 +50,18 @@ max_wal_senders = 10
 ```
 
 Size these for your cluster rather than copying the numbers - see
-[Sizing Postgres Resources for Spock](sizing.md). Note that a physical standby
+[Sizing Postgres Resources for Spock](sizing.md). Slots, walsenders, and
+origins scale with the number of other nodes multiplied by the number of
+replicated databases in the instance. Note that a physical standby
 adds to both `max_wal_senders` and `max_replication_slots` on the primary, and
 that on PostgreSQL 15-17 the `spock_failover_slots` worker occupies one
 `max_worker_processes` slot on every node (it is not registered on PostgreSQL
 18+).
 
 On PostgreSQL 18, also size `max_active_replication_origins` (default 10) to at
-least the number of subscriptions plus some headroom.
+least the number of subscriptions this node applies - `(nodes - 1) x replicated
+databases` in a full mesh - plus some headroom. Setting it equal to
+`max_replication_slots` is the simplest safe choice.
 
 ### Native path (PostgreSQL 17 with `sync_replication_slots = on`, and PostgreSQL 18)
 

--- a/docs/logical_slot_failover.md
+++ b/docs/logical_slot_failover.md
@@ -44,10 +44,17 @@ These are the settings Spock needs to replicate at all. They are covered in
 wal_level = logical
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
-max_worker_processes = 10
-max_replication_slots = 10
+max_worker_processes = 20
+max_replication_slots = 12
 max_wal_senders = 10
 ```
+
+Size these for your cluster rather than copying the numbers - see
+[Sizing Postgres Resources for Spock](sizing.md). Note that a physical standby
+adds to both `max_wal_senders` and `max_replication_slots` on the primary, and
+that on PostgreSQL 15-17 the `spock_failover_slots` worker occupies one
+`max_worker_processes` slot on every node (it is not registered on PostgreSQL
+18+).
 
 On PostgreSQL 18, also size `max_active_replication_origins` (default 10) to at
 least the number of subscriptions plus some headroom.

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -11,23 +11,30 @@ Spock actually launches so you can size each parameter deliberately.
 
 !!! warning
 
-    Every parameter on this page requires a **server restart** to change.
-    Under-sizing them is not a soft failure: Spock raises an `ERROR` when a
-    worker cannot be registered and the supervisor retries in a loop, so
-    replication does not start at all. Size with headroom.
+    Every parameter on this page backed by an explicit recommendation requires
+    a **server restart** to change. Under-sizing them is not a soft failure:
+    Spock raises an `ERROR` when a worker cannot be registered and the
+    supervisor retries in a loop, so replication does not start at all. Formulas
+    include a small amount of headroom partially to prevent this.
 
 ## What Spock Runs on Each Node
 
 | Process | How many | Counts against |
 |---|---|---|
 | Supervisor | 1 per instance, always running | `max_worker_processes` |
-| Failover-slots worker | 1 per instance on PostgreSQL 15-17; not registered on 18+ | `max_worker_processes` |
+| Slot sync worker | 1 per instance | `max_worker_processes` |
 | Manager | 1 per **connectable database** in the instance | `max_worker_processes` |
 | Apply worker | 1 per enabled subscription | `max_worker_processes` |
-| Sync worker | at most 1 concurrently per subscription | `max_worker_processes` |
+| Table sync worker | at most 1 concurrently per subscription | `max_worker_processes` |
 | Walsender | 1 per subscription streaming from this node, plus 1 more per subscription during table sync | `max_wal_senders` |
 
-Three of these counts are commonly misjudged.
+Four of these counts are commonly misjudged.
+
+**A slot sync worker exists on every node, not just standbys.** These workers
+copy logical replication slots to each physical standby so that failovers do
+not force a full resync of every subscriber. These workers remain idle on
+primary nodes but still consume a worker slot, so are included in the formula.
+See [Slot Synchronization](#slot-synchronization) below for more information.
 
 **Managers are launched for every connectable database, not just the ones
 using Spock.** The supervisor cannot determine whether a database contains a
@@ -47,26 +54,43 @@ inside a single database, and each subscription connects one database on this
 instance to the corresponding database on one other instance. An instance that
 replicates several databases therefore hosts one Spock node per replicated
 database, and each of those nodes carries its own full set of subscriptions.
-Everything downstream of the subscription count — apply workers, sync workers,
-walsenders, slots, and origins — scales with **node count multiplied by
-replicated database count**, not node count alone.
+Everything downstream of the subscription count such as apply workers, table
+sync workers, walsenders, slots, and origins, all scale with **node count
+multiplied by replicated database count**, not node count alone.
+
+### Slot Synchronization
+
+Slot synchronization is not optional for a cluster with a physical standby: a
+promotion without it forces every subscriber to recreate its slot and re-sync
+its tables. What changes between PostgreSQL versions is only *who supplies the
+worker*.
+
+| PostgreSQL | Supplied by | Charged to `max_worker_processes` |
+|---|---|---|
+| 15, 16 | Spock's `spock_failover_slots` background worker | Yes |
+| 17 | Either, depending on `sync_replication_slots` | Yes - Spock registers its worker regardless, and it stands down when the native one is enabled |
+| 18+ | PostgreSQL's native slotsync worker | No - it is a dedicated postmaster process, counted separately in `MaxBackends` |
+
+Budget a worker for it on every node and every version. Where PostgreSQL
+supplies the worker the budgeted slot simply becomes headroom, which costs
+nothing beyond a little shared memory and spares you a version-dependent
+formula. [Logical Slot Failover](logical_slot_failover.md) covers the
+configuration each mechanism needs.
 
 ## Sizing `max_worker_processes`
 
 For one node, at peak:
 
-```
-spock_workers = 1    # supervisor
-              + 1    # failover-slots worker (PostgreSQL 15-17 only; 0 on 18+)
-              + D    # connectable databases in this instance
-              + S    # apply workers: one per enabled subscription
-              + S    # sync workers: worst case, one per subscription
+    spock_workers = 1    # supervisor
+                  + 1    # slot sync worker
+                  + D    # connectable databases in this instance
+                  + S    # apply workers: one per enabled subscription
+                  + S    # table sync workers: worst case, one per subscription
 
-max_worker_processes = spock_workers
-                     + max_parallel_workers        # shared pool - see below
-                     + other_extension_workers     # pg_cron, pg_squeeze, ...
-                     + 2                           # headroom
-```
+    max_worker_processes = spock_workers
+                         + max_parallel_workers        # shared pool - see below
+                         + other_extension_workers     # pg_cron, pg_squeeze, ...
+                         + 2                           # headroom
 
 Where:
 
@@ -98,11 +122,11 @@ worker-using extensions:
 
 | Cluster | Spock Workers | Total Workers |
 |---|---|---|
-| 2-node | 6-7 | 20 |
-| 3-node | 8-9 | 20 |
-| 4-node | 10-11 | 24 |
-| 5-node | 12-13 | 24 |
-| 8-node | 18-19 | 32 |
+| 2-node | 7 | 20 |
+| 3-node | 9 | 20 |
+| 4-node | 11 | 24 |
+| 5-node | 13 | 24 |
+| 8-node | 19 | 32 |
 
 The totals are rounded up to leave room for growth; there is no meaningful
 cost to over-provisioning `max_worker_processes` beyond a small amount of
@@ -115,52 +139,53 @@ not already counted in `D`) plus `2 * (N - 1)` workers for its apply and sync
 workers, so a 3-node cluster replicating three databases needs `3 * 2 * 2 = 12`
 apply and sync workers per instance rather than `4`.
 
-## Sizing `max_wal_senders`
+## Sizing `max_replication_slots` and `max_wal_senders`
 
-Each node needs a walsender for every subscription that streams from it, plus
-one additional walsender per subscription while that subscriber is
-synchronizing tables. Sync workers open their own replication connection
-alongside the ongoing apply stream. Because subscriptions are per database, an
-instance replicating several databases serves one set of walsenders per
-replicated database.
+Each node holds a logical replication slot for every subscription that streams
+from it, plus a transient slot for each in-progress table sync. Sync slots are
+created as persistent slots (not temporary), so each one occupies a slot until
+the sync finishes and the slot is dropped. Every one of those slots has a
+walsender behind it while it is streaming, so **set both parameters to the same
+value** and compute it once, from the slot count.
 
-```
-max_wal_senders = 2 * subscriptions_served     # apply stream + sync stream
-                + physical_standbys
-                + 2                            # pg_basebackup, ad-hoc tooling
-```
+!!! note "Default values"
 
-In a fully-meshed cluster of `N` nodes each replicating `R` databases,
-`subscriptions_served = R * (N - 1)`, giving:
+    The default is 10 for `max_replication_slots` and `max_wal_senders`. Consider
+    this a minimum value for each. If any formulas provide a value below 10,
+    simply retain the default value.
 
-```
-max_wal_senders = 2 * R * (N - 1)
-                + physical_standbys
-                + 2
-```
+Where `N` is the number of Spock nodes and `R` the number of replicated
+databases in the instance:
 
-A 5-node mesh with one replicated database needs at least `2 * 1 * 4 = 8`
-walsenders per node; the same mesh replicating three databases needs
-`2 * 3 * 4 = 24`, before accounting for physical standbys in either case.
-
-Sync workers also open a second, non-replication connection to run `COPY`,
-which draws from `max_connections` rather than `max_wal_senders`.
-
-## Sizing `max_replication_slots` and Replication Origins
-
-Each node holds a logical replication slot for every database subscription,
-plus a transient slot for each in-progress table sync. Sync slots are created
-as persistent slots (not temporary), so they occupy a slot until the sync
-completes and the slot is dropped.
-
-Consider this formula for determining the max slot count, where `N` is the
-number of Spock nodes and `R` the number of synchronized databases:
-
-    max_replication_slots = 2 * R * (N - 1)
+    max_replication_slots = 2 * R * (N - 1)   # apply slot + sync slot per subscription
                           + physical_and_failover_slots
-                          + 2  # headroom
+                          + 2                 # headroom for pg_basebackup and ad-hoc tooling
 
-The number of synced databases in a Spock cluster is 1 in most cases.
+    max_wal_senders = max_replication_slots
+
+`R` is 1 in most deployments. A 5-node mesh replicating a single database, with
+one physical standby per node, needs `2 * 1 * 4 + 1 + 2 = 11` for both
+parameters; the same mesh replicating three databases needs
+`2 * 3 * 4 + 1 + 2 = 27`.
+
+!!! note "Why the two values are equal"
+
+    PostgreSQL's logical replication documentation recommends setting
+    `max_wal_senders` to at least `max_replication_slots` plus the number of
+    physical replicas connected at the same time. That extra term covers
+    physical standbys that stream without a slot; the formula above already
+    gives each physical standby a slot in `physical_and_failover_slots`, so
+    adding them a second time would double-count. Sizing every node from the
+    same formula, standbys included, also satisfies the separate rule that a
+    standby's `max_wal_senders` be at least as high as its primary's.
+
+Not every replication connection is a walsender. Table sync workers open a
+second, non-replication connection to run `COPY`, which draws from
+`max_connections`. The slot sync worker on a standby likewise reaches the
+primary over an ordinary connection. Both Spock's worker and PostgreSQL's
+native one cost the primary a `max_connections` slot, not a walsender.
+
+## Replication Origins
 
 Postgres uses *origins* to track local state for remote replication slots.
 Internally, Postgres tracks replication origins separately from slots and
@@ -178,7 +203,12 @@ parameter:
 This should cause Postgres 18+ to operate with a sufficiently large origin
 pool.
 
-## Worked Example: 3-Node Mesh on PostgreSQL 17
+## Worked Examples
+
+Because these settings require so many inputs, this documentation provides
+some examples.
+
+### 3-Node Mesh
 
 Three nodes, each with a single replicated database `app`, plus the default
 `postgres` and `template1` databases. Each node subscribes to the other two,
@@ -188,27 +218,37 @@ Per node: `D = 3`, `R = 1`, `S = R * (N - 1) = 2`.
 
 ```ini
 # Background workers:
-#   1 supervisor + 1 failover-slots + 3 managers + 2 apply + 2 sync = 9
-#   + 8 max_parallel_workers + 2 headroom = 19, rounded up
+#   1 supervisor + 1 slot sync + 3 managers + 2 apply + 2 table sync = 9
+#   + 8 max_parallel_workers + 2 headroom = 19; 20 to match the table above
 max_worker_processes = 20
 
-# Walsenders: (2 subscriptions x 2) + 1 physical standby + 2 spare = 7
+# Slots and walsenders, set equal:
+#   (2 x 1 database x 2 subscribers) + 1 physical standby + 2 headroom = 7;
+#   This is lower than the default of 10, so do not reduce.
+max_replication_slots = 10
 max_wal_senders = 10
-
-# Slots: 2 x 1 database x 2 subscribers + 1 physical + 2 headroom = 7
-max_replication_slots = 12
-
-wal_level = logical
-shared_preload_libraries = 'spock'
-track_commit_timestamp = on
 ```
 
-If each of those three instances replicated **two** databases instead of one,
-the same topology would need `D = 4`, `R = 2`, and `S = 4`. Per node that is 14
-Spock workers at peak (1 supervisor + 1 failover-slots + 4 managers + 4 apply +
-4 sync), `2 * 2 * 2 = 8` subscription walsenders, and `2 * 2 * 2 = 8`
-subscription slots - so `max_worker_processes = 26`, `max_wal_senders = 12`,
-and `max_replication_slots = 12` once the standby and headroom are included.
+### 5-Node Mesh
+
+Five nodes, each with replicated databases `app` and `ledger`, plus the default
+`postgres` and `template1` databases. Each node subscribes to the other four,
+and each node has two physical standbys, common in clusters leveraging safe
+synchronous replication.
+
+Per node: `D = 4`, `R = 2`, `S = R * (N - 1) = 8`.
+
+```ini
+# Background workers:
+#   1 supervisor + 1 slot sync + 4 managers + 8 apply + 8 table sync = 22
+#   + 8 max_parallel_workers + 2 headroom = 32
+max_worker_processes = 32
+
+# Slots and walsenders, set equal:
+#   (2 x 2 databases x 4 subscribers) + 2 standbys + 2 headroom = 20
+max_replication_slots = 20
+max_wal_senders = 20
+```
 
 ## Verifying Your Configuration
 
@@ -235,7 +275,7 @@ SELECT current_setting('max_worker_processes')::int AS worker_limit,
          'client backend', 'walsender', 'autovacuum launcher',
          'autovacuum worker', 'checkpointer', 'background writer',
          'walwriter', 'walreceiver', 'walsummarizer', 'archiver',
-         'startup', 'io worker', 'slotsync worker', 'standalone backend');
+         'startup', 'io worker', 'standalone backend');
 ```
 
 The exclusion list names the client backends and auxiliary processes that do

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -25,9 +25,9 @@ Spock actually launches so you can size each parameter deliberately.
 | Manager | 1 per **connectable database** in the instance | `max_worker_processes` |
 | Apply worker | 1 per enabled subscription | `max_worker_processes` |
 | Sync worker | at most 1 concurrently per subscription | `max_worker_processes` |
-| Walsender | 1 per subscriber streaming from this node, plus 1 more per subscriber during table sync | `max_wal_senders` |
+| Walsender | 1 per subscription streaming from this node, plus 1 more per subscription during table sync | `max_wal_senders` |
 
-Two of these counts are commonly misjudged.
+Three of these counts are commonly misjudged.
 
 **Managers are launched for every connectable database, not just the ones
 using Spock.** The supervisor cannot determine whether a database contains a
@@ -41,6 +41,15 @@ excluded because it does not allow connections.
 **Walsenders are not background workers.** They are governed by
 `max_wal_senders` and counted separately in `MaxBackends`. Raising
 `max_worker_processes` does nothing for walsender exhaustion, and vice versa.
+
+**Subscriptions are per database, not per node.** A Spock node is created
+inside a single database, and each subscription connects one database on this
+instance to the corresponding database on one other instance. An instance that
+replicates several databases therefore hosts one Spock node per replicated
+database, and each of those nodes carries its own full set of subscriptions.
+Everything downstream of the subscription count — apply workers, sync workers,
+walsenders, slots, and origins — scales with **node count multiplied by
+replicated database count**, not node count alone.
 
 ## Sizing `max_worker_processes`
 
@@ -61,12 +70,16 @@ max_worker_processes = spock_workers
 
 Where:
 
+- `N` is the number of Spock nodes in the cluster.
 - `D` is the number of databases in the instance with `datallowconn = true`,
   including `postgres` and `template1` — **not** just the databases
   participating in replication.
+- `R` is the number of databases in this instance that actually participate
+  in Spock replication (`R <= D`). It is `1` in most deployments.
 - `S` is the total number of enabled subscriptions across all databases in
-  the instance. In a fully-meshed cluster of `N` nodes with a single
-  replicated database, `S = N - 1`.
+  the instance. In a fully-meshed cluster of `N` nodes each replicating the
+  same `R` databases, `S = R * (N - 1)`. With a single replicated database
+  that reduces to the familiar `S = N - 1`.
 
 !!! warning
 
@@ -80,8 +93,8 @@ Where:
 ### Recommended Minimums
 
 Assuming a single replicated database alongside `postgres` and `template1`
-(`D = 3`), the default `max_parallel_workers = 8`, and no other worker-using
-extensions:
+(`D = 3`, `R = 1`), the default `max_parallel_workers = 8`, and no other
+worker-using extensions:
 
 | Cluster | Spock Workers | Total Workers |
 |---|---|---|
@@ -97,50 +110,73 @@ shared memory, and the parameter cannot be changed without a restart.
 
 Add to these numbers if your instance hosts more databases, replicates more
 than one database, or runs other extensions that register background workers.
+Each **additional replicated database** costs `1` manager (if the database is
+not already counted in `D`) plus `2 * (N - 1)` workers for its apply and sync
+workers, so a 3-node cluster replicating three databases needs `3 * 2 * 2 = 12`
+apply and sync workers per instance rather than `4`.
 
 ## Sizing `max_wal_senders`
 
-Each node needs a walsender for every subscriber that streams from it, plus
-one additional walsender per subscriber while that subscriber is
+Each node needs a walsender for every subscription that streams from it, plus
+one additional walsender per subscription while that subscriber is
 synchronizing tables. Sync workers open their own replication connection
-alongside the ongoing apply stream.
+alongside the ongoing apply stream. Because subscriptions are per database, an
+instance replicating several databases serves one set of walsenders per
+replicated database.
 
 ```
-max_wal_senders = 2 * subscribers_of_this_node
+max_wal_senders = 2 * subscriptions_served     # apply stream + sync stream
                 + physical_standbys
-                + 2                              # pg_basebackup, ad-hoc tooling
+                + 2                            # pg_basebackup, ad-hoc tooling
 ```
 
-In a fully-meshed cluster of `N` nodes, `subscribers_of_this_node = N - 1`,
-so a 5-node mesh needs at least `2 * 4 = 8` walsenders per node before
-accounting for physical standbys.
+In a fully-meshed cluster of `N` nodes each replicating `R` databases,
+`subscriptions_served = R * (N - 1)`, giving:
+
+```
+max_wal_senders = 2 * R * (N - 1)
+                + physical_standbys
+                + 2
+```
+
+A 5-node mesh with one replicated database needs at least `2 * 1 * 4 = 8`
+walsenders per node; the same mesh replicating three databases needs
+`2 * 3 * 4 = 24`, before accounting for physical standbys in either case.
 
 Sync workers also open a second, non-replication connection to run `COPY`,
 which draws from `max_connections` rather than `max_wal_senders`.
 
 ## Sizing `max_replication_slots` and Replication Origins
 
-Each node holds a logical replication slot for every node subscribing to it,
+Each node holds a logical replication slot for every database subscription,
 plus a transient slot for each in-progress table sync. Sync slots are created
 as persistent slots (not temporary), so they occupy a slot until the sync
 completes and the slot is dropped.
 
-```
-max_replication_slots = 2 * subscribers_of_this_node
-                      + physical_and_failover_slots
-                      + 2                              # headroom
-```
+Consider this formula for determining the max slot count, where `N` is the
+number of Spock nodes and `R` the number of synchronized databases:
 
-Replication *origins* are tracked separately from slots, and where they are
-configured depends on your Postgres version:
+    max_replication_slots = 2 * R * (N - 1)
+                          + physical_and_failover_slots
+                          + 2  # headroom
 
-- **PostgreSQL 15-17**: `max_replication_slots` governs both replication
-  slots *and* replication origin states. Size it for the sum: add one origin
-  per subscription this node applies (`N - 1` in a full mesh) on top of the
-  slot count above.
-- **PostgreSQL 18+**: `max_active_replication_origins` governs origin states
-  independently. Its default is `10`, which may be insufficient for larger
-  clusters. Set it to at least the number of subscriptions plus headroom.
+The number of synced databases in a Spock cluster is 1 in most cases.
+
+Postgres uses *origins* to track local state for remote replication slots.
+Internally, Postgres tracks replication origins separately from slots and
+pins their count to `max_replication_slots` in Postgres versions 15-17. Our
+formula should make it impossible for there to be more origins than slots in
+those versions of Postgres.
+
+However, Postgres 18 introduces `max_active_replication_origins` with a
+default value of 10, which may be too low for an active Spock cluster. For
+the sake of simplicity, we encourage using this simple formula for that
+parameter:
+
+    max_active_replication_origins = max_replication_slots
+
+This should cause Postgres 18+ to operate with a sufficiently large origin
+pool.
 
 ## Worked Example: 3-Node Mesh on PostgreSQL 17
 
@@ -148,7 +184,7 @@ Three nodes, each with a single replicated database `app`, plus the default
 `postgres` and `template1` databases. Each node subscribes to the other two,
 and each node has one physical standby.
 
-Per node: `D = 3`, `S = 2`, `subscribers_of_this_node = 2`.
+Per node: `D = 3`, `R = 1`, `S = R * (N - 1) = 2`.
 
 ```ini
 # Background workers:
@@ -156,16 +192,23 @@ Per node: `D = 3`, `S = 2`, `subscribers_of_this_node = 2`.
 #   + 8 max_parallel_workers + 2 headroom = 19, rounded up
 max_worker_processes = 20
 
-# Walsenders: (2 subscribers x 2) + 1 physical standby + 2 spare = 7
+# Walsenders: (2 subscriptions x 2) + 1 physical standby + 2 spare = 7
 max_wal_senders = 10
 
-# Slots: (2 subscribers x 2) + 1 physical + 2 origins (PG 17) + 2 spare = 9
+# Slots: 2 x 1 database x 2 subscribers + 1 physical + 2 headroom = 7
 max_replication_slots = 12
 
 wal_level = logical
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
 ```
+
+If each of those three instances replicated **two** databases instead of one,
+the same topology would need `D = 4`, `R = 2`, and `S = 4`. Per node that is 14
+Spock workers at peak (1 supervisor + 1 failover-slots + 4 managers + 4 apply +
+4 sync), `2 * 2 * 2 = 8` subscription walsenders, and `2 * 2 * 2 = 8`
+subscription slots - so `max_worker_processes = 26`, `max_wal_senders = 12`,
+and `max_replication_slots = 12` once the standby and headroom are included.
 
 ## Verifying Your Configuration
 

--- a/docs/sizing.md
+++ b/docs/sizing.md
@@ -1,0 +1,236 @@
+# Sizing Postgres Resources for Spock
+
+Spock replication consumes three separate, independently-configured Postgres
+resources: background worker slots, walsender slots, and replication
+slots/origins. Each is governed by a different parameter, and each is sized
+from a different property of your cluster.
+
+Many of the values shown in the tutorials are a starting point for a small
+test cluster, not a recommendation for production. This page explains what
+Spock actually launches so you can size each parameter deliberately.
+
+!!! warning
+
+    Every parameter on this page requires a **server restart** to change.
+    Under-sizing them is not a soft failure: Spock raises an `ERROR` when a
+    worker cannot be registered and the supervisor retries in a loop, so
+    replication does not start at all. Size with headroom.
+
+## What Spock Runs on Each Node
+
+| Process | How many | Counts against |
+|---|---|---|
+| Supervisor | 1 per instance, always running | `max_worker_processes` |
+| Failover-slots worker | 1 per instance on PostgreSQL 15-17; not registered on 18+ | `max_worker_processes` |
+| Manager | 1 per **connectable database** in the instance | `max_worker_processes` |
+| Apply worker | 1 per enabled subscription | `max_worker_processes` |
+| Sync worker | at most 1 concurrently per subscription | `max_worker_processes` |
+| Walsender | 1 per subscriber streaming from this node, plus 1 more per subscriber during table sync | `max_wal_senders` |
+
+Two of these counts are commonly misjudged.
+
+**Managers are launched for every connectable database, not just the ones
+using Spock.** The supervisor cannot determine whether a database contains a
+Spock node without connecting to it, and a background worker cannot switch
+databases. So it launches a manager for every database in `pg_database` with
+`datallowconn = true`; managers that find no Spock node exit immediately.
+On a default cluster that means `postgres` and `template1` each get a
+short-lived manager in addition to your replicated database. `template0` is
+excluded because it does not allow connections.
+
+**Walsenders are not background workers.** They are governed by
+`max_wal_senders` and counted separately in `MaxBackends`. Raising
+`max_worker_processes` does nothing for walsender exhaustion, and vice versa.
+
+## Sizing `max_worker_processes`
+
+For one node, at peak:
+
+```
+spock_workers = 1    # supervisor
+              + 1    # failover-slots worker (PostgreSQL 15-17 only; 0 on 18+)
+              + D    # connectable databases in this instance
+              + S    # apply workers: one per enabled subscription
+              + S    # sync workers: worst case, one per subscription
+
+max_worker_processes = spock_workers
+                     + max_parallel_workers        # shared pool - see below
+                     + other_extension_workers     # pg_cron, pg_squeeze, ...
+                     + 2                           # headroom
+```
+
+Where:
+
+- `D` is the number of databases in the instance with `datallowconn = true`,
+  including `postgres` and `template1` — **not** just the databases
+  participating in replication.
+- `S` is the total number of enabled subscriptions across all databases in
+  the instance. In a fully-meshed cluster of `N` nodes with a single
+  replicated database, `S = N - 1`.
+
+!!! warning
+
+    `max_worker_processes` is a **shared pool**. Parallel query workers
+    (`max_parallel_workers`, default `8`), native logical replication workers
+    (`max_logical_replication_workers`), and background workers belonging to
+    other extensions all draw from the same allocation. A parallel-heavy
+    workload can starve replication of worker slots. Autovacuum workers are
+    the exception — they have their own `autovacuum_max_workers` allocation.
+
+### Recommended Minimums
+
+Assuming a single replicated database alongside `postgres` and `template1`
+(`D = 3`), the default `max_parallel_workers = 8`, and no other worker-using
+extensions:
+
+| Cluster | Spock Workers | Total Workers |
+|---|---|---|
+| 2-node | 6-7 | 20 |
+| 3-node | 8-9 | 20 |
+| 4-node | 10-11 | 24 |
+| 5-node | 12-13 | 24 |
+| 8-node | 18-19 | 32 |
+
+The totals are rounded up to leave room for growth; there is no meaningful
+cost to over-provisioning `max_worker_processes` beyond a small amount of
+shared memory, and the parameter cannot be changed without a restart.
+
+Add to these numbers if your instance hosts more databases, replicates more
+than one database, or runs other extensions that register background workers.
+
+## Sizing `max_wal_senders`
+
+Each node needs a walsender for every subscriber that streams from it, plus
+one additional walsender per subscriber while that subscriber is
+synchronizing tables. Sync workers open their own replication connection
+alongside the ongoing apply stream.
+
+```
+max_wal_senders = 2 * subscribers_of_this_node
+                + physical_standbys
+                + 2                              # pg_basebackup, ad-hoc tooling
+```
+
+In a fully-meshed cluster of `N` nodes, `subscribers_of_this_node = N - 1`,
+so a 5-node mesh needs at least `2 * 4 = 8` walsenders per node before
+accounting for physical standbys.
+
+Sync workers also open a second, non-replication connection to run `COPY`,
+which draws from `max_connections` rather than `max_wal_senders`.
+
+## Sizing `max_replication_slots` and Replication Origins
+
+Each node holds a logical replication slot for every node subscribing to it,
+plus a transient slot for each in-progress table sync. Sync slots are created
+as persistent slots (not temporary), so they occupy a slot until the sync
+completes and the slot is dropped.
+
+```
+max_replication_slots = 2 * subscribers_of_this_node
+                      + physical_and_failover_slots
+                      + 2                              # headroom
+```
+
+Replication *origins* are tracked separately from slots, and where they are
+configured depends on your Postgres version:
+
+- **PostgreSQL 15-17**: `max_replication_slots` governs both replication
+  slots *and* replication origin states. Size it for the sum: add one origin
+  per subscription this node applies (`N - 1` in a full mesh) on top of the
+  slot count above.
+- **PostgreSQL 18+**: `max_active_replication_origins` governs origin states
+  independently. Its default is `10`, which may be insufficient for larger
+  clusters. Set it to at least the number of subscriptions plus headroom.
+
+## Worked Example: 3-Node Mesh on PostgreSQL 17
+
+Three nodes, each with a single replicated database `app`, plus the default
+`postgres` and `template1` databases. Each node subscribes to the other two,
+and each node has one physical standby.
+
+Per node: `D = 3`, `S = 2`, `subscribers_of_this_node = 2`.
+
+```ini
+# Background workers:
+#   1 supervisor + 1 failover-slots + 3 managers + 2 apply + 2 sync = 9
+#   + 8 max_parallel_workers + 2 headroom = 19, rounded up
+max_worker_processes = 20
+
+# Walsenders: (2 subscribers x 2) + 1 physical standby + 2 spare = 7
+max_wal_senders = 10
+
+# Slots: (2 subscribers x 2) + 1 physical + 2 origins (PG 17) + 2 spare = 9
+max_replication_slots = 12
+
+wal_level = logical
+shared_preload_libraries = 'spock'
+track_commit_timestamp = on
+```
+
+## Verifying Your Configuration
+
+List the Spock workers currently running on a node:
+
+```sql
+SELECT pid, backend_type, datname
+  FROM pg_stat_activity
+ WHERE backend_type LIKE 'spock%'
+ ORDER BY backend_type;
+```
+
+Each Spock worker reports its role and the OIDs it serves in `backend_type` -
+for example `spock supervisor`, `spock manager 16384`, and
+`spock apply 16384:1`.
+
+Compare the number of background workers in use against the limit:
+
+```sql
+SELECT current_setting('max_worker_processes')::int AS worker_limit,
+       count(*) AS in_use
+  FROM pg_stat_activity
+ WHERE backend_type NOT IN (
+         'client backend', 'walsender', 'autovacuum launcher',
+         'autovacuum worker', 'checkpointer', 'background writer',
+         'walwriter', 'walreceiver', 'walsummarizer', 'archiver',
+         'startup', 'io worker', 'slotsync worker', 'standalone backend');
+```
+
+The exclusion list names the client backends and auxiliary processes that do
+not draw on `max_worker_processes`; everything left over does. The list of
+auxiliary process types changes between major versions, so check it against
+[`pg_stat_activity`](https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ACTIVITY-VIEW)
+for your version.
+
+## Diagnosing Exhaustion
+
+**`worker registration failed, you might want to increase max_worker_processes setting`**
+
+Postgres refused to register a background worker because
+`max_worker_processes` is fully allocated. Recompute with the formula above,
+remembering that parallel query workers share the pool, and restart.
+
+**`could not register spock worker: all background worker slots are already used`**
+
+Spock's own worker-tracking array — sized to `max_worker_processes` at
+startup — has no free entry. A worker that exits cleanly releases its entry
+immediately, but a worker that *crashes* leaves its entry reserved for the
+same database until that database's manager (or the supervisor) reclaims it.
+Repeated worker crashes across many different databases can therefore exhaust
+the array while Postgres still reports free worker slots. Check the server log
+for the preceding crash and address that; raising `max_worker_processes`
+enlarges the array but does not fix the underlying failures.
+
+**Subscription stuck in `initializing`**
+
+Usually `max_replication_slots` or `max_wal_senders` on the *provider*. A
+subscription that is initializing needs a slot and walsender for its sync
+worker in addition to those already held by its apply stream, which is why a
+cluster that replicates fine in steady state can fail to add or resync a
+table. See [Troubleshooting](troubleshooting.md).
+
+**Increasing replication lag with idle apply workers**
+
+If `spock.lag_tracker` shows growing lag but apply workers are not running,
+check the server log for worker registration failures — the manager retries
+registration on a delay, so an exhausted worker pool presents as intermittent
+apply rather than a hard stop.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -44,7 +44,11 @@ configuration parameters.
   SHOW max_replication_slots;
   ```
 
-  The minimum value is one per node on the provider.
+  A subscription that is initializing needs *two* slots on the provider: the
+  one held by its apply stream, plus one created for the sync worker that
+  copies the table data. Size for `2 x subscribers` per node, plus any
+  physical or failover slots. On PostgreSQL 15-17 this parameter also caps
+  replication origins, so add one per subscription this node applies.
 
 - Verify that `max_wal_senders` is set to a sufficient value:
 
@@ -52,7 +56,9 @@ configuration parameters.
   SHOW max_wal_senders;
   ```
 
-  The minimum value is one per node on the provider.
+  Same accounting as above: `2 x subscribers` per node while syncs are in
+  progress, plus any physical standbys. This is the most common reason a
+  cluster that replicates fine in steady state cannot add or resync a table.
 
 - For PostgreSQL 18+, check the `max_active_replication_origins` setting:
 
@@ -181,12 +187,19 @@ function properly:
 
 ```sql
 wal_level = logical
-max_worker_processes = 10
-max_replication_slots = 10
+max_worker_processes = 20
+max_replication_slots = 12
 max_wal_senders = 10
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
 ```
+
+The three numeric values shown are a small-cluster starting point. If you are
+troubleshooting worker registration failures, stuck subscriptions, or apply
+workers that will not start, size them from your actual topology using
+[Sizing Postgres Resources for Spock](sizing.md) - the defaults in the
+tutorials do not account for parallel query workers sharing the
+`max_worker_processes` pool.
 
 After modifying `postgresql.conf`, restart PostgreSQL with this command:
 
@@ -264,7 +277,10 @@ subscription.
 
 Possible causes and solutions include:
 
-- Insufficient `max_worker_processes` - increase the value.
+- Insufficient `max_worker_processes` - increase the value; see
+  [Sizing Postgres Resources for Spock](sizing.md). Remember that parallel
+  query workers draw from the same pool, so a parallel-heavy workload can
+  starve apply workers even when the value looks generous.
 - Network bandwidth limitations - check network throughput.
 - Large transactions - break into smaller transactions if possible.
 - Slow subscriber hardware - upgrade hardware or reduce workload.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,10 +57,10 @@ configuration parameters.
   SHOW max_wal_senders;
   ```
 
-  Same accounting as above: `2 x subscribers x replicated databases` per node
-  while syncs are in progress, plus any physical standbys. This is the most
-  common reason a cluster that replicates fine in steady state cannot add or
-  resync a table.
+  Set this equal to `max_replication_slots`: every slot has a walsender behind
+  it while it streams, so the accounting above applies unchanged. A shortfall
+  here is the most common reason a cluster that replicates fine in steady
+  state cannot add or resync a table.
 
 - For PostgreSQL 18+, check the `max_active_replication_origins` setting:
 
@@ -151,7 +151,7 @@ only one `UNIQUE` index or constraint exists on downstream tables.
 
 The error message for deferrable index constraints appears as follows:
 
-```
+```text
 ERROR: spock doesn't support index rechecks needed for deferrable indexes
 DETAIL: relation "public"."test_relation" has deferrable indexes: "index1"
 ```
@@ -192,7 +192,7 @@ function properly:
 ```sql
 wal_level = logical
 max_worker_processes = 20
-max_replication_slots = 12
+max_replication_slots = 10
 max_wal_senders = 10
 shared_preload_libraries = 'spock'
 track_commit_timestamp = on
@@ -203,7 +203,8 @@ troubleshooting worker registration failures, stuck subscriptions, or apply
 workers that will not start, size them from your actual topology using
 [Sizing Postgres Resources for Spock](sizing.md) - the defaults in the
 tutorials do not account for parallel query workers sharing the
-`max_worker_processes` pool.
+`max_worker_processes` pool, nor for the per-database managers, the
+supervisor, and the slot sync worker that every node runs.
 
 After modifying `postgresql.conf`, restart PostgreSQL with this command:
 
@@ -284,7 +285,9 @@ Possible causes and solutions include:
 - Insufficient `max_worker_processes` - increase the value; see
   [Sizing Postgres Resources for Spock](sizing.md). Remember that parallel
   query workers draw from the same pool, so a parallel-heavy workload can
-  starve apply workers even when the value looks generous.
+  starve apply workers even when the value looks generous, and that the
+  supervisor, the per-database managers, and the slot sync worker each consume
+  a slot before any apply worker starts.
 - Network bandwidth limitations - check network throughput.
 - Large transactions - break into smaller transactions if possible.
 - Slow subscriber hardware - upgrade hardware or reduce workload.
@@ -462,7 +465,7 @@ SHOW log_filename;
 
 On RHEL/Rocky Linux, logs are typically located at:
 
-```
+```text
 /var/lib/pgsql/18/data/log/
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,9 +46,10 @@ configuration parameters.
 
   A subscription that is initializing needs *two* slots on the provider: the
   one held by its apply stream, plus one created for the sync worker that
-  copies the table data. Size for `2 x subscribers` per node, plus any
-  physical or failover slots. On PostgreSQL 15-17 this parameter also caps
-  replication origins, so add one per subscription this node applies.
+  copies the table data. Subscriptions are per database, so size for
+  `2 x subscribers x replicated databases` per node, plus any physical or
+  failover slots. On PostgreSQL 15-17 this parameter also caps replication
+  origins.
 
 - Verify that `max_wal_senders` is set to a sufficient value:
 
@@ -56,9 +57,10 @@ configuration parameters.
   SHOW max_wal_senders;
   ```
 
-  Same accounting as above: `2 x subscribers` per node while syncs are in
-  progress, plus any physical standbys. This is the most common reason a
-  cluster that replicates fine in steady state cannot add or resync a table.
+  Same accounting as above: `2 x subscribers x replicated databases` per node
+  while syncs are in progress, plus any physical standbys. This is the most
+  common reason a cluster that replicates fine in steady state cannot add or
+  resync a table.
 
 - For PostgreSQL 18+, check the `max_active_replication_origins` setting:
 
@@ -66,7 +68,9 @@ configuration parameters.
   SHOW max_active_replication_origins;
   ```
 
-  Ensure that the value to at least the number of subscriptions plus headroom.
+  Ensure that the value is at least the number of subscriptions this node
+  applies - `(nodes - 1) x replicated databases` in a full mesh - plus
+  headroom.
 
 - If parameters were modified, restart PostgreSQL with this command:
 

--- a/docs/two_node_cluster.md
+++ b/docs/two_node_cluster.md
@@ -12,15 +12,21 @@ After installing and initializing Postgres and creating the Spock Extension, you
 
     `wal_level = 'logical'`
 
-    `max_worker_processes = 10`
+    `max_worker_processes = 20`
 
-    `max_replication_slots = 10`
+    `max_replication_slots = 12`
 
     `max_wal_senders = 10`
 
     `shared_preload_libraries = 'spock'`
 
     `track_commit_timestamp = on`
+
+    These values are sized for this two-node example. Before moving to
+    production, or if you add nodes or databases, size them from your topology
+    using [Sizing Postgres Resources for Spock](sizing.md) -
+    `max_worker_processes` in particular is shared with parallel query workers
+    and needs one slot per database in the instance, not just per node.
 
 3. Edit the [`pg_hba.conf` file](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) (located in `/var/lib/pgsql/current/data/postgresql.conf`) and allow connections between `n1` and `n2`; the following commands are provided as an example only, and are not recommended for production systems as they will open your system for connection from any client:
 

--- a/docs/two_node_cluster.md
+++ b/docs/two_node_cluster.md
@@ -22,11 +22,14 @@ After installing and initializing Postgres and creating the Spock Extension, you
 
     `track_commit_timestamp = on`
 
-    These values are sized for this two-node example. Before moving to
-    production, or if you add nodes or databases, size them from your topology
-    using [Sizing Postgres Resources for Spock](sizing.md) -
-    `max_worker_processes` in particular is shared with parallel query workers
-    and needs one slot per database in the instance, not just per node.
+    These values are sized for this two-node example, which replicates a
+    single database. Before moving to production, or if you add nodes or
+    databases, size them from your topology using
+    [Sizing Postgres Resources for Spock](sizing.md) - subscriptions are
+    created per database, so slots, walsenders, and workers scale with node
+    count multiplied by replicated database count, and `max_worker_processes`
+    is additionally shared with parallel query workers and needs one slot per
+    database in the instance.
 
 3. Edit the [`pg_hba.conf` file](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) (located in `/var/lib/pgsql/current/data/postgresql.conf`) and allow connections between `n1` and `n2`; the following commands are provided as an example only, and are not recommended for production systems as they will open your system for connection from any client:
 

--- a/docs/two_node_cluster.md
+++ b/docs/two_node_cluster.md
@@ -14,7 +14,7 @@ After installing and initializing Postgres and creating the Spock Extension, you
 
     `max_worker_processes = 20`
 
-    `max_replication_slots = 12`
+    `max_replication_slots = 10`
 
     `max_wal_senders = 10`
 
@@ -29,7 +29,8 @@ After installing and initializing Postgres and creating the Spock Extension, you
     created per database, so slots, walsenders, and workers scale with node
     count multiplied by replicated database count, and `max_worker_processes`
     is additionally shared with parallel query workers and needs one slot per
-    database in the instance.
+    database in the instance, one for the supervisor, and one more for the
+    slot sync worker.
 
 3. Edit the [`pg_hba.conf` file](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html) (located in `/var/lib/pgsql/current/data/postgresql.conf`) and allow connections between `n1` and `n2`; the following commands are provided as an example only, and are not recommended for production systems as they will open your system for connection from any client:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ repo_url: https://github.com/pgEdge/spock
 nav:
   - Introduction: index.md
   - Installing and Configuring Spock: install_spock.md
+  - Sizing Postgres Resources for Spock: sizing.md
   - Creating a Two-Node Cluster: two_node_cluster.md
   - Getting Started: getting_started.md
   - Using Advanced Configuration Options: configuring.md


### PR DESCRIPTION
Adds documentation on properly configuring several Postgres variables relevant to Spock:

* `max_worker_processes`
* `max_wal_senders`
* `max_replication_slots`

Addresses JIRA issue SPOC-672.