### PR TITLE
Fix apply-group progress entry accounting and initialization

### DIFF
--- a/include/spock_group.h
+++ b/include/spock_group.h
@@ -150,6 +150,8 @@ extern void spock_group_shmem_startup(bool found);
 
 extern SpockGroupEntry *spock_group_attach(Oid dbid, Oid node_id,
 										   Oid remote_node_id);
+extern void spock_group_ensure_entry(Oid dbid, Oid node_id,
+									 Oid remote_node_id);
 extern void spock_group_detach(void);
 extern bool spock_group_progress_update(const SpockApplyProgress *sap);
 extern void spock_group_progress_update_ptr(SpockGroupEntry *entry,

--- a/src/spock_apply.c
+++ b/src/spock_apply.c
@@ -2296,7 +2296,6 @@ handle_startup(StringInfo s)
 
 	/* Register callback for cleaning up */
 	before_shmem_exit(spock_apply_worker_shmem_exit, 0);
-	on_proc_exit(spock_apply_worker_on_exit, 0);
 }
 
 /*
@@ -2326,7 +2325,16 @@ spock_apply_worker_shmem_exit(int code, Datum arg)
 }
 
 /*
- * Cleanup called on proc_exit
+ * Cleanup callback: decrement the group's nattached.
+ *
+ * Must run BEFORE spock_worker_on_exit() releases our shmem worker slot:
+ * once the slot is released the manager can hand it to a new worker, whose
+ * spock_worker_attach() zeroes worker.apply.apply_group - and an on_proc_exit
+ * callback (which runs after all shmem-exit callbacks) would then read NULL
+ * through MyApplyWorker and silently skip the decrement, leaking nattached.
+ * Registering this as before_shmem_exit AFTER spock_worker_attach()'s
+ * registration makes LIFO ordering run it first, while the slot is still
+ * ours.
  */
 static void
 spock_apply_worker_on_exit(int code, Datum arg)
@@ -2350,6 +2358,13 @@ spock_apply_worker_attach(void)
 
 	Assert(MyApplyWorker->apply_group != NULL);
 	LWLockRelease(SpockCtx->apply_group_master_lock);
+
+	/*
+	 * Pair the attachment with its cleanup right here, so a worker that fails
+	 * before the startup message still detaches. See the ordering note on
+	 * spock_apply_worker_on_exit().
+	 */
+	before_shmem_exit(spock_apply_worker_on_exit, 0);
 }
 
 /* Remove a worker from it's group. */

--- a/src/spock_functions.c
+++ b/src/spock_functions.c
@@ -701,8 +701,14 @@ spock_create_subscription(PG_FUNCTION_ARGS)
 	spock_stat_create_subscription(sub.id);
 #endif
 
-	/* Create progress entry to track commit ts per local/remote origin */
-	spock_group_attach(MyDatabaseId, localnode->node->id, originif.nodeid);
+	/*
+	 * Create progress entry to track commit ts per local/remote origin.
+	 * Ensure-only: this backend is not an apply worker, so it must not count
+	 * itself in nattached (readers use it as the number of streams feeding
+	 * the entry).
+	 */
+	spock_group_ensure_entry(MyDatabaseId, localnode->node->id,
+							 originif.nodeid);
 
 
 	/* Create synchronization status for the subscription. */

--- a/src/spock_group.c
+++ b/src/spock_group.c
@@ -242,6 +242,48 @@ spock_group_attach(Oid dbid, Oid node_id, Oid remote_node_id)
 }
 
 /*
+ * spock_group_ensure_entry
+ *
+ * Make sure a progress entry exists for the group without attaching to it.
+ * For callers (e.g. sub_create) that only need the entry present; nattached
+ * keeps counting actual apply workers, which readers rely on to know how
+ * many streams feed the entry.
+ */
+void
+spock_group_ensure_entry(Oid dbid, Oid node_id, Oid remote_node_id)
+{
+	SpockGroupKey key;
+	SpockGroupEntry *entry;
+	bool		found;
+
+	Assert(OidIsValid(dbid) && OidIsValid(node_id) &&
+		   OidIsValid(remote_node_id));
+
+	key = make_key(dbid, node_id, remote_node_id);
+
+	LWLockAcquire(SpockCtx->apply_group_master_lock, LW_EXCLUSIVE);
+
+	entry = (SpockGroupEntry *) hash_search(SpockGroupHash, &key,
+											HASH_ENTER, &found);
+	if (entry == NULL)
+	{
+		LWLockRelease(SpockCtx->apply_group_master_lock);
+		elog(ERROR, "SpockGroupHash is full, cannot create entry for group "
+			 "(dbid=%u, node_id=%u, remote_node_id=%u)",
+			 dbid, node_id, remote_node_id);
+	}
+
+	if (!found)
+	{
+		spock_init_progress_fields(&entry->progress);
+		pg_atomic_init_u32(&entry->nattached, 0);
+		ConditionVariableInit(&entry->prev_processed_cv);
+	}
+
+	LWLockRelease(SpockCtx->apply_group_master_lock);
+}
+
+/*
  * spock_group_detach
  *
  * Decrements nattached. Entries are not deleted (stable pointers).

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -518,6 +518,9 @@ adjust_progress_info(PGconn *origin_conn)
 			sap->key.remote_node_id = atooid(remote_node_id);
 			Assert(OidIsValid(sap->key.remote_node_id));
 
+			/* Alloc above doesn't zero; set every non-key field to "unset" */
+			spock_init_progress_fields(sap);
+
 			/* Check: we view only values related to a single database */
 			Assert(!PQgetisnull(originRes, rno, GP_DBOID));
 			if (dbid_str == NULL)
@@ -766,8 +769,8 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 		sap->key.remote_node_id = atooid(remote_node_id_str);
 		Assert(OidIsValid(sap->key.remote_node_id));
 
-		sap->remote_commit_ts = 0;
-		sap->prev_remote_ts = 0;
+		/* Alloc above doesn't zero; set every non-key field to "unset" */
+		spock_init_progress_fields(sap);
 		if (!PQgetisnull(res, rno, COL_OFFSET + GP_REMOTE_COMMIT_TS))
 		{
 			remote_commit_ts_str = PQgetvalue(res, rno, COL_OFFSET + GP_REMOTE_COMMIT_TS);


### PR DESCRIPTION
Two fixes to `SpockApplyProgress` / apply-group entry handling in shared memory.

### 1. Sync-path allocations wrote uninitialized memory into shmem

Both `SpockApplyProgress` allocations in `spock_sync.c` use plain
`MemoryContextAlloc`, which does not zero, and then set fields by hand.
`adjust_progress_info()` assigns `remote_commit_ts` only when the peer's
column is non-NULL — and the SRF emits NULL whenever that value is 0, which
is the state of every freshly created entry. The garbage is then copied to
`prev_remote_ts` and compared against `last_updated_ts`.

That struct goes to `spock_group_progress_force_set_list()`, which does
`entry->progress = *sap` — the whole struct adopted into shared memory as
authoritative. The invariant fix-ups that follow only ever raise values, so a
garbage LSN that is too high passes straight through. And
`progress_update_struct()` merges monotonically, gated on
`remote_commit_ts`, so one garbage-high value permanently blocks every later
update. Entries are never deleted, so it persists until postmaster restart.

This is not cosmetic: zodan's catchup phase polls `spock.progress` and
proceeds once the LSN passes its target — its own comment warns that going
early risks losing rows in the COPY window — and `spock.lag_tracker` is
computed entirely from these fields.

Both sites now call `spock_init_progress_fields()` right after setting the
key, the helper that is already the single source of truth for "unset".

### 2. `nattached` accounting

Two ways the counter drifted:

- `sub_create()` called `spock_group_attach()` from the client backend just
  to make the entry exist. That backend is not an apply worker and never
  detaches, so every subscription creation permanently incremented the
  count. New `spock_group_ensure_entry()` creates the entry under the master
  lock without claiming attachment; `spock_group_attach()` keeps its one
  legitimate caller.
- The detach ran as `on_proc_exit`, after `spock_worker_on_exit()` releases
  the worker's shmem slot. The manager can hand that slot to a new worker
  within milliseconds, and `spock_worker_attach()` zeroes
  `worker.apply.apply_group` in it, so the exiting process read NULL through
  `MyApplyWorker` and skipped the decrement. Registering it as
  `before_shmem_exit` at attach time fixes the ordering — LIFO runs it while
  the slot is still ours — and pairing it with `spock_apply_worker_attach()`
  also covers a worker that dies before the startup message.

`nattached` is not exposed through any view or function, so neither change
has an observable effect today. The reason to take the second one is the
ordering itself: the old code reached through `MyApplyWorker` into a slot
that may already belong to another worker. The counter is just what happens
to be read there now.

### Testing

None. The initialization bug cannot be covered by a portable regression test
— uninitialized memory that happens to be zero passes any assertion — and
the `nattached` fixes have no SQL-visible effect to assert on. Both were
found and fixed by inspection.