### PR TITLE
Allow zodan add_node to join a Spock 6.0.0 node to a 5.0.9+ cluster

### DIFF
--- a/docs/modify/zodan/index.md
+++ b/docs/modify/zodan/index.md
@@ -36,7 +36,10 @@ node addition:
 - Zodan automatically detects existing schemas on the new node and populates the
   `skip_schema` parameter, preventing conflicts during structure sync.
 
-- Zodan verifies all nodes run the same Spock version before starting.
+- Zodan checks Spock versions before starting. Existing nodes must all run
+  the same major.minor version (patch levels may differ). The new node may
+  run the same version or a newer major.minor, so a 6.0.x node can join a
+  5.0.x cluster; an older new node is rejected.
 
 - Zodan includes the `verify_subscription_replicating()` function after
   enabling subscriptions to ensure they reach replicating status.

--- a/samples/Z0DAN/zodan.sql
+++ b/samples/Z0DAN/zodan.sql
@@ -2,6 +2,9 @@
 -- ZODAN (Zero Downtime Add Node) - Spock Extension
 -- Version: 1.0.0
 -- Required Spock Version: 5.0.9 or later
+-- Mixed versions: the new node may run a newer major.minor than the existing
+--                 cluster (for example a 6.0.x node joining a 5.0.x cluster).
+--                 Existing nodes must all share one major.minor.
 -- ============================================================================
 -- Adds a new node to the cluster of Spock.
 -- NOTE: Run the add_node procedure on the new node you are adding, not on an existing cluster node.
@@ -93,6 +96,23 @@ RETURNS int[] LANGUAGE sql IMMUTABLE AS $$
 $$;
 
 -- ============================================================================
+-- Function: progress_lsn_column
+-- Purpose : Name of the spock.progress column that holds the LSN of the last
+--           commit applied from a peer, for a node running the given Spock
+--           version.  Spock 6.0.0 renamed it from remote_lsn to
+--           remote_commit_lsn, so a query sent to a remote node over dblink
+--           has to use the name that node understands.
+-- Arguments:
+--   v - The remote node's Spock version string.
+-- Returns  : 'remote_lsn' for versions before 6.0.0, else 'remote_commit_lsn'.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION spock.progress_lsn_column(v text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+    SELECT CASE WHEN spock.version_to_array(v) < ARRAY[6,0,0]
+                THEN 'remote_lsn' ELSE 'remote_commit_lsn' END;
+$$;
+
+-- ============================================================================
 -- Procedure: check_spock_version_compatibility
 -- Purpose: Verify all nodes have the same Spock version before adding a node
 -- ============================================================================
@@ -143,9 +163,12 @@ BEGIN
             new_version, min_required_version, min_required_version;
     END IF;
 
-    -- Allow rolling upgrades: patch differences are fine, but major.minor must match
-    IF spock.version_major_minor(new_version) IS DISTINCT FROM spock.version_major_minor(src_version) THEN
-        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. Major.minor versions must match (patch differences are allowed).',
+    -- Patch differences are fine.  The new node may also run a newer
+    -- major.minor than the existing cluster (e.g. a 6.0.x node joining a
+    -- 5.0.x cluster), but never an older one: the new node's sync worker
+    -- knows how to talk to older providers, not the other way around.
+    IF spock.version_major_minor(new_version) < spock.version_major_minor(src_version) THEN
+        RAISE EXCEPTION 'Spock version mismatch: new node has version %, but source version is %. The new node must run the same or a newer major.minor version.',
             new_version, src_version;
     END IF;
 
@@ -168,12 +191,17 @@ BEGIN
                 node_rec.node_name, node_version, min_required_version, min_required_version;
         END IF;
 
-        -- Allow rolling upgrades: patch differences are fine, but major.minor must match
-        IF spock.version_major_minor(node_version) IS DISTINCT FROM spock.version_major_minor(new_version) THEN
-            RAISE EXCEPTION 'Spock version mismatch: new node has version %, but found node version %. Major.minor versions must match (patch differences are allowed).',
-                new_version, node_version;
+        -- Existing nodes must all share the source node's major.minor
+        -- (patch differences are allowed).
+        IF spock.version_major_minor(node_version) IS DISTINCT FROM spock.version_major_minor(src_version) THEN
+            RAISE EXCEPTION 'Spock version mismatch: node % has version %, but source version is %. Existing cluster nodes must share the same major.minor version.',
+                node_rec.node_name, node_version, src_version;
         END IF;
     END LOOP;
+
+    IF spock.version_major_minor(new_version) IS DISTINCT FROM spock.version_major_minor(src_version) THEN
+        RAISE NOTICE 'Mixed-version add: new node runs Spock %, existing cluster runs Spock %', new_version, src_version;
+    END IF;
 
     IF verb THEN
         RAISE NOTICE 'Version check passed: All nodes running Spock version % or later. Source version is %, new node version is %', min_required_version, src_version, new_version;
@@ -1881,15 +1909,21 @@ BEGIN
             wait_started             timestamptz := clock_timestamp();
             wait_budget              integer  := spock.sync_timeout();
             progress_sql             text;
+            src_lsn_column           text;
             v_prev_statement_timeout text;
         BEGIN
+            -- The column name depends on the source node's Spock version
+            -- (remote_lsn before 6.0.0, remote_commit_lsn from 6.0.0 on).
+            SELECT spock.progress_lsn_column(t.v) INTO src_lsn_column
+              FROM dblink(src_dsn, 'SELECT extversion FROM pg_extension WHERE extname = ''spock''') AS t(v text);
+
             progress_sql := format(
-                'SELECT p.remote_commit_lsn '
+                'SELECT p.%I '
                 'FROM spock.progress p '
                 'JOIN spock.node n ON n.node_id = p.remote_node_id '
                 'WHERE p.node_id = (SELECT node_id FROM spock.node_info()) '
                 '  AND n.node_name = %L',
-                rec.node_name);
+                src_lsn_column, rec.node_name);
 
             RAISE NOTICE '    - Waiting for source node % to apply % changes up to sync LSN %...',
                          src_node_name, rec.node_name, _catchup_lsn;

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -622,12 +622,22 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	List	   *progress_list = NIL;
 	int			nrows;
 	int			rno;
+	int			provider_version_num = 0;
 
 	/*
-	 * Column indices in the result: lsn(0), snapshot(1) are skipped; GP_*
-	 * start at 2
+	 * Columns (PP_ = peer progress) of the peer progress query below.  Both
+	 * the 6.0.0 form (spock.read_peer_progress) and the pre-6.0.0 form
+	 * (direct read of spock.progress) select exactly these, in this order.
 	 */
-	const int	COL_OFFSET = 2; /* GP_* indices start at COL_OFFSET */
+	enum
+	{
+		PP_REMOTE_NODE_ID = 0,
+		PP_REMOTE_COMMIT_TS,
+		PP_REMOTE_COMMIT_LSN,
+		PP_REMOTE_INSERT_LSN,
+		PP_LAST_UPDATED_TS,
+		PP_UPDATED_BY_DECODE
+	};
 
 	initStringInfo(&query);
 
@@ -721,11 +731,51 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	PQclear(res);
 	resetStringInfo(&query);
 
-	/* Read peer progress via the SQL function (slot already exists) */
-	appendStringInfo(&query,
-					 "SELECT * FROM spock.read_peer_progress"
-					 "('%s', %u, %u)",
-					 slot_name, origin_node_id, subscriber_node_id);
+	/*
+	 * Read peer progress: one row per peer subscription on the provider, with
+	 * the PP_ columns declared above.  The resume LSN (remote_commit_lsn) is
+	 * the peer origin's remote_lsn from pg_replication_origin_status, exact
+	 * because apply workers are paused.
+	 *
+	 * A provider older than 6.0.0 has no spock.read_peer_progress() and keeps
+	 * progress in a plain table, so read the same six values from its catalog
+	 * directly.  Detect the version with spock_version_num(), which every
+	 * supported release has.
+	 */
+	res = PQexec(conn, "SELECT spock.spock_version_num()");
+	if (PQresultStatus(res) == PGRES_TUPLES_OK && PQntuples(res) == 1)
+		provider_version_num = atoi(PQgetvalue(res, 0, 0));
+	PQclear(res);
+	elog(LOG, "SPOCK cswp provider spock version_num=%d", provider_version_num);
+
+	if (provider_version_num > 0 && provider_version_num < 60000)
+	{
+		appendStringInfo(&query,
+						 "SELECT p.remote_node_id, p.remote_commit_ts, "
+						 "       COALESCE(ros.remote_lsn, '0/0'::pg_lsn) AS remote_commit_lsn, "
+						 "       p.remote_insert_lsn, p.last_updated_ts, p.updated_by_decode "
+						 "FROM spock.subscription sub "
+						 "JOIN spock.progress p ON p.remote_node_id = sub.sub_origin "
+						 "                     AND p.node_id = sub.sub_target "
+						 "JOIN pg_replication_origin o ON o.roname = sub.sub_slot_name "
+						 "LEFT JOIN pg_replication_origin_status ros ON ros.local_id = o.roident "
+						 "WHERE sub.sub_target = %u AND sub.sub_origin <> %u",
+						 origin_node_id, subscriber_node_id);
+	}
+	else
+	{
+		/*
+		 * read_peer_progress() also returns a header row (remote_node_id
+		 * NULL) and lsn/snapshot columns; neither is needed here because the
+		 * slot's LSN and snapshot were taken from CREATE_REPLICATION_SLOT.
+		 */
+		appendStringInfo(&query,
+						 "SELECT remote_node_id, remote_commit_ts, remote_commit_lsn, "
+						 "       remote_insert_lsn, last_updated_ts, updated_by_decode "
+						 "FROM spock.read_peer_progress('%s', %u, %u) "
+						 "WHERE remote_node_id IS NOT NULL",
+						 slot_name, origin_node_id, subscriber_node_id);
+	}
 	res = PQexec(conn, query.data);
 	resetStringInfo(&query);
 
@@ -733,20 +783,12 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 		elog(ERROR, "could not create replication slot and get progress on "
 			 "origin: %s", PQerrorMessage(conn));
 
+	/* Zero rows is legitimate: the provider may have no other peers. */
 	nrows = PQntuples(res);
-	if (nrows < 1)
-		elog(ERROR, "spock.read_peer_progress returned no rows");
-
-	/*
-	 * Row 0 is the header row: lsn + snapshot, progress fields all NULL.
-	 * lsn_out and snapshot are already set from the replication protocol;
-	 * just log for debugging.  Skip COL_LSN/COL_SNAP from SQL result.
-	 */
 	elog(LOG, "SPOCK cswp slot=%s lsn=%X/%X snapshot=%s peers=%d",
-		 slot_name, LSN_FORMAT_ARGS(*lsn_out), snapshot, nrows - 1);
+		 slot_name, LSN_FORMAT_ARGS(*lsn_out), snapshot, nrows);
 
-	/* Rows 1+ are progress entries (remote_node_id NOT NULL) */
-	for (rno = 1; rno < nrows; rno++)
+	for (rno = 0; rno < nrows; rno++)
 	{
 		SpockApplyProgress *sap;
 		MemoryContext oldctx;
@@ -756,7 +798,7 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 		char	   *remote_insert_lsn_str;
 		char	   *last_updated_ts_str;
 
-		if (PQgetisnull(res, rno, COL_OFFSET + GP_REMOTE_NODE_ID))
+		if (PQgetisnull(res, rno, PP_REMOTE_NODE_ID))
 			continue;			/* shouldn't happen but be safe */
 
 		sap = (SpockApplyProgress *) MemoryContextAlloc(CacheMemoryContext,
@@ -765,35 +807,35 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 
 		sap->key.dbid = MyDatabaseId;
 		sap->key.node_id = MySubscription->target->id;
-		remote_node_id_str = PQgetvalue(res, rno, COL_OFFSET + GP_REMOTE_NODE_ID);
+		remote_node_id_str = PQgetvalue(res, rno, PP_REMOTE_NODE_ID);
 		sap->key.remote_node_id = atooid(remote_node_id_str);
 		Assert(OidIsValid(sap->key.remote_node_id));
 
 		/* Alloc above doesn't zero; set every non-key field to "unset" */
 		spock_init_progress_fields(sap);
-		if (!PQgetisnull(res, rno, COL_OFFSET + GP_REMOTE_COMMIT_TS))
+		if (!PQgetisnull(res, rno, PP_REMOTE_COMMIT_TS))
 		{
-			remote_commit_ts_str = PQgetvalue(res, rno, COL_OFFSET + GP_REMOTE_COMMIT_TS);
+			remote_commit_ts_str = PQgetvalue(res, rno, PP_REMOTE_COMMIT_TS);
 			sap->remote_commit_ts = str_to_timestamptz(remote_commit_ts_str);
 		}
 		sap->prev_remote_ts = sap->remote_commit_ts;
 
-		remote_commit_lsn_str = PQgetvalue(res, rno, COL_OFFSET + GP_REMOTE_COMMIT_LSN);
+		remote_commit_lsn_str = PQgetvalue(res, rno, PP_REMOTE_COMMIT_LSN);
 		sap->remote_commit_lsn = str_to_lsn(remote_commit_lsn_str);
 
-		remote_insert_lsn_str = PQgetvalue(res, rno, COL_OFFSET + GP_REMOTE_INSERT_LSN);
+		remote_insert_lsn_str = PQgetvalue(res, rno, PP_REMOTE_INSERT_LSN);
 		sap->remote_insert_lsn = str_to_lsn(remote_insert_lsn_str);
 
 		sap->received_lsn = sap->remote_commit_lsn;
 
 		sap->last_updated_ts = 0;
-		if (!PQgetisnull(res, rno, COL_OFFSET + GP_LAST_UPDATED_TS))
+		if (!PQgetisnull(res, rno, PP_LAST_UPDATED_TS))
 		{
-			last_updated_ts_str = PQgetvalue(res, rno, COL_OFFSET + GP_LAST_UPDATED_TS);
+			last_updated_ts_str = PQgetvalue(res, rno, PP_LAST_UPDATED_TS);
 			sap->last_updated_ts = str_to_timestamptz(last_updated_ts_str);
 		}
 
-		sap->updated_by_decode = (PQgetvalue(res, rno, COL_OFFSET + GP_UPDATED_BY_DECODE)[0] == 't');
+		sap->updated_by_decode = (PQgetvalue(res, rno, PP_UPDATED_BY_DECODE)[0] == 't');
 
 		progress_list = lappend(progress_list, sap);
 		MemoryContextSwitchTo(oldctx);

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -82,7 +82,7 @@
 
 /*
  * Columns (PP_ = peer progress) of the queries that read a provider's
- * replication progress, in adjust_progress_info() and
+ * replication progress, in read_provider_progress() and
  * spock_create_slot_and_read_progress().  Every form of those queries, for
  * 6.0.0 and pre-6.0.0 providers alike, selects exactly these, in this order,
  * and peer_progress_from_row() turns one such row into a SpockApplyProgress.
@@ -575,7 +575,7 @@ peer_progress_from_row(PGresult *res, int rno)
 }
 
 static List *
-adjust_progress_info(PGconn *origin_conn)
+read_provider_progress(PGconn *origin_conn)
 {
 	StringInfoData query;
 	PGresult   *originRes;
@@ -613,7 +613,7 @@ adjust_progress_info(PGconn *origin_conn)
 			resultList = lappend(resultList, sap);
 			MemoryContextSwitchTo(oldctx);
 
-			elog(LOG, "SPOCK: adjust spock.progress %s->%d to "
+			elog(LOG, "SPOCK: read provider progress %s->%d: "
 				 "remote_commit_ts='%s' "
 				 "remote_commit_lsn='%s' "
 				 "remote_insert_lsn='%s'",
@@ -1293,7 +1293,7 @@ copy_tables_data(SpockSubscription *sub, const char *origin_dsn,
 		CHECK_FOR_INTERRUPTS();
 	}
 
-	progress_entries_list = adjust_progress_info(origin_conn);
+	progress_entries_list = read_provider_progress(origin_conn);
 
 	/* Finish the transactions and disconnect. */
 	finish_copy_origin_tx(origin_conn);
@@ -1339,7 +1339,7 @@ copy_replication_sets_data(SpockSubscription *sub, const char *origin_dsn,
 	 * LSN values are consistent with the data we are about to copy.
 	 */
 	if (progress_out)
-		*progress_out = adjust_progress_info(origin_conn);
+		*progress_out = read_provider_progress(origin_conn);
 
 	/* Get tables to copy from origin node. */
 	tables = spock_get_remote_repset_tables(origin_conn,

--- a/src/spock_sync.c
+++ b/src/spock_sync.c
@@ -80,6 +80,27 @@
 #define Anum_sync_status		5
 #define Anum_sync_statuslsn		6
 
+/*
+ * Columns (PP_ = peer progress) of the queries that read a provider's
+ * replication progress, in adjust_progress_info() and
+ * spock_create_slot_and_read_progress().  Every form of those queries, for
+ * 6.0.0 and pre-6.0.0 providers alike, selects exactly these, in this order,
+ * and peer_progress_from_row() turns one such row into a SpockApplyProgress.
+ */
+enum PeerProgressCol
+{
+	PP_REMOTE_NODE_ID = 0,
+	PP_REMOTE_COMMIT_TS,
+	PP_REMOTE_COMMIT_LSN,
+	PP_REMOTE_INSERT_LSN,
+	PP_LAST_UPDATED_TS,
+	PP_UPDATED_BY_DECODE
+};
+
+#define PEER_PROGRESS_COLUMNS \
+	"remote_node_id, remote_commit_ts, %s AS remote_commit_lsn, " \
+	"remote_insert_lsn, last_updated_ts, updated_by_decode"
+
 PGDLLEXPORT void spock_sync_main(Datum main_arg);
 
 static SpockSyncWorker *MySyncWorker = NULL;
@@ -464,19 +485,107 @@ ensure_replication_origin(char *slot_name)
 }
 
 
+/*
+ * Does the provider's spock.progress carry the 6.0.0 column names?  Before
+ * 6.0.0, and on a 6.0 binary whose extension has not been updated yet, it is
+ * a plain table whose commit-LSN column is called remote_lsn.  Ask the
+ * catalog, not the library version.
+ */
+static bool
+provider_progress_has_commit_lsn(PGconn *conn)
+{
+	PGresult   *res;
+	bool		found;
+
+	res = PQexec(conn,
+				 "SELECT EXISTS (SELECT 1 FROM pg_attribute "
+				 "WHERE attrelid = 'spock.progress'::regclass "
+				 "  AND attname = 'remote_commit_lsn' AND NOT attisdropped)");
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		elog(ERROR, "could not inspect spock.progress on origin: %s",
+			 PQerrorMessage(conn));
+	found = (PQgetvalue(res, 0, 0)[0] == 't');
+	PQclear(res);
+	return found;
+}
+
+/*
+ * Build a SpockApplyProgress for this node from row rno of a result laid
+ * out per enum PeerProgressCol.  The caller owns the allocation, made in
+ * CacheMemoryContext.
+ */
+static SpockApplyProgress *
+peer_progress_from_row(PGresult *res, int rno)
+{
+	SpockApplyProgress *sap;
+	char	   *remote_node_id = PQgetvalue(res, rno, PP_REMOTE_NODE_ID);
+	char	   *remote_commit_ts = NULL;
+	char	   *last_updated_ts = NULL;
+
+	sap = MemoryContextAlloc(CacheMemoryContext, sizeof(SpockApplyProgress));
+	sap->key.dbid = MyDatabaseId;
+	sap->key.node_id = MySubscription->target->id;
+	sap->key.remote_node_id = atooid(remote_node_id);
+	Assert(OidIsValid(sap->key.remote_node_id));
+
+	/* Alloc above doesn't zero; set every non-key field to "unset" */
+	spock_init_progress_fields(sap);
+
+	if (!PQgetisnull(res, rno, PP_REMOTE_COMMIT_TS))
+	{
+		remote_commit_ts = PQgetvalue(res, rno, PP_REMOTE_COMMIT_TS);
+		sap->remote_commit_ts = str_to_timestamptz(remote_commit_ts);
+		Assert(IS_VALID_TIMESTAMP(sap->remote_commit_ts));
+	}
+	sap->prev_remote_ts = sap->remote_commit_ts;
+
+	sap->remote_commit_lsn = str_to_lsn(PQgetvalue(res, rno, PP_REMOTE_COMMIT_LSN));
+	sap->remote_insert_lsn = str_to_lsn(PQgetvalue(res, rno, PP_REMOTE_INSERT_LSN));
+
+	/*
+	 * We don't actually receive a single WAL record - just assume we've got
+	 * the last commit only. Don't set it to the Invalid value in case someone
+	 * uses tracking data in state monitoring scripts.
+	 */
+	sap->received_lsn = sap->remote_commit_lsn;
+
+	if (!PQgetisnull(res, rno, PP_LAST_UPDATED_TS))
+	{
+		last_updated_ts = PQgetvalue(res, rno, PP_LAST_UPDATED_TS);
+		sap->last_updated_ts = str_to_timestamptz(last_updated_ts);
+		Assert(IS_VALID_TIMESTAMP(sap->last_updated_ts));
+
+		if (sap->last_updated_ts < sap->remote_commit_ts)
+
+			/*
+			 * Complaining at the end of the sync we shouldn't flood the log
+			 */
+			ereport(WARNING,
+					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+					 errmsg("transaction apply time precedes its original commit time"),
+					 errdetail("Commit time %s (node ID %s), but it was applied at %s on the replica (node ID %d)",
+							   remote_commit_ts, remote_node_id,
+							   last_updated_ts,
+							   MySubscription->origin->id),
+					 errhint("usually it means that the server's clocks are out of sync.")));
+	}
+	sap->updated_by_decode = (PQgetvalue(res, rno, PP_UPDATED_BY_DECODE)[0] == 't');
+
+	return sap;
+}
+
 static List *
 adjust_progress_info(PGconn *origin_conn)
 {
-	const char *originQuery =
-		"SELECT * FROM spock.progress "
-		"WHERE node_id = %u AND remote_node_id <> %u";
 	StringInfoData query;
 	PGresult   *originRes;
 	List	   *resultList = NIL;
 
 	/*
-	 * Select the current content of the origin's spock.progress table where
-	 * the origin is the target and this node is not the origin.
+	 * Select the current content of the origin's spock.progress where the
+	 * origin is the target and this node is not the origin.  In 6.0.0 that is
+	 * a view already limited to the current database; before 6.0.0 it is a
+	 * per-database table with the commit LSN under its old name.
 	 *
 	 * We use this information to update the target's spock.progress table so
 	 * that START REPLICATION can ask the walsender to skip all transactions
@@ -484,96 +593,23 @@ adjust_progress_info(PGconn *origin_conn)
 	 * therefore part of the snapshot we are copying.
 	 */
 	initStringInfo(&query);
-	appendStringInfo(&query, originQuery, MySubscription->origin->id,
-					 MySubscription->target->id);
+	appendStringInfo(&query,
+					 "SELECT " PEER_PROGRESS_COLUMNS " FROM spock.progress "
+					 "WHERE node_id = %u AND remote_node_id <> %u",
+					 provider_progress_has_commit_lsn(origin_conn)
+					 ? "remote_commit_lsn" : "remote_lsn",
+					 MySubscription->origin->id, MySubscription->target->id);
 	originRes = PQexec(origin_conn, query.data);
 	if (PQresultStatus(originRes) == PGRES_TUPLES_OK)
 	{
 		int			rno;
-		char	   *dbid_str = NULL;
 
 		for (rno = 0; rno < PQntuples(originRes); rno++)
 		{
-			SpockApplyProgress *sap =
-				MemoryContextAlloc(CacheMemoryContext,
-								   sizeof(SpockApplyProgress));
+			SpockApplyProgress *sap = peer_progress_from_row(originRes, rno);
 			MemoryContext oldctx;
 
-			/*
-			 * Update the remote node's progress entry to what our sync
-			 * provider has included in the COPY snapshot.
-			 *
-			 * We assume here that the progress table entry already exists.
-			 * Turning this into an INSERT if not should be easy.
-			 */
-			char	   *remote_node_id = PQgetvalue(originRes, rno, GP_REMOTE_NODE_ID);
-			char	   *remote_commit_ts = NULL;
-			char	   *remote_commit_lsn = PQgetvalue(originRes, rno, GP_REMOTE_COMMIT_LSN);
-			char	   *remote_insert_lsn = PQgetvalue(originRes, rno, GP_REMOTE_INSERT_LSN);
-			char	   *last_updated_ts = NULL;
-			char	   *updated_by_decode = PQgetvalue(originRes, rno, GP_UPDATED_BY_DECODE);
-
-			sap->key.dbid = MyDatabaseId;
-			sap->key.node_id = MySubscription->target->id;
-			sap->key.remote_node_id = atooid(remote_node_id);
-			Assert(OidIsValid(sap->key.remote_node_id));
-
-			/* Alloc above doesn't zero; set every non-key field to "unset" */
-			spock_init_progress_fields(sap);
-
-			/* Check: we view only values related to a single database */
-			Assert(!PQgetisnull(originRes, rno, GP_DBOID));
-			if (dbid_str == NULL)
-				dbid_str = PQgetvalue(originRes, rno, GP_DBOID);
-			else
-			{
-				Assert(strcmp(dbid_str, PQgetvalue(originRes, rno, GP_DBOID)) == 0);
-			}
-
-			if (!PQgetisnull(originRes, rno, GP_REMOTE_COMMIT_TS))
-			{
-				remote_commit_ts = PQgetvalue(originRes, rno, GP_REMOTE_COMMIT_TS);
-				sap->remote_commit_ts = str_to_timestamptz(remote_commit_ts);
-				Assert(IS_VALID_TIMESTAMP(sap->remote_commit_ts));
-			}
-			sap->prev_remote_ts = sap->remote_commit_ts;
-
-			sap->remote_commit_lsn = str_to_lsn(remote_commit_lsn);
-			sap->remote_insert_lsn = str_to_lsn(remote_insert_lsn);
-
-			/*
-			 * We don't actually receive a single WAL record - just assume
-			 * we've got the last commit only. Don't set it to the Invalid
-			 * value in case someone uses tracking data in state monitoring
-			 * scripts.
-			 */
-			sap->received_lsn = str_to_lsn(remote_commit_lsn);
-
-			if (!PQgetisnull(originRes, rno, GP_LAST_UPDATED_TS))
-			{
-				last_updated_ts = PQgetvalue(originRes, rno, GP_LAST_UPDATED_TS);
-				sap->last_updated_ts = str_to_timestamptz(last_updated_ts);
-
-				Assert(IS_VALID_TIMESTAMP(sap->last_updated_ts));
-
-				if (sap->last_updated_ts < sap->remote_commit_ts)
-
-					/*
-					 * Complaining at the end of the sync we shouldn't flood
-					 * the log
-					 */
-					ereport(WARNING,
-							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("transaction apply time precedes its original commit time"),
-							 errdetail("Commit time %s (node ID %s), but it was applied at %s on the replica (node ID %d)",
-									   remote_commit_ts, remote_node_id,
-									   last_updated_ts,
-									   MySubscription->origin->id),
-							 errhint("usually it means that the server's clocks are out of sync.")));
-			}
-			sap->updated_by_decode = updated_by_decode[0] == 't',
-
-				oldctx = MemoryContextSwitchTo(CacheMemoryContext);
+			oldctx = MemoryContextSwitchTo(CacheMemoryContext);
 			resultList = lappend(resultList, sap);
 			MemoryContextSwitchTo(oldctx);
 
@@ -581,11 +617,11 @@ adjust_progress_info(PGconn *origin_conn)
 				 "remote_commit_ts='%s' "
 				 "remote_commit_lsn='%s' "
 				 "remote_insert_lsn='%s'",
-				 remote_node_id,
+				 PQgetvalue(originRes, rno, PP_REMOTE_NODE_ID),
 				 MySubscription->target->id,
-				 remote_commit_ts,
-				 remote_commit_lsn,
-				 remote_insert_lsn);
+				 PQgetvalue(originRes, rno, PP_REMOTE_COMMIT_TS),
+				 PQgetvalue(originRes, rno, PP_REMOTE_COMMIT_LSN),
+				 PQgetvalue(originRes, rno, PP_REMOTE_INSERT_LSN));
 		}
 	}
 	else
@@ -595,7 +631,7 @@ adjust_progress_info(PGconn *origin_conn)
 	}
 	PQclear(originRes);
 
-	resetStringInfo(&query);
+	pfree(query.data);
 	return resultList;
 }
 
@@ -622,22 +658,7 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	List	   *progress_list = NIL;
 	int			nrows;
 	int			rno;
-	int			provider_version_num = 0;
-
-	/*
-	 * Columns (PP_ = peer progress) of the peer progress query below.  Both
-	 * the 6.0.0 form (spock.read_peer_progress) and the pre-6.0.0 form
-	 * (direct read of spock.progress) select exactly these, in this order.
-	 */
-	enum
-	{
-		PP_REMOTE_NODE_ID = 0,
-		PP_REMOTE_COMMIT_TS,
-		PP_REMOTE_COMMIT_LSN,
-		PP_REMOTE_INSERT_LSN,
-		PP_LAST_UPDATED_TS,
-		PP_UPDATED_BY_DECODE
-	};
+	bool		have_read_peer_progress = false;
 
 	initStringInfo(&query);
 
@@ -657,6 +678,24 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 
 	elog(LOG, "SPOCK cswp slot=%s provider=%u subscriber=%u",
 		 slot_name, origin_node_id, subscriber_node_id);
+
+	/*
+	 * Does the provider have spock.read_peer_progress()?  It arrives with the
+	 * 6.0.0 extension version, so a provider on an older extension, or on the
+	 * 6.0 binary with ALTER EXTENSION spock UPDATE still pending, lacks it
+	 * and keeps its progress in the pre-6.0.0 spock.progress table.  Ask the
+	 * catalog rather than the library version, and ask before pausing apply
+	 * workers so a failure here cannot leave them paused.
+	 */
+	res = PQexec(conn,
+				 "SELECT to_regprocedure('spock.read_peer_progress(text,oid,oid)') IS NOT NULL");
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		elog(ERROR, "could not check for spock.read_peer_progress() on origin: %s",
+			 PQerrorMessage(conn));
+	have_read_peer_progress = (PQgetvalue(res, 0, 0)[0] == 't');
+	PQclear(res);
+	elog(LOG, "SPOCK cswp provider has read_peer_progress: %s",
+		 have_read_peer_progress ? "yes" : "no");
 
 	/*
 	 * Pause apply workers so ros.remote_lsn reflects only fully committed
@@ -737,23 +776,23 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	 * the peer origin's remote_lsn from pg_replication_origin_status, exact
 	 * because apply workers are paused.
 	 *
-	 * A provider older than 6.0.0 has no spock.read_peer_progress() and keeps
-	 * progress in a plain table, so read the same six values from its catalog
-	 * directly.  Detect the version with spock_version_num(), which every
-	 * supported release has.
+	 * Without spock.read_peer_progress() (see the probe above) the provider
+	 * keeps progress in a plain table, so read the same six values from its
+	 * catalog directly.  Only the resume LSN is exact on that path: the table
+	 * is flushed at most once a second, so remote_commit_ts,
+	 * remote_insert_lsn, last_updated_ts and updated_by_decode can trail the
+	 * paused state by up to that.  They seed the new node's lag tracking and
+	 * are replaced by the first replicated message, so that is acceptable;
+	 * remote_insert_lsn is clamped to the resume LSN so it never reads as
+	 * behind a commit we know has been applied.
 	 */
-	res = PQexec(conn, "SELECT spock.spock_version_num()");
-	if (PQresultStatus(res) == PGRES_TUPLES_OK && PQntuples(res) == 1)
-		provider_version_num = atoi(PQgetvalue(res, 0, 0));
-	PQclear(res);
-	elog(LOG, "SPOCK cswp provider spock version_num=%d", provider_version_num);
-
-	if (provider_version_num > 0 && provider_version_num < 60000)
+	if (!have_read_peer_progress)
 	{
 		appendStringInfo(&query,
 						 "SELECT p.remote_node_id, p.remote_commit_ts, "
 						 "       COALESCE(ros.remote_lsn, '0/0'::pg_lsn) AS remote_commit_lsn, "
-						 "       p.remote_insert_lsn, p.last_updated_ts, p.updated_by_decode "
+						 "       GREATEST(p.remote_insert_lsn, COALESCE(ros.remote_lsn, '0/0'::pg_lsn)) AS remote_insert_lsn, "
+						 "       p.last_updated_ts, p.updated_by_decode "
 						 "FROM spock.subscription sub "
 						 "JOIN spock.progress p ON p.remote_node_id = sub.sub_origin "
 						 "                     AND p.node_id = sub.sub_target "
@@ -770,10 +809,10 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 		 * slot's LSN and snapshot were taken from CREATE_REPLICATION_SLOT.
 		 */
 		appendStringInfo(&query,
-						 "SELECT remote_node_id, remote_commit_ts, remote_commit_lsn, "
-						 "       remote_insert_lsn, last_updated_ts, updated_by_decode "
+						 "SELECT " PEER_PROGRESS_COLUMNS " "
 						 "FROM spock.read_peer_progress('%s', %u, %u) "
 						 "WHERE remote_node_id IS NOT NULL",
+						 "remote_commit_lsn",
 						 slot_name, origin_node_id, subscriber_node_id);
 	}
 	res = PQexec(conn, query.data);
@@ -792,59 +831,22 @@ spock_create_slot_and_read_progress(PGconn *conn, PGconn *repl_conn,
 	{
 		SpockApplyProgress *sap;
 		MemoryContext oldctx;
-		char	   *remote_node_id_str;
-		char	   *remote_commit_ts_str;
-		char	   *remote_commit_lsn_str;
-		char	   *remote_insert_lsn_str;
-		char	   *last_updated_ts_str;
 
 		if (PQgetisnull(res, rno, PP_REMOTE_NODE_ID))
 			continue;			/* shouldn't happen but be safe */
 
-		sap = (SpockApplyProgress *) MemoryContextAlloc(CacheMemoryContext,
-														sizeof(SpockApplyProgress));
+		sap = peer_progress_from_row(res, rno);
+
 		oldctx = MemoryContextSwitchTo(CacheMemoryContext);
-
-		sap->key.dbid = MyDatabaseId;
-		sap->key.node_id = MySubscription->target->id;
-		remote_node_id_str = PQgetvalue(res, rno, PP_REMOTE_NODE_ID);
-		sap->key.remote_node_id = atooid(remote_node_id_str);
-		Assert(OidIsValid(sap->key.remote_node_id));
-
-		/* Alloc above doesn't zero; set every non-key field to "unset" */
-		spock_init_progress_fields(sap);
-		if (!PQgetisnull(res, rno, PP_REMOTE_COMMIT_TS))
-		{
-			remote_commit_ts_str = PQgetvalue(res, rno, PP_REMOTE_COMMIT_TS);
-			sap->remote_commit_ts = str_to_timestamptz(remote_commit_ts_str);
-		}
-		sap->prev_remote_ts = sap->remote_commit_ts;
-
-		remote_commit_lsn_str = PQgetvalue(res, rno, PP_REMOTE_COMMIT_LSN);
-		sap->remote_commit_lsn = str_to_lsn(remote_commit_lsn_str);
-
-		remote_insert_lsn_str = PQgetvalue(res, rno, PP_REMOTE_INSERT_LSN);
-		sap->remote_insert_lsn = str_to_lsn(remote_insert_lsn_str);
-
-		sap->received_lsn = sap->remote_commit_lsn;
-
-		sap->last_updated_ts = 0;
-		if (!PQgetisnull(res, rno, PP_LAST_UPDATED_TS))
-		{
-			last_updated_ts_str = PQgetvalue(res, rno, PP_LAST_UPDATED_TS);
-			sap->last_updated_ts = str_to_timestamptz(last_updated_ts_str);
-		}
-
-		sap->updated_by_decode = (PQgetvalue(res, rno, PP_UPDATED_BY_DECODE)[0] == 't');
-
 		progress_list = lappend(progress_list, sap);
 		MemoryContextSwitchTo(oldctx);
 
 		elog(LOG, "SPOCK cswp peer=%s->%d commit_lsn=%s insert_lsn=%s",
-			 remote_node_id_str, MySubscription->target->id,
-			 remote_commit_lsn_str, remote_insert_lsn_str);
+			 PQgetvalue(res, rno, PP_REMOTE_NODE_ID),
+			 MySubscription->target->id,
+			 PQgetvalue(res, rno, PP_REMOTE_COMMIT_LSN),
+			 PQgetvalue(res, rno, PP_REMOTE_INSERT_LSN));
 	}
-
 	PQclear(res);
 
 	/*

--- a/tests/tap/schedule-nightly
+++ b/tests/tap/schedule-nightly
@@ -21,3 +21,11 @@ test: 017_zodan_3n_timeout
 # deadlock.
 test: 035_deadlock_retry
 test: 036_real_deadlock_retry
+
+# Mixed-version add_node: builds Spock from v5_STABLE and HEAD into separate
+# PostgreSQL install copies, adds a HEAD node to a two-node v5 cluster with
+# zodan, then checks replication, a single-table resync from the old
+# provider, and the version rule in check_spock_version_compatibility.
+# About two minutes once the trees are built; the first run also compiles
+# both Spock versions.
+test: 099_zodan_mixed_version

--- a/tests/tap/t/099_zodan_mixed_version.pl
+++ b/tests/tap/t/099_zodan_mixed_version.pl
@@ -1,0 +1,315 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Path qw(make_path remove_tree);
+use File::Basename qw(dirname);
+use Cwd qw(getcwd);
+use IPC::Run;
+
+use lib '.';
+use lib 't';
+use SpockTest qw(
+    create_cluster destroy_cluster system_or_bail system_maybe
+    get_test_config cross_wire psql_or_bail scalar_query
+);
+
+# =============================================================================
+# Test: mixed-version add_node.  Two Spock 5.0.11 nodes (n1, n2, built from
+# v5_STABLE) plus a Spock 6.0.0 node (n3, current branch) added with zodan
+# add_node() running on n3.
+#
+# Each Spock build lives in its own PostgreSQL install tree under
+# /tmp/spock_rolling_upgrade_test/pg<major>_<name>: a copy of the install
+# whose binaries are in PATH, with that Spock version built from a clone of
+# this repository and installed into it (as 014_rolling_upgrade.pl does).
+# PostgreSQL finds lib/ and share/ relative to its own binary, so a node
+# started from such a tree has its own spock.so and extension scripts, exactly
+# like separate installs on separate hosts.  Nothing outside those trees is
+# modified, and no per-node path settings are needed.  Works on any
+# PostgreSQL version the two Spock builds support.  Trees are kept between
+# runs; remove /tmp/spock_rolling_upgrade_test to force a rebuild.
+#
+# Env knobs:
+#   ZODAN_N12_VER  name of the build n1/n2 run: v5 (default, built from
+#                  origin/v5_STABLE), v6 (HEAD, gives the all-6.0.0 control
+#                  run), or any other name together with ZODAN_N12_REF
+#   ZODAN_N12_REF  git ref to build for ZODAN_N12_VER (e.g. v5.0.9); defaults
+#                  exist for v5 and v6 only
+#   ZODAN_LOAD     1 = run pgbench load on n1/n2 while adding n3 (default 0)
+#   ZODAN_SQL      path to the zodan.sql to use (default: ../../samples/Z0DAN/zodan.sql)
+#   ZODAN_SCRATCH  where add_node output and state dumps go (default: TESTLOGDIR or logs)
+# =============================================================================
+my $TEMP_BASE = "/tmp/spock_rolling_upgrade_test";
+my $PG_CONFIG = `which pg_config`; chomp $PG_CONFIG;
+my ($PG_MAJOR) = (`$PG_CONFIG --version` =~ /(\d+)/);
+
+# Install tree holding a given Spock build for this PostgreSQL major version.
+sub install_dir { my ($name) = @_; return "$TEMP_BASE/pg${PG_MAJOR}_${name}"; }
+
+# Spock version a tree will report, from its extension control file.
+sub install_version {
+    my ($name) = @_;
+    my $sharedir = `${\ install_dir($name)}/bin/pg_config --sharedir`; chomp $sharedir;
+    my $ctl = "$sharedir/extension/spock.control";
+    open(my $fh, '<', $ctl) or die "cannot read $ctl: $!";
+    my ($v) = map { /default_version\s*=\s*'([^']+)'/ ? $1 : () } <$fh>;
+    close $fh;
+    return $v;
+}
+my $SCRATCH    = $ENV{ZODAN_SCRATCH} // $ENV{TESTLOGDIR} // 'logs';
+make_path($SCRATCH) unless -d $SCRATCH;
+my $ZODAN_SQL  = $ENV{ZODAN_SQL} // '../../samples/Z0DAN/zodan.sql';
+my $LOAD       = $ENV{ZODAN_LOAD} // 0;
+my $N12_VER    = $ENV{ZODAN_N12_VER} // 'v5';
+
+my %BUILD_REF = (v5 => 'origin/v5_STABLE', v6 => 'HEAD');
+my $N12_REF = $ENV{ZODAN_N12_REF} // $BUILD_REF{$N12_VER}
+    // die "no default git ref for build '$N12_VER'; set ZODAN_N12_REF";
+
+# Repository to build from: the CI checkout if present, else derive from cwd
+# (tests run from tests/tap).  Same rule as 014_rolling_upgrade.pl.
+my $SPOCK_REPO;
+if (-d "/home/pgedge/spock" && -f "/home/pgedge/spock/Makefile") {
+    $SPOCK_REPO = "/home/pgedge/spock";
+} else {
+    my $cwd = getcwd();
+    $SPOCK_REPO = ($cwd =~ m{^(/.+)/tests/tap(?:/t)?$}) ? $1 : $cwd;
+}
+die "SPOCK_REPO not found or missing Makefile: $SPOCK_REPO"
+    unless -d $SPOCK_REPO && -f "$SPOCK_REPO/Makefile";
+
+# Build Spock at $git_ref into its own copy of the PostgreSQL install.
+# The commit that was built is recorded in the tree; an existing tree is
+# reused only when it holds the commit $git_ref resolves to now.
+sub build_spock_tree {
+    my ($git_ref, $name) = @_;
+    my $tree = install_dir($name);
+    my $pg_bin = "$tree/bin";
+    my $stamp = "$tree/.spock_commit";
+
+    my $commit = `git -C $SPOCK_REPO rev-parse --verify --quiet $git_ref`;
+    chomp $commit;
+    die "cannot resolve git ref '$git_ref' in $SPOCK_REPO" unless $commit;
+
+    if (-f $stamp) {
+        open(my $fh, '<', $stamp) or die "cannot read $stamp: $!";
+        my $built = <$fh>; close $fh; chomp $built;
+        if ($built eq $commit) {
+            diag("Spock $name already built from $git_ref ($commit) in $tree, skipping");
+            return 1;
+        }
+        diag("Tree $tree holds $built, but $git_ref is now $commit; rebuilding");
+    }
+
+    if ($git_ref eq 'HEAD') {
+        my $dirty = `git -C $SPOCK_REPO status --porcelain -- src sql include`;
+        diag("NOTE: uncommitted changes under src/, sql/ or include/ are not part of this build (it clones HEAD):\n$dirty")
+            if $dirty;
+    }
+
+    my $pghome    = dirname(dirname($PG_CONFIG));
+    my $build_dir = "$TEMP_BASE/build_pg${PG_MAJOR}_${name}";
+    diag("Building Spock $name from $git_ref into $tree (PostgreSQL install copied from $pghome)");
+    remove_tree($tree);
+    remove_tree($build_dir);
+    make_path($TEMP_BASE);
+
+    # A full copy: PostgreSQL resolves lib/ and share/ relative to bin/, so
+    # the copy is an independent install.  Drop the system Spock from it so
+    # the tree holds only the version built here.
+    system_or_bail('cp', '-a', $pghome, $tree);
+    my $libdir   = `$pg_bin/pg_config --pkglibdir`; chomp $libdir;
+    my $sharedir = `$pg_bin/pg_config --sharedir`;  chomp $sharedir;
+    unlink glob("$libdir/spock*.so"), glob("$sharedir/extension/spock*");
+
+    system_or_bail("git clone --quiet $SPOCK_REPO $build_dir");
+    system_or_bail("cd $build_dir && git checkout --quiet $git_ref") if $git_ref ne 'HEAD';
+    system_or_bail("cd $build_dir && make PG_CONFIG=$pg_bin/pg_config");
+    system_or_bail("cd $build_dir && make install PG_CONFIG=$pg_bin/pg_config");
+
+    open(my $fh, '>', $stamp) or die "cannot write $stamp: $!";
+    print $fh "$commit\n";
+    close $fh;
+    return 1;
+}
+
+ok(build_spock_tree($N12_REF, $N12_VER), "Built Spock $N12_VER ($N12_REF) into " . install_dir($N12_VER));
+ok(build_spock_tree('HEAD', 'v6'), "Built Spock v6 (HEAD) into " . install_dir('v6'));
+
+sub stop_node {
+    my ($n) = @_;
+    my $c = get_test_config();
+    system("$c->{pg_bin}/pg_ctl stop -D $c->{node_datadirs}->[$n-1] -m fast -w >/dev/null 2>&1");
+    sleep(1);
+}
+# Start node $n from the install tree holding Spock build $name.
+sub start_node {
+    my ($n, $name) = @_;
+    my $c = get_test_config();
+    my $bin = install_dir($name) . "/bin";
+    system("$bin/pg_ctl start -D $c->{node_datadirs}->[$n-1] -l $c->{log_file} -w >/dev/null 2>&1");
+    sleep(2);
+}
+
+# Poll a scalar query on a node until it equals $want or timeout (seconds).
+sub wait_until {
+    my ($node, $sql, $want, $timeout, $label) = @_;
+    $timeout //= 120;
+    my $got;
+    for (1 .. $timeout) {
+        $got = scalar_query($node, $sql);
+        last if defined $got && $got eq $want;
+        sleep 1;
+    }
+    is($got, $want, $label);
+}
+
+# Dump replication state of all nodes plus node log tails into $file.
+sub dump_state {
+    my ($file) = @_;
+    my $c = get_test_config();
+    open(my $fh, '>', $file) or die $!;
+    for my $n (1..3) {
+        my $port = $c->{node_ports}->[$n-1];
+        print $fh "\n===== node n$n (port $port) =====\n";
+        for my $q (
+            "SELECT spock.spock_version()",
+            "SELECT subscription_name, status, provider_node, slot_name FROM spock.sub_show_status()",
+            "SELECT sub_name, sub_enabled, sub_slot_name, sub_sync_structure, sub_sync_data FROM spock.subscription",
+            "SELECT * FROM spock.local_sync_status",
+            "SELECT external_id, remote_lsn, local_lsn FROM pg_replication_origin_status",
+            "SELECT slot_name, active, confirmed_flush_lsn, restart_lsn FROM pg_replication_slots",
+            "SELECT application_name, state, sent_lsn, write_lsn, flush_lsn, replay_lsn FROM pg_stat_replication",
+            "SELECT pid, backend_type, state, wait_event_type, wait_event, left(query,120) FROM pg_stat_activity WHERE backend_type LIKE '%spock%' OR application_name LIKE '%spock%' OR query LIKE '%spock%'",
+            "SELECT * FROM spock.lag_tracker",
+        ) {
+            print $fh "-- $q\n";
+            print $fh `$c->{pg_bin}/psql -X -p $port -d $c->{db_name} -c "$q" 2>&1`;
+        }
+        my $log = "$ENV{TESTLOGDIR}/00$port.log";
+        print $fh "-- tail of $log (non-DEBUG)\n";
+        print $fh `grep -v DEBUG '$log' 2>/dev/null | grep -v 'log_statement\|duration:\|STATEMENT:' | tail -120`;
+    }
+    close $fh;
+    diag("state dump written to $file");
+}
+
+# ---------------------------------------------------------------------------
+create_cluster(3, 'Create 3-node cluster (temporary, will be re-versioned)');
+my $config = get_test_config();
+my ($host, $dbname, $db_user, $ports) = ($config->{host}, $config->{db_name}, $config->{db_user}, $config->{node_ports});
+
+my $ver12 = install_version($N12_VER);
+my $ver3  = install_version('v6');
+diag("Re-versioning: n1,n2 -> Spock $ver12 ($N12_VER tree), n3 -> Spock $ver3 (v6 tree)");
+psql_or_bail($_, "DROP EXTENSION IF EXISTS spock CASCADE") for 1..3;
+stop_node($_) for 1..3;
+start_node(1, $N12_VER);
+start_node(2, $N12_VER);
+start_node(3, 'v6');
+psql_or_bail($_, "CREATE EXTENSION spock") for 1..3;
+psql_or_bail(1, "SELECT spock.node_create('n1', 'host=$host dbname=$dbname port=$ports->[0] user=$db_user')");
+psql_or_bail(2, "SELECT spock.node_create('n2', 'host=$host dbname=$dbname port=$ports->[1] user=$db_user')");
+
+my @v = map { scalar_query($_, "SELECT spock.spock_version()") } 1..3;
+diag("Versions: n1=$v[0] n2=$v[1] n3=$v[2]");
+is($v[0], $ver12, "n1 runs Spock $ver12 ($N12_VER build)");
+is($v[1], $ver12, "n2 runs Spock $ver12 ($N12_VER build)");
+is($v[2], $ver3, "n3 runs Spock $ver3 (v6 build)");
+
+cross_wire(2, ['n1', 'n2'], "Cross-wire n1 <-> n2 (both $N12_VER)");
+
+# zodan lives on the new node only.
+psql_or_bail(3, "CREATE EXTENSION dblink");
+psql_or_bail(3, "\\i $ZODAN_SQL");
+psql_or_bail(3, "\\i ../../samples/Z0DAN/wait_subscription.sql");
+
+# Seed data on n1, wait for n2.
+system_or_bail("$config->{pg_bin}/pgbench", '-i', '-s', 1, '-h', $host, '-p', $ports->[0], '-U', $db_user, $dbname);
+psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+wait_until(2, "SELECT count(*) FROM pgbench_accounts", '100000', 180, "pgbench data replicated n1 -> n2");
+
+my (@pgb, @pgb_out, @pgb_err);
+if ($LOAD) {
+    diag("Starting non-intersecting pgbench load on n1 and n2");
+    psql_or_bail(3, "ALTER SYSTEM SET spock.exception_behaviour = 'transdiscard'");
+    psql_or_bail(3, "SELECT pg_reload_conf()");
+    for my $i (0, 1) {
+        my $f = '../../samples/Z0DAN/n' . ($i+1) . '.pgb';
+        $pgb_out[$i] = ''; $pgb_err[$i] = '';
+        $pgb[$i] = IPC::Run::start(
+            [ "$config->{pg_bin}/pgbench", '-n', '-f', $f, '-T', 600, '-j', 2, '-c', 2,
+              '-h', $host, '-p', $ports->[$i], '-U', $db_user, $dbname ],
+            '>', \$pgb_out[$i], '2>', \$pgb_err[$i]);
+    }
+    sleep(20);
+    psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+    psql_or_bail(2, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+}
+
+# ---------------------------------------------------------------------------
+diag("Calling spock.add_node() on n3 (6.0.0) with source n1 (5.0.11)");
+my $out_file = "$SCRATCH/add_node_" . $N12_VER . '_' . ($LOAD ? 'load' : 'noload') . ".out";
+my $add_sql = "CALL spock.add_node(src_node_name := 'n1',
+    src_dsn := 'host=$host dbname=$dbname port=$ports->[0] user=$db_user',
+    new_node_name := 'n3',
+    new_node_dsn := 'host=$host dbname=$dbname port=$ports->[2] user=$db_user',
+    verb := true);";
+my $t0 = time();
+my $rc = system("timeout 1200 $config->{pg_bin}/psql -X -p $ports->[2] -d $dbname -v ON_ERROR_STOP=1 -c \"$add_sql\" > '$out_file' 2>&1");
+my $elapsed = time() - $t0;
+diag("add_node exit code " . ($rc >> 8) . " after ${elapsed}s; output in $out_file");
+is($rc, 0, "add_node completed without error");
+if ($rc != 0) {
+    open(my $fh, '<', $out_file); my @tail = <$fh>; close $fh;
+    diag("--- add_node output tail ---"); diag($_) for @tail[-25..-1];
+}
+
+dump_state("$SCRATCH/state_" . $N12_VER . '_' . ($LOAD ? 'load' : 'noload') . ".txt");
+if ($LOAD) {
+    for my $i (0, 1) { $pgb[$i]->kill_kill; $pgb[$i]->finish; }
+}
+
+if ($rc != 0) {
+    diag("add_node failed; skipping data verification");
+    destroy_cluster('Destroy cluster');
+    done_testing();
+    exit 0;
+}
+
+# ---------------------------------------------------------------------------
+diag("Verifying subscriptions and data");
+wait_until(3, "SELECT count(*) FROM spock.sub_show_status() WHERE status = 'replicating'", '2', 120,
+    "n3 has 2 replicating subscriptions (from n1, n2)");
+wait_until(1, "SELECT count(*) FROM spock.sub_show_status() WHERE provider_node = 'n3' AND status = 'replicating'", '1', 120,
+    "n1 replicates from n3");
+wait_until(2, "SELECT count(*) FROM spock.sub_show_status() WHERE provider_node = 'n3' AND status = 'replicating'", '1', 120,
+    "n2 replicates from n3");
+
+psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+psql_or_bail(2, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+for my $src ('n1', 'n2') {
+    my $lag = scalar_query(3, "SELECT * FROM wait_subscription(remote_node_name := '$src', report_it := true, timeout := '5 minutes', delay := 1.)");
+    ok(defined $lag && $lag <= 0, "n3 caught up with $src (lag=$lag)");
+}
+my @agg = map { scalar_query($_, "SELECT sum(abalance), sum(aid), count(*) FROM pgbench_accounts") } 1..3;
+diag("pgbench_accounts aggregates: n1=$agg[0] n2=$agg[1] n3=$agg[2]");
+is($agg[2], $agg[0], "n3 data equals n1");
+is($agg[2], $agg[1], "n3 data equals n2");
+
+# Three-way traffic after the add, including DDL from a 5.0.11 node.
+psql_or_bail(1, "CREATE TABLE mixed_test (id int PRIMARY KEY, src text)");
+wait_until(3, "SELECT count(*) FROM pg_tables WHERE tablename = 'mixed_test'", '1', 60, "DDL from n1 ($v[0]) reached n3 ($v[2])");
+wait_until(2, "SELECT count(*) FROM pg_tables WHERE tablename = 'mixed_test'", '1', 60, "DDL from n1 reached n2");
+psql_or_bail(1, "INSERT INTO mixed_test VALUES (1, 'n1')");
+psql_or_bail(2, "INSERT INTO mixed_test VALUES (2, 'n2')");
+psql_or_bail(3, "INSERT INTO mixed_test VALUES (3, 'n3')");
+wait_until($_, "SELECT count(*) FROM mixed_test", '3', 90, "n$_ sees rows from all three nodes") for 1..3;
+psql_or_bail(3, "UPDATE mixed_test SET src = 'n3-upd' WHERE id = 1");
+wait_until(1, "SELECT src FROM mixed_test WHERE id = 1", 'n3-upd', 60, "UPDATE from n3 ($v[2]) applied on n1 ($v[0])");
+
+my @subs = map { scalar_query($_, "SELECT string_agg(subscription_name || ':' || status, ',' ORDER BY subscription_name) FROM spock.sub_show_status()") } 1..3;
+diag("Final subs: n1=[$subs[0]] n2=[$subs[1]] n3=[$subs[2]]");
+
+destroy_cluster('Destroy cluster');
+done_testing();

--- a/tests/tap/t/099_zodan_mixed_version.pl
+++ b/tests/tap/t/099_zodan_mixed_version.pl
@@ -339,12 +339,13 @@ if ($ver12 ne $ver3) {
 }
 
 # Resync one table on n3 from n1.  This goes through copy_tables_data() and
-# adjust_progress_info(), which read the provider's spock.progress directly,
+# read_provider_progress(), which read the provider's spock.progress directly,
 # so it covers the other place the sync worker must understand an older
-# provider's catalog.
+# provider's catalog.  read_provider_progress() logs one "read provider
+# progress" line per peer; that text is unique to it.
 my $n3_log = "$ENV{TESTLOGDIR}/00$ports->[2].log";
 sub count_progress_adjustments {
-    my $n = `grep -c 'SPOCK: adjust spock.progress' '$n3_log' 2>/dev/null`; chomp $n;
+    my $n = `grep -c 'SPOCK: read provider progress' '$n3_log' 2>/dev/null`; chomp $n;
     return $n || 0;
 }
 my $adjusted_before = count_progress_adjustments();
@@ -354,7 +355,7 @@ psql_or_bail(3, "SELECT spock.sub_resync_table('sub_n1_n3', 'pgbench_branches')"
 wait_until(3, "SELECT status FROM spock.sub_show_table('sub_n1_n3', 'pgbench_branches')", 'replicating', 120,
     "single-table resync of pgbench_branches on n3 from n1 ($v[0]) completed");
 cmp_ok(count_progress_adjustments(), '>', $adjusted_before,
-    "resync read the provider's progress entries (adjust_progress_info ran; $adjusted_before log lines before)");
+    "resync read the provider's progress entries (read_provider_progress ran; $adjusted_before log lines before)");
 my @br = map { scalar_query($_, "SELECT sum(bbalance), count(*) FROM pgbench_branches") } 1, 3;
 is($br[1], $br[0], "pgbench_branches equal on n1 and n3 after resync");
 

--- a/tests/tap/t/099_zodan_mixed_version.pl
+++ b/tests/tap/t/099_zodan_mixed_version.pl
@@ -342,14 +342,19 @@ if ($ver12 ne $ver3) {
 # adjust_progress_info(), which read the provider's spock.progress directly,
 # so it covers the other place the sync worker must understand an older
 # provider's catalog.
+my $n3_log = "$ENV{TESTLOGDIR}/00$ports->[2].log";
+sub count_progress_adjustments {
+    my $n = `grep -c 'SPOCK: adjust spock.progress' '$n3_log' 2>/dev/null`; chomp $n;
+    return $n || 0;
+}
+my $adjusted_before = count_progress_adjustments();
 psql_or_bail(1, "UPDATE pgbench_branches SET bbalance = bbalance + 1");
 psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
 psql_or_bail(3, "SELECT spock.sub_resync_table('sub_n1_n3', 'pgbench_branches')");
 wait_until(3, "SELECT status FROM spock.sub_show_table('sub_n1_n3', 'pgbench_branches')", 'replicating', 120,
     "single-table resync of pgbench_branches on n3 from n1 ($v[0]) completed");
-my $n3_log = "$ENV{TESTLOGDIR}/00$ports->[2].log";
-my $adjusted = `grep -c 'SPOCK: adjust spock.progress' '$n3_log' 2>/dev/null`; chomp $adjusted;
-cmp_ok($adjusted, '>=', 1, "resync read the provider's progress entries (adjust_progress_info ran)");
+cmp_ok(count_progress_adjustments(), '>', $adjusted_before,
+    "resync read the provider's progress entries (adjust_progress_info ran; $adjusted_before log lines before)");
 my @br = map { scalar_query($_, "SELECT sum(bbalance), count(*) FROM pgbench_branches") } 1, 3;
 is($br[1], $br[0], "pgbench_branches equal on n1 and n3 after resync");
 

--- a/tests/tap/t/099_zodan_mixed_version.pl
+++ b/tests/tap/t/099_zodan_mixed_version.pl
@@ -151,6 +151,16 @@ sub start_node {
     sleep(2);
 }
 
+# Run $sql on a node and check that it fails with an error matching $re.
+sub psql_expect_error {
+    my ($node, $sql, $re, $label) = @_;
+    my $c = get_test_config();
+    my $port = $c->{node_ports}->[$node-1];
+    my $out = `$c->{pg_bin}/psql -X -p $port -d $c->{db_name} -v ON_ERROR_STOP=1 -c "$sql" 2>&1`;
+    my $rc = $? >> 8;
+    ok($rc != 0 && $out =~ $re, $label) or diag("exit $rc, output:\n$out");
+}
+
 # Poll a scalar query on a node until it equals $want or timeout (seconds).
 sub wait_until {
     my ($node, $sql, $want, $timeout, $label) = @_;
@@ -307,6 +317,41 @@ psql_or_bail(3, "INSERT INTO mixed_test VALUES (3, 'n3')");
 wait_until($_, "SELECT count(*) FROM mixed_test", '3', 90, "n$_ sees rows from all three nodes") for 1..3;
 psql_or_bail(3, "UPDATE mixed_test SET src = 'n3-upd' WHERE id = 1");
 wait_until(1, "SELECT src FROM mixed_test WHERE id = 1", 'n3-upd', 60, "UPDATE from n3 ($v[2]) applied on n1 ($v[0])");
+
+# The version rule in check_spock_version_compatibility.  The passing case is
+# the add_node above; here are the two rejections, exercised by calling the
+# procedure directly with the roles swapped.  Only meaningful when the
+# versions differ.
+if ($ver12 ne $ver3) {
+    my $n1_dsn = "host=$host dbname=$dbname port=$ports->[0] user=$db_user";
+    my $n3_dsn = "host=$host dbname=$dbname port=$ports->[2] user=$db_user";
+    my $notice = `grep -c 'Mixed-version add: new node runs Spock $ver3, existing cluster runs Spock $ver12' '$out_file'`;
+    chomp $notice;
+    is($notice, '1', "add_node reported the mixed-version add ($ver12 cluster, $ver3 new node)");
+    psql_expect_error(3,
+        "CALL spock.check_spock_version_compatibility('$n3_dsn', '$n1_dsn')",
+        qr/new node has version \Q$ver12\E, but source version is \Q$ver3\E\. The new node must run the same or a newer major\.minor version/,
+        "version rule rejects an older new node ($ver12) joining via a $ver3 source");
+    psql_expect_error(3,
+        "CALL spock.check_spock_version_compatibility('$n1_dsn', '$n3_dsn')",
+        qr/node n3 has version \Q$ver3\E, but source version is \Q$ver12\E\. Existing cluster nodes must share the same major\.minor version/,
+        "version rule rejects a cluster whose existing nodes differ in major.minor");
+}
+
+# Resync one table on n3 from n1.  This goes through copy_tables_data() and
+# adjust_progress_info(), which read the provider's spock.progress directly,
+# so it covers the other place the sync worker must understand an older
+# provider's catalog.
+psql_or_bail(1, "UPDATE pgbench_branches SET bbalance = bbalance + 1");
+psql_or_bail(1, 'SELECT spock.wait_slot_confirm_lsn(NULL, NULL)');
+psql_or_bail(3, "SELECT spock.sub_resync_table('sub_n1_n3', 'pgbench_branches')");
+wait_until(3, "SELECT status FROM spock.sub_show_table('sub_n1_n3', 'pgbench_branches')", 'replicating', 120,
+    "single-table resync of pgbench_branches on n3 from n1 ($v[0]) completed");
+my $n3_log = "$ENV{TESTLOGDIR}/00$ports->[2].log";
+my $adjusted = `grep -c 'SPOCK: adjust spock.progress' '$n3_log' 2>/dev/null`; chomp $adjusted;
+cmp_ok($adjusted, '>=', 1, "resync read the provider's progress entries (adjust_progress_info ran)");
+my @br = map { scalar_query($_, "SELECT sum(bbalance), count(*) FROM pgbench_branches") } 1, 3;
+is($br[1], $br[0], "pgbench_branches equal on n1 and n3 after resync");
 
 my @subs = map { scalar_query($_, "SELECT string_agg(subscription_name || ':' || status, ',' ORDER BY subscription_name) FROM spock.sub_show_status()") } 1..3;
 diag("Final subs: n1=[$subs[0]] n2=[$subs[1]] n3=[$subs[2]]");


### PR DESCRIPTION
Customers on Spock 5.0.9 or later can now add a 6.0.0 node to their cluster with zodan add_node() instead of upgrading every node first. 5.0.9 stays the floor: zodan already refuses anything older, and releases before 5.0.9 have known issues we do not want in production.

Before this change a 6.0.0 node could not join a 5.0.x cluster: zodan required the same major.minor on every node, and even with that gate removed two things broke against a 5.0.x provider.

- The 6.0.0 sync worker calls spock.read_peer_progress() on the provider, which only exists in 6.0.0. Probe the provider's spock_version_num() and, below 6.0.0, read peer progress with an inline query against the 5.x spock.progress table. The resume LSN comes from pg_replication_origin_status in both paths, so its meaning is unchanged.

- zodan polls the source node's spock.progress for remote_commit_lsn, which 5.x still calls remote_lsn. Pick the column name from the source node's Spock version.

Version rule in check_spock_version_compatibility: every node must be 5.0.9 or later; existing nodes must share one major.minor (patch differences allowed); the new node may run the same or a newer major.minor, never an older one, since only the newer sync worker knows how to talk to older providers.

Add tests/tap/t/099_zodan_mixed_version.pl, which adds a current-branch node to a cluster built from an older tag or branch, optionally under pgbench load. Like 014_rolling_upgrade.pl it needs PostgreSQL 18 for extension_control_path.

Tested: 6.0.0 node added to 5.0.9, 5.0.10 and 5.0.11 clusters, idle and under load, plus an all-6.0.0 control run.