### PR TITLE
tests: recreate lolor after the drop and replicate large objects again

### DIFF
--- a/tests/tap/t/033_zodan_lolor_add_node.pl
+++ b/tests/tap/t/033_zodan_lolor_add_node.pl
@@ -16,6 +16,9 @@ use SpockTest qw(create_cluster destroy_cluster system_or_bail system_maybe
 #   - stream large objects created after the join,
 #   - leave the lolor tables in the new node's own default replication set,
 #     so large objects created there replicate back to the existing nodes.
+# After that, the cluster drops lolor without shipping its cleanup DDL, then
+# recreates it, migrates the native large objects back on every node, and
+# replicates a new large object again.
 
 my $cfg   = get_test_config();
 my $PG    = $cfg->{pg_bin};
@@ -198,7 +201,8 @@ for my $node (1, 2) {
 # that follows then fails in migrate_to_native() with "lolor must be enabled
 # before migration to native" -- which stalls apply.
 #
-# Runs last: it removes the extension the rest of this file depends on.
+# Runs after the add_node checks: it removes the extension they depend on.
+# The section below puts it back.
 #
 # spock.allow_ddl_from_functions is enabled deliberately. With it off, DDL
 # arriving from a function is never a replication candidate, and this would
@@ -252,6 +256,71 @@ ok(psql_ok(1, "INSERT INTO public.fence (id, v) VALUES (1, 'after-drop')"),
 for my $node (2, 3) {
     ok(wait_for_scalar($node, "SELECT v FROM public.fence WHERE id = 1", 'after-drop'),
        "fence row reached n$node after the drop, so apply did not stall");
+}
+
+# --- Recreate lolor after the drop and replicate large objects again --------
+#
+# The drop above moved every large object into pg_catalog on every node.
+# Create the extension again, pull the native large objects back into lolor
+# storage on each node with lolor.migrate_from_native(), add the lolor tables
+# back to the default set, and check that a new large object replicates.
+#
+# repset_add_table must run with synchronize_data => false here. Every node
+# already holds the same rows after migrate_from_native(), and the table sync
+# that synchronize_data => true triggers on each subscriber is a plain COPY
+# into the local table with no truncate. It fails on the primary key, the
+# subscription records the table's sync as failed (spock.local_sync_status
+# shows 'f'), and the apply worker then skips every later change to that
+# table on that subscription, silently. New large objects never arrive.
+
+ok(psql_ok(1, "CREATE EXTENSION lolor"), 'lolor recreated on n1');
+for my $node (2, 3) {
+    ok(wait_for_scalar($node, "SELECT count(*) FROM pg_extension WHERE extname = 'lolor'", '1'),
+       "recreated lolor arrived on n$node via DDL replication");
+}
+
+# Three large objects exist (deadbeefcafe, feedface, c0ffee); after the drop
+# they live in pg_catalog on every node.
+for my $node (1, 2, 3) {
+    is(scalar_query($node, "SELECT count(*) FROM pg_catalog.pg_largeobject_metadata"),
+       '3', "n$node holds the 3 large objects natively after the drop");
+    is(scalar_query($node, "SELECT lolor.migrate_from_native()"),
+       '3', "n$node migrated its 3 native large objects back into lolor");
+}
+
+# Only after every node has migrated: once a table is back in a set, rows
+# written to it replicate, and the migration must stay local to each node.
+for my $node (1, 2, 3) {
+    for my $tbl ('pg_largeobject', 'pg_largeobject_metadata') {
+        ok(psql_ok($node, "SELECT spock.repset_add_table('default', 'lolor.$tbl', false)"),
+           "lolor.$tbl re-added to default repset on n$node");
+    }
+}
+
+ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xabad1dea')"),
+   'large object created on n1 after lolor was recreated');
+
+for my $node (2, 3) {
+    my $arrived = wait_for_scalar($node,
+        "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'abad1dea'", '1');
+    my $failed = scalar_query($node,
+        "SELECT count(*) FROM spock.local_sync_status WHERE sync_status = 'f'");
+
+    ok($arrived, "large object created after lolor recreate replicated to n$node");
+    # Guards the synchronize_data => false above: a failed table sync is the
+    # first sign that someone put it back to true.
+    is($failed, '0', "n$node has no failed table sync");
+
+    diag("n$node local_sync_status:\n" . (psql_capture($node,
+        "SELECT sync_kind, sync_subid, sync_nspname, sync_relname, sync_status, sync_statuslsn " .
+        "FROM spock.local_sync_status ORDER BY 2,3,4"))[1])
+        unless $arrived && defined $failed && $failed eq '0';
+}
+
+# The three migrated large objects and the new one live side by side.
+for my $node (1, 2, 3) {
+    is(scalar_query($node, "SELECT count(*) FROM lolor.pg_largeobject_metadata"),
+       '4', "n$node holds the 3 migrated large objects plus the new one");
 }
 
 destroy_cluster('Destroy zodan lolor test cluster');

--- a/tests/tap/t/033_zodan_lolor_add_node.pl
+++ b/tests/tap/t/033_zodan_lolor_add_node.pl
@@ -300,21 +300,28 @@ for my $node (1, 2, 3) {
 ok(psql_ok(1, "SET lolor.node=1; SELECT lo_from_bytea(0, '\\xabad1dea')"),
    'large object created on n1 after lolor was recreated');
 
-for my $node (2, 3) {
-    my $arrived = wait_for_scalar($node,
-        "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'abad1dea'", '1');
-    my $failed = scalar_query($node,
-        "SELECT count(*) FROM spock.local_sync_status WHERE sync_status = 'f'");
-
-    ok($arrived, "large object created after lolor recreate replicated to n$node");
-    # Guards the synchronize_data => false above: a failed table sync is the
-    # first sign that someone put it back to true.
-    is($failed, '0', "n$node has no failed table sync");
-
+sub diag_sync_status {
+    my ($node) = @_;
     diag("n$node local_sync_status:\n" . (psql_capture($node,
         "SELECT sync_kind, sync_subid, sync_nspname, sync_relname, sync_status, sync_statuslsn " .
-        "FROM spock.local_sync_status ORDER BY 2,3,4"))[1])
-        unless $arrived && defined $failed && $failed eq '0';
+        "FROM spock.local_sync_status ORDER BY 2,3,4"))[1]);
+}
+
+for my $node (2, 3) {
+    ok(wait_for_scalar($node,
+        "SELECT count(*) FROM lolor.pg_largeobject WHERE encode(data, 'hex') = 'abad1dea'", '1'),
+       "large object created after lolor recreate replicated to n$node")
+        or diag_sync_status($node);
+}
+
+# Guards the synchronize_data => false above: a failed table sync is the
+# first sign that someone put it back to true. Every node subscribes to the
+# others, so every node is checked.
+for my $node (1, 2, 3) {
+    is(scalar_query($node,
+        "SELECT count(*) FROM spock.local_sync_status WHERE sync_status = 'f'"),
+       '0', "n$node has no failed table sync")
+        or diag_sync_status($node);
 }
 
 # The three migrated large objects and the new one live side by side.


### PR DESCRIPTION
Extend 033 with the scenario QA reported: drop lolor (already covered), create it again, run lolor.migrate_from_native() on every node, put the lolor tables back in the default replication set, and check that a new large object reaches the other nodes.

We do not want to re-add tables with synchronize_data => true. Every node already holds the same rows after the migration, and the table sync that flag triggers is a plain COPY into the local table with no truncate. It fails on the primary key, the subscription marks the table's sync as failed, and apply then skips every later change to that table on that subscription without logging anything. The test uses false, explains why in a comment, and checks that no subscription is left with a failed table sync.